### PR TITLE
Make protected::traits public so that I can make types using Protected<>

### DIFF
--- a/src/protected.rs
+++ b/src/protected.rs
@@ -101,7 +101,8 @@ mod int {
     }
 }
 
-mod traits {
+#[doc(hidden)] // Edit this PR to remove doc(hidden) or add a doc comment.
+pub mod traits {
     pub trait ProtectMode {}
     pub struct ReadOnly {}
     pub struct ReadWrite {}


### PR DESCRIPTION
I cannot use `Protected` memory directly in any of my types with generics because the `traits` module is private, so I could not actually write something like:

```rs
struct ProtectedMemory<X: traits::ReadWrite, traits::LockMode> {
  my_struct: Protected<HeapBytes, X, Y>
}
```
