### PR TITLE
feat: add `VecSignedMessage` type alias

### DIFF
--- a/src/sign.rs
+++ b/src/sign.rs
@@ -312,6 +312,9 @@ pub struct SignedMessage<
     message: Message,
 }
 
+/// [Vec]-based signed message.
+pub type VecSignedMessage = SignedMessage<Signature, Vec<u8>>;
+
 impl<
     PublicKey: ByteArray<CRYPTO_SIGN_PUBLICKEYBYTES> + Zeroize,
     SecretKey: ByteArray<CRYPTO_SIGN_SECRETKEYBYTES> + Zeroize,


### PR DESCRIPTION
This provides similar utility as `VecBox` in `dryocsecretbox`, allowing the following:


```rust
let message: Vec<u8> = some_message_from_somewhere;

let secret_box = VecBox::from_bytes(message).unwrap();

let message = secret_box.decrypt_to_vec(&nonce, &secret_key).unwrap();

let signed_message = VecSignedMessage::from_bytes(&message).unwrap();

signed_message.verify(public_key).unwrap();

let (_signature, message) = signed_message.into_parts();

// use unpacked `message`.
```

without `VecSignedMessage`, the `from_bytes` call on `SignedMessage` needs type annotations.

(Caveat - while I've used libsodium in javascript before, I'm very new to writing Rust. So this might not make sense 😀)