### PR TITLE
Fix breakage from zeroize updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "dryoc"
 readme = "README.md"
 repository = "https://github.com/brndnmtthws/dryoc"
 rust-version = "1.56"
-version = "0.4.4"
+version = "0.5.0"
 
 [dependencies]
 base64 = { version = "0.21", optional = true }
@@ -24,7 +24,7 @@ salsa20 = { version = "0.10", features = ["zeroize"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 sha2 = "0.10"
 subtle = "2.4"
-zeroize = { version = "1.5", features = ["zeroize_derive"] }
+zeroize = { version = "1.6", features = ["zeroize_derive"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = [

--- a/src/blake2b/blake2b_simd.rs
+++ b/src/blake2b/blake2b_simd.rs
@@ -1,7 +1,7 @@
 use std::simd::Which::{First, Second};
 use std::simd::{simd_swizzle, Simd};
 
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::error::Error;
 use crate::utils::load_u64_le;
@@ -47,8 +47,7 @@ impl Default for Params {
     }
 }
 
-#[derive(Zeroize, Debug, Default)]
-#[zeroize(drop)]
+#[derive(Zeroize, ZeroizeOnDrop, Debug, Default)]
 pub struct State {
     t: [u64; 2],
     f: [u64; 2],

--- a/src/blake2b/blake2b_soft.rs
+++ b/src/blake2b/blake2b_soft.rs
@@ -1,4 +1,4 @@
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::error::Error;
 use crate::utils::{load_u64_le, rotr64};
@@ -44,8 +44,7 @@ impl Default for Params {
     }
 }
 
-#[derive(Zeroize, Debug, Default)]
-#[zeroize(drop)]
+#[derive(Zeroize, ZeroizeOnDrop, Debug, Default)]
 pub struct State {
     h: [u64; 8],
     t: [u64; 2],

--- a/src/classic/crypto_auth.rs
+++ b/src/classic/crypto_auth.rs
@@ -6,7 +6,6 @@
 //! # Classic API single-part example
 //!
 //! ```
-//! use base64::encode;
 //! use dryoc::classic::crypto_auth::{crypto_auth, crypto_auth_keygen, crypto_auth_verify, Mac};
 //!
 //! let key = crypto_auth_keygen();
@@ -24,7 +23,6 @@
 //! # Classic API multi-part example
 //!
 //! ```
-//! use base64::encode;
 //! use dryoc::classic::crypto_auth::{
 //!     crypto_auth_final, crypto_auth_init, crypto_auth_keygen, crypto_auth_update,
 //!     crypto_auth_verify, Mac,

--- a/src/classic/crypto_core.rs
+++ b/src/classic/crypto_core.rs
@@ -219,7 +219,8 @@ mod tests {
 
     #[test]
     fn test_crypto_scalarmult_base() {
-        use base64::encode;
+        use base64::engine::general_purpose;
+        use base64::Engine as _;
         for _ in 0..20 {
             use sodiumoxide::crypto::scalarmult::curve25519::{scalarmult_base, Scalar};
 
@@ -232,13 +233,17 @@ mod tests {
 
             let ge = scalarmult_base(&Scalar::from_slice(&sk).unwrap());
 
-            assert_eq!(encode(ge.as_ref()), encode(public_key));
+            assert_eq!(
+                general_purpose::STANDARD.encode(ge.as_ref()),
+                general_purpose::STANDARD.encode(public_key)
+            );
         }
     }
 
     #[test]
     fn test_crypto_scalarmult() {
-        use base64::encode;
+        use base64::engine::general_purpose;
+        use base64::Engine as _;
         for _ in 0..20 {
             use sodiumoxide::crypto::scalarmult::curve25519::{scalarmult, GroupElement, Scalar};
 
@@ -254,13 +259,17 @@ mod tests {
             )
             .expect("scalarmult failed");
 
-            assert_eq!(encode(ge.as_ref()), encode(shared_secret));
+            assert_eq!(
+                general_purpose::STANDARD.encode(ge.as_ref()),
+                general_purpose::STANDARD.encode(shared_secret)
+            );
         }
     }
 
     #[test]
     fn test_crypto_core_hchacha20() {
-        use base64::encode;
+        use base64::engine::general_purpose;
+        use base64::Engine as _;
         use libsodium_sys::crypto_core_hchacha20 as so_crypto_core_hchacha20;
 
         use crate::rng::copy_randombytes;
@@ -284,13 +293,17 @@ mod tests {
                 );
                 assert_eq!(ret, 0);
             }
-            assert_eq!(encode(&out), encode(&so_out));
+            assert_eq!(
+                general_purpose::STANDARD.encode(&out),
+                general_purpose::STANDARD.encode(&so_out)
+            );
         }
     }
 
     #[test]
     fn test_crypto_core_hsalsa20() {
-        use base64::encode;
+        use base64::engine::general_purpose;
+        use base64::Engine as _;
         use libsodium_sys::crypto_core_hsalsa20 as so_crypto_core_hsalsa20;
 
         use crate::rng::copy_randombytes;
@@ -314,7 +327,10 @@ mod tests {
                 );
                 assert_eq!(ret, 0);
             }
-            assert_eq!(encode(&out), encode(&so_out));
+            assert_eq!(
+                general_purpose::STANDARD.encode(&out),
+                general_purpose::STANDARD.encode(&so_out)
+            );
         }
     }
 }

--- a/src/classic/crypto_generichash.rs
+++ b/src/classic/crypto_generichash.rs
@@ -8,7 +8,8 @@
 //! # Classic API example, one-time interface
 //!
 //! ```
-//! use base64::encode;
+//! use base64::engine::general_purpose;
+//! use base64::Engine as _;
 //! use dryoc::classic::crypto_generichash::*;
 //! use dryoc::constants::CRYPTO_GENERICHASH_BYTES;
 //!
@@ -18,7 +19,7 @@
 //! crypto_generichash(&mut output, b"a string of bytes", None).ok();
 //!
 //! assert_eq!(
-//!     encode(output),
+//!     general_purpose::STANDARD.encode(output),
 //!     "GdztjR9nU/rLh8VJt8e74+/seKTUnHgBexhGSpxLau0="
 //! );
 //! ```
@@ -26,7 +27,8 @@
 //! # Classic API example, incremental interface
 //!
 //! ```
-//! use base64::encode;
+//! use base64::engine::general_purpose;
+//! use base64::Engine as _;
 //! use dryoc::classic::crypto_generichash::*;
 //! use dryoc::constants::CRYPTO_GENERICHASH_BYTES;
 //!
@@ -40,7 +42,7 @@
 //! crypto_generichash_final(state, &mut output).expect("final failed");
 //!
 //! assert_eq!(
-//!     encode(output),
+//!     general_purpose::STANDARD.encode(output),
 //!     "GdztjR9nU/rLh8VJt8e74+/seKTUnHgBexhGSpxLau0="
 //! );
 //! ```

--- a/src/classic/crypto_kdf.rs
+++ b/src/classic/crypto_kdf.rs
@@ -7,7 +7,8 @@
 //! # Classic API example
 //!
 //! ```
-//! use base64::encode;
+//! use base64::engine::general_purpose;
+//! use base64::Engine as _;
 //! use dryoc::classic::crypto_kdf::*;
 //!
 //! // Generate a random main key
@@ -19,7 +20,7 @@
 //! for i in 0..20 {
 //!     let mut key = Key::default();
 //!     crypto_kdf_derive_from_key(&mut key, i, context, &main_key).expect("kdf failed");
-//!     println!("Subkey {}: {}", i, encode(&key));
+//!     println!("Subkey {}: {}", i, general_purpose::STANDARD.encode(&key));
 //! }
 //! ```
 

--- a/src/classic/crypto_onetimeauth.rs
+++ b/src/classic/crypto_onetimeauth.rs
@@ -6,7 +6,8 @@
 //! # Classic API single-part example
 //!
 //! ```
-//! use base64::encode;
+//! use base64::engine::general_purpose;
+//! use base64::Engine as _;
 //! use dryoc::classic::crypto_onetimeauth::{
 //!     crypto_onetimeauth, crypto_onetimeauth_keygen, crypto_onetimeauth_verify, Mac,
 //! };
@@ -26,7 +27,8 @@
 //! # Classic API multi-part example
 //!
 //! ```
-//! use base64::encode;
+//! use base64::engine::general_purpose;
+//! use base64::Engine as _;
 //! use dryoc::classic::crypto_onetimeauth::{
 //!     crypto_onetimeauth_final, crypto_onetimeauth_init, crypto_onetimeauth_keygen,
 //!     crypto_onetimeauth_update, crypto_onetimeauth_verify, Mac,

--- a/src/classic/crypto_pwhash.rs
+++ b/src/classic/crypto_pwhash.rs
@@ -151,21 +151,16 @@ pub fn crypto_pwhash(
 #[cfg(any(feature = "base64", all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "base64")))]
 pub(crate) fn pwhash_to_string(t_cost: u32, m_cost: u32, salt: &[u8], hash: &[u8]) -> String {
-    #[cfg(feature = "base64")]
-    use base64::Engine;
-
-    let base64_engine = base64::engine::general_purpose::GeneralPurpose::new(
-        &base64::alphabet::STANDARD,
-        base64::engine::general_purpose::NO_PAD,
-    );
+    use base64::engine::general_purpose;
+    use base64::Engine as _;
 
     format!(
         "$argon2id$v={}$m={},t={},p=1${}${}",
         argon2::ARGON2_VERSION_NUMBER,
         m_cost,
         t_cost,
-        base64_engine.encode(salt),
-        base64_engine.encode(hash),
+        general_purpose::STANDARD_NO_PAD.encode(salt),
+        general_purpose::STANDARD_NO_PAD.encode(hash),
     )
 }
 

--- a/src/classic/crypto_secretbox.rs
+++ b/src/classic/crypto_secretbox.rs
@@ -179,7 +179,8 @@ mod tests {
     #[test]
     fn test_crypto_secretbox_easy() {
         for i in 0..20 {
-            use base64::encode;
+            use base64::engine::general_purpose;
+            use base64::Engine as _;
             use sodiumoxide::crypto::secretbox;
             use sodiumoxide::crypto::secretbox::{Key as SOKey, Nonce as SONonce};
 
@@ -197,7 +198,10 @@ mod tests {
                 &SONonce::from_slice(&nonce).unwrap(),
                 &SOKey::from_slice(&key).unwrap(),
             );
-            assert_eq!(encode(&ciphertext), encode(&so_ciphertext));
+            assert_eq!(
+                general_purpose::STANDARD.encode(&ciphertext),
+                general_purpose::STANDARD.encode(&so_ciphertext)
+            );
 
             let mut decrypted = vec![0u8; message.len()];
             crypto_secretbox_open_easy(&mut decrypted, &ciphertext, &nonce, &key)
@@ -217,7 +221,8 @@ mod tests {
     #[test]
     fn test_crypto_secretbox_easy_inplace() {
         for i in 0..20 {
-            use base64::encode;
+            use base64::engine::general_purpose;
+            use base64::Engine as _;
             use sodiumoxide::crypto::secretbox;
             use sodiumoxide::crypto::secretbox::{Key as SOKey, Nonce as SONonce};
 
@@ -236,7 +241,10 @@ mod tests {
                 &SONonce::from_slice(&nonce).unwrap(),
                 &SOKey::from_slice(&key).unwrap(),
             );
-            assert_eq!(encode(&ciphertext), encode(&so_ciphertext));
+            assert_eq!(
+                general_purpose::STANDARD.encode(&ciphertext),
+                general_purpose::STANDARD.encode(&so_ciphertext)
+            );
 
             let mut decrypted = ciphertext.clone();
             crypto_secretbox_open_easy_inplace(&mut decrypted, &nonce, &key)

--- a/src/classic/crypto_sign.rs
+++ b/src/classic/crypto_sign.rs
@@ -203,7 +203,8 @@ mod tests {
 
     #[test]
     fn test_crypto_sign() {
-        use base64::encode;
+        use base64::engine::general_purpose;
+        use base64::Engine as _;
         use sodiumoxide::crypto::sign;
 
         for _ in 0..10 {
@@ -217,7 +218,10 @@ mod tests {
                 &sign::SecretKey::from_slice(&secret_key).expect("secret key failed"),
             );
 
-            assert_eq!(encode(&signed_message), encode(&so_signed_message));
+            assert_eq!(
+                general_purpose::STANDARD.encode(&signed_message),
+                general_purpose::STANDARD.encode(&so_signed_message)
+            );
 
             let so_m = sign::verify(
                 &signed_message,
@@ -231,7 +235,8 @@ mod tests {
 
     #[test]
     fn test_crypto_sign_open() {
-        use base64::encode;
+        use base64::engine::general_purpose;
+        use base64::Engine as _;
         use sodiumoxide::crypto::sign;
 
         for _ in 0..10 {
@@ -245,7 +250,10 @@ mod tests {
                 &sign::SecretKey::from_slice(&secret_key).expect("secret key failed"),
             );
 
-            assert_eq!(encode(&signed_message), encode(&so_signed_message));
+            assert_eq!(
+                general_purpose::STANDARD.encode(&signed_message),
+                general_purpose::STANDARD.encode(&so_signed_message)
+            );
 
             let so_m = sign::verify(
                 &signed_message,

--- a/src/classic/crypto_sign_ed25519.rs
+++ b/src/classic/crypto_sign_ed25519.rs
@@ -329,7 +329,8 @@ pub(crate) fn crypto_sign_ed25519ph_final_verify(
 
 #[cfg(test)]
 mod tests {
-    use base64::encode;
+    use base64::engine::general_purpose;
+    use base64::Engine as _;
 
     use super::*;
     use crate::rng::copy_randombytes;
@@ -347,8 +348,14 @@ mod tests {
             let (so_pk, so_sk) =
                 sign::keypair_from_seed(&sign::Seed::from_slice(&seed).expect("seed failed"));
 
-            assert_eq!(encode(pk), encode(so_pk.0));
-            assert_eq!(encode(sk), encode(so_sk.0));
+            assert_eq!(
+                general_purpose::STANDARD.encode(pk),
+                general_purpose::STANDARD.encode(so_pk.0)
+            );
+            assert_eq!(
+                general_purpose::STANDARD.encode(sk),
+                general_purpose::STANDARD.encode(so_sk.0)
+            );
         }
     }
 
@@ -380,8 +387,14 @@ mod tests {
                 );
             }
 
-            assert_eq!(encode(xpk), encode(so_xpk));
-            assert_eq!(encode(xsk), encode(so_xsk));
+            assert_eq!(
+                general_purpose::STANDARD.encode(xpk),
+                general_purpose::STANDARD.encode(so_xpk)
+            );
+            assert_eq!(
+                general_purpose::STANDARD.encode(xsk),
+                general_purpose::STANDARD.encode(so_xsk)
+            );
         }
     }
 }

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -200,9 +200,9 @@ pub mod protected {
 ///
 /// Refer to [crate::dryocbox] for sample usage.
 pub struct DryocBox<
-    EphemeralPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
-    Mac: ByteArray<CRYPTO_BOX_MACBYTES>,
-    Data: Bytes,
+    EphemeralPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,
+    Mac: ByteArray<CRYPTO_BOX_MACBYTES> + Zeroize,
+    Data: Bytes + Zeroize,
 > {
     ephemeral_pk: Option<EphemeralPublicKey>,
     tag: Mac,
@@ -213,9 +213,9 @@ pub struct DryocBox<
 pub type VecBox = DryocBox<PublicKey, Mac, Vec<u8>>;
 
 impl<
-    EphemeralPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
-    Mac: NewByteArray<CRYPTO_BOX_MACBYTES>,
-    Data: NewBytes + ResizableBytes,
+    EphemeralPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,
+    Mac: NewByteArray<CRYPTO_BOX_MACBYTES> + Zeroize,
+    Data: NewBytes + ResizableBytes + Zeroize,
 > DryocBox<EphemeralPublicKey, Mac, Data>
 {
     /// Encrypts a message using `sender_secret_key` for `recipient_public_key`,
@@ -255,9 +255,9 @@ impl<
 }
 
 impl<
-    EphemeralPublicKey: NewByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
-    Mac: NewByteArray<CRYPTO_BOX_MACBYTES>,
-    Data: NewBytes + ResizableBytes,
+    EphemeralPublicKey: NewByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,
+    Mac: NewByteArray<CRYPTO_BOX_MACBYTES> + Zeroize,
+    Data: NewBytes + ResizableBytes + Zeroize,
 > DryocBox<EphemeralPublicKey, Mac, Data>
 {
     /// Encrypts a message for `recipient_public_key`, using an ephemeral secret
@@ -304,9 +304,9 @@ impl<
 
 impl<
     'a,
-    EphemeralPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + std::convert::TryFrom<&'a [u8]>,
-    Mac: ByteArray<CRYPTO_BOX_MACBYTES> + std::convert::TryFrom<&'a [u8]>,
-    Data: Bytes + From<&'a [u8]>,
+    EphemeralPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + std::convert::TryFrom<&'a [u8]> + Zeroize,
+    Mac: ByteArray<CRYPTO_BOX_MACBYTES> + std::convert::TryFrom<&'a [u8]> + Zeroize,
+    Data: Bytes + From<&'a [u8]> + Zeroize,
 > DryocBox<EphemeralPublicKey, Mac, Data>
 {
     /// Initializes a [`DryocBox`] from a slice. Expects the first
@@ -356,9 +356,9 @@ impl<
 }
 
 impl<
-    EphemeralPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
-    Mac: ByteArray<CRYPTO_BOX_MACBYTES>,
-    Data: Bytes,
+    EphemeralPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,
+    Mac: ByteArray<CRYPTO_BOX_MACBYTES> + Zeroize,
+    Data: Bytes + Zeroize,
 > DryocBox<EphemeralPublicKey, Mac, Data>
 {
     /// Returns a new box with `tag`, `data` and (optional) `ephemeral_pk`,
@@ -415,9 +415,9 @@ impl<
     /// Decrypts this sealed box using `recipient_secret_key`, and
     /// returning the decrypted message upon success.
     pub fn unseal<
-        RecipientPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
-        RecipientSecretKey: ByteArray<CRYPTO_BOX_SECRETKEYBYTES>,
-        Output: ResizableBytes + NewBytes,
+        RecipientPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,
+        RecipientSecretKey: ByteArray<CRYPTO_BOX_SECRETKEYBYTES> + Zeroize,
+        Output: ResizableBytes + NewBytes + Zeroize,
     >(
         &self,
         recipient_keypair: &crate::keypair::KeyPair<RecipientPublicKey, RecipientSecretKey>,
@@ -515,8 +515,8 @@ impl DryocBox<PublicKey, Mac, Vec<u8>> {
     /// Decrypts this sealed box using `recipient_secret_key`, returning the
     /// decrypted message upon success.
     pub fn unseal_to_vec<
-        RecipientPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
-        RecipientSecretKey: ByteArray<CRYPTO_BOX_SECRETKEYBYTES>,
+        RecipientPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,
+        RecipientSecretKey: ByteArray<CRYPTO_BOX_SECRETKEYBYTES> + Zeroize,
     >(
         &self,
         recipient_keypair: &crate::keypair::KeyPair<RecipientPublicKey, RecipientSecretKey>,
@@ -527,9 +527,9 @@ impl DryocBox<PublicKey, Mac, Vec<u8>> {
 
 impl<
     'a,
-    EphemeralPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
-    Mac: ByteArray<CRYPTO_BOX_MACBYTES>,
-    Data: Bytes + ResizableBytes + From<&'a [u8]>,
+    EphemeralPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,
+    Mac: ByteArray<CRYPTO_BOX_MACBYTES> + Zeroize,
+    Data: Bytes + ResizableBytes + From<&'a [u8]> + Zeroize,
 > DryocBox<EphemeralPublicKey, Mac, Data>
 {
     /// Returns a new box with `data` and `tag`, with data copied from `input`
@@ -559,9 +559,9 @@ impl<
 }
 
 impl<
-    EphemeralPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
-    Mac: ByteArray<CRYPTO_BOX_MACBYTES>,
-    Data: Bytes,
+    EphemeralPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,
+    Mac: ByteArray<CRYPTO_BOX_MACBYTES> + Zeroize,
+    Data: Bytes + Zeroize,
 > PartialEq<DryocBox<EphemeralPublicKey, Mac, Data>> for DryocBox<EphemeralPublicKey, Mac, Data>
 {
     fn eq(&self, other: &Self) -> bool {
@@ -599,7 +599,8 @@ mod tests {
     #[test]
     fn test_dryocbox_vecbox() {
         for i in 0..20 {
-            use base64::encode;
+            use base64::engine::general_purpose;
+            use base64::Engine as _;
             use sodiumoxide::crypto::box_;
             use sodiumoxide::crypto::box_::{Nonce as SONonce, PublicKey, SecretKey};
 
@@ -628,7 +629,10 @@ mod tests {
                 &SecretKey::from_slice(&keypair_sender_copy.secret_key).unwrap(),
             );
 
-            assert_eq!(encode(&ciphertext), encode(&so_ciphertext));
+            assert_eq!(
+                general_purpose::STANDARD.encode(&ciphertext),
+                general_purpose::STANDARD.encode(&so_ciphertext)
+            );
 
             let keypair_sender = keypair_sender_copy.clone();
             let keypair_recipient = keypair_recipient_copy.clone();
@@ -656,7 +660,8 @@ mod tests {
     #[test]
     fn test_decrypt_failure() {
         for i in 0..20 {
-            use base64::encode;
+            use base64::engine::general_purpose;
+            use base64::Engine as _;
             use sodiumoxide::crypto::box_;
             use sodiumoxide::crypto::box_::{
                 Nonce as SONonce, PublicKey as SOPublicKey, SecretKey as SOSecretKey,
@@ -687,7 +692,10 @@ mod tests {
                 &SOSecretKey::from_slice(&keypair_sender_copy.secret_key).unwrap(),
             );
 
-            assert_eq!(encode(&ciphertext), encode(&so_ciphertext));
+            assert_eq!(
+                general_purpose::STANDARD.encode(&ciphertext),
+                general_purpose::STANDARD.encode(&so_ciphertext)
+            );
 
             let invalid_key = KeyPair::gen();
             let invalid_key_copy_1 = invalid_key.clone();

--- a/src/generichash.rs
+++ b/src/generichash.rs
@@ -6,7 +6,8 @@
 //! # Rustaceous API example, one-time interface
 //!
 //! ```
-//! use base64::encode;
+//! use base64::engine::general_purpose;
+//! use base64::Engine as _;
 //! use dryoc::generichash::{GenericHash, Key};
 //!
 //! // NOTE: The type for `key` param must be specified, the compiler cannot infer it when
@@ -15,7 +16,7 @@
 //!     GenericHash::hash_with_defaults_to_vec::<_, Key>(b"hello", None).expect("hash failed");
 //!
 //! assert_eq!(
-//!     encode(&hash),
+//!     general_purpose::STANDARD.encode(&hash),
 //!     "Mk3PAn3UowqTLEQfNlol6GsXPe+kuOWJSCU0cbgbcs8="
 //! );
 //! ```
@@ -23,7 +24,8 @@
 //! # Rustaceous API example, incremental interface
 //!
 //! ```
-//! use base64::encode;
+//! use base64::engine::general_purpose;
+//! use base64::Engine as _;
 //! use dryoc::generichash::{GenericHash, Key};
 //!
 //! // The compiler cannot infer the `Key` type, so we pass it below.
@@ -32,7 +34,7 @@
 //! let hash = hasher.finalize_to_vec().expect("finalize failed");
 //!
 //! assert_eq!(
-//!     encode(&hash),
+//!     general_purpose::STANDARD.encode(&hash),
 //!     "Mk3PAn3UowqTLEQfNlol6GsXPe+kuOWJSCU0cbgbcs8="
 //! );
 //! ```
@@ -62,7 +64,6 @@ pub mod protected {
     //! ## Example
     //!
     //! ```
-    //! use base64::encode;
     //! use dryoc::generichash::protected::*;
     //! use dryoc::generichash::GenericHash;
     //!
@@ -125,14 +126,15 @@ impl<const KEY_LENGTH: usize, const OUTPUT_LENGTH: usize> GenericHash<KEY_LENGTH
     /// # Example
     ///
     /// ```
-    /// use base64::encode;
+    /// use base64::engine::general_purpose;
+    /// use base64::Engine as _;
     /// use dryoc::generichash::{GenericHash, Hash};
     ///
     /// let output: Hash =
     ///     GenericHash::hash(b"hello", Some(b"a very secret key")).expect("hash failed");
     ///
     /// assert_eq!(
-    ///     encode(&output),
+    ///     general_purpose::STANDARD.encode(&output),
     ///     "AECDe+XJsB6nOkbCsbS/OPXdzpcRm3AolW/Bg1LFY9A="
     /// );
     /// ```
@@ -205,7 +207,8 @@ mod tests {
 
     #[test]
     fn test_generichash() {
-        use base64::encode;
+        use base64::engine::general_purpose;
+        use base64::Engine as _;
 
         let mut hasher = GenericHash::new_with_defaults::<Key>(None).expect("new hash failed");
         hasher.update(b"hello");
@@ -213,7 +216,7 @@ mod tests {
         let output: Vec<u8> = hasher.finalize().expect("finalize failed");
 
         assert_eq!(
-            encode(&output),
+            general_purpose::STANDARD.encode(&output),
             "Mk3PAn3UowqTLEQfNlol6GsXPe+kuOWJSCU0cbgbcs8="
         );
 
@@ -223,20 +226,21 @@ mod tests {
         let output = hasher.finalize_to_vec().expect("finalize failed");
 
         assert_eq!(
-            encode(&output),
+            general_purpose::STANDARD.encode(&output),
             "Mk3PAn3UowqTLEQfNlol6GsXPe+kuOWJSCU0cbgbcs8="
         );
     }
 
     #[test]
     fn test_generichash_onetime() {
-        use base64::encode;
+        use base64::engine::general_purpose;
+        use base64::Engine as _;
 
         let output: Hash =
             GenericHash::hash(b"hello", Some(b"a very secret key")).expect("hash failed");
 
         assert_eq!(
-            encode(&output),
+            general_purpose::STANDARD.encode(&output),
             "AECDe+XJsB6nOkbCsbS/OPXdzpcRm3AolW/Bg1LFY9A="
         );
 
@@ -244,7 +248,7 @@ mod tests {
             GenericHash::hash_with_defaults::<_, Key, _>(b"hello", None).expect("hash failed");
 
         assert_eq!(
-            encode(&output),
+            general_purpose::STANDARD.encode(&output),
             "Mk3PAn3UowqTLEQfNlol6GsXPe+kuOWJSCU0cbgbcs8="
         );
 
@@ -252,19 +256,20 @@ mod tests {
             GenericHash::hash_with_defaults_to_vec::<_, Key>(b"hello", None).expect("hash failed");
 
         assert_eq!(
-            encode(&output),
+            general_purpose::STANDARD.encode(&output),
             "Mk3PAn3UowqTLEQfNlol6GsXPe+kuOWJSCU0cbgbcs8="
         );
     }
     #[test]
     fn test_generichash_onetime_empty() {
-        use base64::encode;
+        use base64::engine::general_purpose;
+        use base64::Engine as _;
 
         let output =
             GenericHash::hash_with_defaults_to_vec::<_, Key>(&[], None).expect("hash failed");
 
         assert_eq!(
-            encode(&output),
+            general_purpose::STANDARD.encode(&output),
             "DldRwCblQ7Loqy6wYJnaodHl30d3j3eH+qtFzfEv46g="
         );
     }

--- a/src/kx.rs
+++ b/src/kx.rs
@@ -72,7 +72,7 @@ pub type KeyPair = crate::keypair::KeyPair<PublicKey, SecretKey>;
 #[cfg_attr(not(feature = "serde"), derive(Zeroize, Clone, Debug))]
 /// Key derivation implemantation based on Curve25519, Diffie-Hellman, and
 /// Blake2b. Compatible with libsodium's `crypto_kx_*` functions.
-pub struct Session<SessionKey: ByteArray<CRYPTO_KX_SESSIONKEYBYTES>> {
+pub struct Session<SessionKey: ByteArray<CRYPTO_KX_SESSIONKEYBYTES> + Zeroize> {
     rx_key: SessionKey,
     tx_key: SessionKey,
 }
@@ -144,12 +144,12 @@ pub mod protected {
     pub type LockedSession = Session<Locked<SessionKey>>;
 }
 
-impl<SessionKey: NewByteArray<CRYPTO_KX_SESSIONKEYBYTES>> Session<SessionKey> {
+impl<SessionKey: NewByteArray<CRYPTO_KX_SESSIONKEYBYTES> + Zeroize> Session<SessionKey> {
     /// Computes client session keys, given `client_keypair` and
     /// `server_public_key`, returning a new session upon success.
     pub fn new_client<
-        PublicKey: ByteArray<CRYPTO_KX_PUBLICKEYBYTES>,
-        SecretKey: ByteArray<CRYPTO_KX_SECRETKEYBYTES>,
+        PublicKey: ByteArray<CRYPTO_KX_PUBLICKEYBYTES> + Zeroize,
+        SecretKey: ByteArray<CRYPTO_KX_SECRETKEYBYTES> + Zeroize,
     >(
         client_keypair: &crate::keypair::KeyPair<PublicKey, SecretKey>,
         server_public_key: &PublicKey,
@@ -171,8 +171,8 @@ impl<SessionKey: NewByteArray<CRYPTO_KX_SESSIONKEYBYTES>> Session<SessionKey> {
     /// Computes server session keys, given `server_keypair` and
     /// `client_public_key`, returning a new session upon success.
     pub fn new_server<
-        PublicKey: ByteArray<CRYPTO_KX_PUBLICKEYBYTES>,
-        SecretKey: ByteArray<CRYPTO_KX_SECRETKEYBYTES>,
+        PublicKey: ByteArray<CRYPTO_KX_PUBLICKEYBYTES> + Zeroize,
+        SecretKey: ByteArray<CRYPTO_KX_SECRETKEYBYTES> + Zeroize,
     >(
         server_keypair: &crate::keypair::KeyPair<PublicKey, SecretKey>,
         client_public_key: &PublicKey,
@@ -197,8 +197,8 @@ impl Session<SessionKey> {
     /// the given `client_keypair` and `server_public_key`. Wraps
     /// [`Session::new_client`], provided for convenience.
     pub fn new_client_with_defaults<
-        PublicKey: ByteArray<CRYPTO_KX_PUBLICKEYBYTES>,
-        SecretKey: ByteArray<CRYPTO_KX_SECRETKEYBYTES>,
+        PublicKey: ByteArray<CRYPTO_KX_PUBLICKEYBYTES> + Zeroize,
+        SecretKey: ByteArray<CRYPTO_KX_SECRETKEYBYTES> + Zeroize,
     >(
         client_keypair: &crate::keypair::KeyPair<PublicKey, SecretKey>,
         server_public_key: &PublicKey,
@@ -210,8 +210,8 @@ impl Session<SessionKey> {
     /// the given `server_keypair` and `client_public_key`. Wraps
     /// [`Session::new_server`], provided for convenience.
     pub fn new_server_with_defaults<
-        PublicKey: ByteArray<CRYPTO_KX_PUBLICKEYBYTES>,
-        SecretKey: ByteArray<CRYPTO_KX_SECRETKEYBYTES>,
+        PublicKey: ByteArray<CRYPTO_KX_PUBLICKEYBYTES> + Zeroize,
+        SecretKey: ByteArray<CRYPTO_KX_SECRETKEYBYTES> + Zeroize,
     >(
         server_keypair: &crate::keypair::KeyPair<PublicKey, SecretKey>,
         client_public_key: &PublicKey,
@@ -220,7 +220,7 @@ impl Session<SessionKey> {
     }
 }
 
-impl<SessionKey: ByteArray<CRYPTO_KX_SESSIONKEYBYTES>> Session<SessionKey> {
+impl<SessionKey: ByteArray<CRYPTO_KX_SESSIONKEYBYTES> + Zeroize> Session<SessionKey> {
     /// Moves the rx_key and tx_key out of this instance, returning them as a
     /// tuple with `(rx_key, tx_key)`.
     pub fn into_parts(self) -> (SessionKey, SessionKey) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
 use lazy_static::__Deref;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 #[cfg(any(feature = "serde"))]
 pub use crate::bytes_serde::*;
@@ -9,8 +9,7 @@ use crate::rng::copy_randombytes;
 
 /// A stack-allocated fixed-length byte array for working with data, with
 /// optional [Serde](https://serde.rs) features.
-#[derive(Zeroize, Debug, PartialEq, Eq, Clone)]
-#[zeroize(drop)]
+#[derive(Zeroize, ZeroizeOnDrop, Debug, PartialEq, Eq, Clone)]
 pub struct StackByteArray<const LENGTH: usize>([u8; LENGTH]);
 
 /// Fixed-length byte array.


### PR DESCRIPTION
This bumps the minimum version for zeroize to 1.6, and fixes some breakage associated with its changes.

This also fixes some deprecation warnings from base64.

This resolves #43.