### PR TITLE
Bump curve25519-dalek version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.5.4"
 base64 = { version = "0.21", optional = true }
 bitflags = "2.3"
 chacha20 = { version = "0.9", features = ["zeroize"] }
-curve25519-dalek = "4.0"
+curve25519-dalek = "4.1.3"
 generic-array = "0.14"
 lazy_static = "1"
 rand_core = { version = "0.6", features = ["getrandom"] }


### PR DESCRIPTION
Bumps the dependency to at least 4.1.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0344.html) 

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)