### PR TITLE
Fix padding calculation for large AADs in xchacha20poly1305 secretstream push/pull

### DIFF
--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -100,7 +100,6 @@ use crate::constants::{
     CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_REKEY, CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES,
     CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES,
 };
-use crate::dryocstream::Tag;
 use crate::error::*;
 use crate::rng::copy_randombytes;
 use crate::types::*;
@@ -458,6 +457,7 @@ pub fn crypto_secretstream_xchacha20poly1305_pull(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dryocstream::Tag;
 
     #[test]
     fn test_sizes() {
@@ -1005,14 +1005,16 @@ mod tests {
         let mut decrypted = vec![0u8; message.len()];
         let mut tag = 0u8;
 
-        assert!(crypto_secretstream_xchacha20poly1305_pull(
-            &mut pull_state,
-            &mut decrypted,
-            &mut tag,
-            &ciphertext,
-            Some(&wrong_aad),
-        )
-        .is_err());
+        assert!(
+            crypto_secretstream_xchacha20poly1305_pull(
+                &mut pull_state,
+                &mut decrypted,
+                &mut tag,
+                &ciphertext,
+                Some(&wrong_aad),
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -1062,13 +1064,15 @@ mod tests {
         let mut decrypted = vec![0u8; message.len()];
         let mut tag = 0u8;
 
-        assert!(crypto_secretstream_xchacha20poly1305_pull(
-            &mut pull_state,
-            &mut decrypted,
-            &mut tag,
-            &ciphertext,
-            Some(wrong_aad),
-        )
-        .is_err());
+        assert!(
+            crypto_secretstream_xchacha20poly1305_pull(
+                &mut pull_state,
+                &mut decrypted,
+                &mut tag,
+                &ciphertext,
+                Some(wrong_aad),
+            )
+            .is_err()
+        );
     }
 }

--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -104,7 +104,7 @@ use crate::dryocstream::Tag;
 use crate::error::*;
 use crate::rng::copy_randombytes;
 use crate::types::*;
-use crate::utils::{increment_bytes, xor_buf};
+use crate::utils::{increment_bytes, pad16, xor_buf};
 
 /// A secret for authenticated secret streams.
 pub type Key = [u8; CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_KEYBYTES];
@@ -296,7 +296,7 @@ pub fn crypto_secretstream_xchacha20poly1305_push(
     mac_key.zeroize();
 
     mac.update(associated_data);
-    mac.update(&_pad0[..((0x10 - (associated_data.len() % 0x10)) & 0xf)]);
+    mac.update(&_pad0[..pad16(associated_data.len())]);
 
     let mut block = [0u8; 64];
     block[0] = tag;
@@ -400,7 +400,7 @@ pub fn crypto_secretstream_xchacha20poly1305_pull(
     mac_key.zeroize();
 
     mac.update(associated_data);
-    mac.update(&_pad0[..((0x10 - (associated_data.len() % 0x10)) & 0xf)]);
+    mac.update(&_pad0[..pad16(associated_data.len())]);
 
     let mut block = [0u8; 64];
     block[0] = ciphertext[0];

--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -399,7 +399,7 @@ pub fn crypto_secretstream_xchacha20poly1305_pull(
     mac_key.zeroize();
 
     mac.update(associated_data);
-    mac.update(&_pad0[..((0x10 - associated_data.len()) & 0xf)]);
+    mac.update(&_pad0[..((0x10 - (associated_data.len() % 0x10)) & 0xf)]);
 
     let mut block = [0u8; 64];
     block[0] = ciphertext[0];

--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -295,7 +295,7 @@ pub fn crypto_secretstream_xchacha20poly1305_push(
     mac_key.zeroize();
 
     mac.update(associated_data);
-    mac.update(&_pad0[..((0x10 - associated_data.len()) & 0xf)]);
+    mac.update(&_pad0[..((0x10 - (associated_data.len() % 0x10)) & 0xf)]);
 
     let mut block = [0u8; 64];
     block[0] = tag;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,6 +51,11 @@ pub(crate) fn rotr64(x: u64, b: u64) -> u64 {
     (x >> b) | (x << (64 - b))
 }
 
+#[inline]
+pub(crate) fn pad16(n: usize) -> usize {
+    (0x10 - (n % 16)) & 0xf
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -134,5 +139,17 @@ mod tests {
 
             assert_eq!(data, data_copy);
         }
+    }
+
+    #[test]
+    fn test_pad16() {
+        assert_eq!(pad16(0), 0);
+        assert_eq!(pad16(1), 15);
+        assert_eq!(pad16(2), 14);
+        assert_eq!(pad16(15), 1);
+        assert_eq!(pad16(16), 0);
+        assert_eq!(pad16(17), 15);
+        assert_eq!(pad16(32), 0);
+        assert_eq!(pad16(33), 15);
     }
 }


### PR DESCRIPTION
* Uses the correct modulo calculation when updating the mac:

` mac.update(&_pad0[..((0x10 - (associated_data.len() % 0x10)) & 0xf)]);`

Previous code did not include the modulus, thus failing on AADs larger than 16 bytes. The XChaCha20 specification allows much more than that.

The original libsodium implementation in C does a similar operation:

```c
    crypto_onetimeauth_poly1305_update(&poly1305_state, _pad0,
                                       (0x10 - adlen) & 0xf);
```

* Adds a unit test to ensure large AAD works

```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.32s
     Running unittests src/lib.rs (/home/james/Develop/dryoc/target/debug/deps/dryoc-fc575e74639062ec)

running 1 test
test classic::crypto_secretstream_xchacha20poly1305::tests::test_secretstream_large_aad ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 87 filtered out; finished in 0.00s
```

Without the fix, it fails:

```
test classic::crypto_secretstream_xchacha20poly1305::tests::test_secretstream_large_aad ... FAILED

failures:

---- classic::crypto_secretstream_xchacha20poly1305::tests::test_secretstream_large_aad stdout ----
thread 'classic::crypto_secretstream_xchacha20poly1305::tests::test_secretstream_large_aad' panicked at src/classic/crypto_secretstream_xchacha20poly1305.rs:394:26:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    classic::crypto_secretstream_xchacha20poly1305::tests::test_secretstream_large_aad

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 87 filtered out; finished in 0.00s
```