### PR TITLE
Decouple dryocbox precalc functions

### DIFF
--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -585,7 +585,7 @@ impl DryocBox<PublicKey, Mac, Vec<u8>> {
     /// Decrypts this box using `nonce` and
     /// `precalc_secret_key`, returning the decrypted message upon
     /// success.
-    pub fn precalc_decrypt_to_vecbox<
+    pub fn precalc_decrypt_to_vec<
         PrecalcSecretKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize,
     >(
         &self,
@@ -678,6 +678,7 @@ impl<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::precalc::PrecalcSecretKey;
 
     #[test]
     fn test_dryocbox_vecbox() {
@@ -943,7 +944,7 @@ mod tests {
             .expect("unable to encrypt");
 
         let decrypted = dryocbox
-            .precalc_decrypt_to_vecbox(&nonce, &precalc_secret_key)
+            .precalc_decrypt_to_vec(&nonce, &precalc_secret_key)
             .expect("unable to decrypt");
 
         assert_eq!(message, decrypted.as_slice());
@@ -1003,7 +1004,7 @@ mod tests {
                     .expect("unable to encrypt");
 
             let decrypted = dryocbox
-                .precalc_decrypt_to_vecbox(&nonce, &precalc_secret_key)
+                .precalc_decrypt_to_vec(&nonce, &precalc_secret_key)
                 .expect("unable to decrypt");
 
             assert_eq!(*message, decrypted.as_slice());

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -102,7 +102,6 @@ use crate::constants::{
     CRYPTO_BOX_PUBLICKEYBYTES, CRYPTO_BOX_SEALBYTES, CRYPTO_BOX_SECRETKEYBYTES,
 };
 use crate::error::*;
-use crate::precalc::PrecalcSecretKey;
 pub use crate::types::*;
 
 /// Stack-allocated public key for authenticated public-key boxes.
@@ -255,13 +254,13 @@ impl<
     /// Encrypts a message using `precalc_secret_key`,
     /// and returns a new [DryocBox] with ciphertext and tag.
     pub fn precalc_encrypt<
-        InnerSecretKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize,
+        PrecalcSecretKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize,
         Message: Bytes + ?Sized,
         Nonce: ByteArray<CRYPTO_BOX_NONCEBYTES>,
     >(
         message: &Message,
         nonce: &Nonce,
-        precalc_secret_key: &PrecalcSecretKey<InnerSecretKey>,
+        precalc_secret_key: &PrecalcSecretKey,
     ) -> Result<Self, Error> {
         use crate::classic::crypto_box::crypto_box_detached_afternm;
 
@@ -446,13 +445,13 @@ impl<
     /// Decrypts this box using `nonce`, `precalc_secret_key`, and
     /// `sender_public_key`, returning the decrypted message upon success.
     pub fn precalc_decrypt<
-        InnerSecretKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize,
+        PrecalcSecretKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize,
         Nonce: ByteArray<CRYPTO_BOX_NONCEBYTES>,
         Output: ResizableBytes + NewBytes,
     >(
         &self,
         nonce: &Nonce,
-        precalc_secret_key: &PrecalcSecretKey<InnerSecretKey>,
+        precalc_secret_key: &PrecalcSecretKey,
     ) -> Result<Output, Error> {
         use crate::classic::crypto_box::crypto_box_open_detached_afternm;
 
@@ -553,11 +552,11 @@ impl DryocBox<PublicKey, Mac, Vec<u8>> {
     /// and returns a new [DryocBox] with ciphertext and tag.
     pub fn precalc_encrypt_to_vecbox<
         Message: Bytes + ?Sized,
-        InnerSecretKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize,
+        PrecalcSecretKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize,
     >(
         message: &Message,
         nonce: &Nonce,
-        precalc_secret_key: &PrecalcSecretKey<InnerSecretKey>,
+        precalc_secret_key: &PrecalcSecretKey,
     ) -> Result<Self, Error> {
         Self::precalc_encrypt(message, nonce, precalc_secret_key)
     }
@@ -587,11 +586,11 @@ impl DryocBox<PublicKey, Mac, Vec<u8>> {
     /// `precalc_secret_key`, returning the decrypted message upon
     /// success.
     pub fn precalc_decrypt_to_vecbox<
-        InnerSecretKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize,
+        PrecalcSecretKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize,
     >(
         &self,
         nonce: &Nonce,
-        precalc_secret_key: &PrecalcSecretKey<InnerSecretKey>,
+        precalc_secret_key: &PrecalcSecretKey,
     ) -> Result<Vec<u8>, Error> {
         self.precalc_decrypt(nonce, precalc_secret_key)
     }

--- a/src/precalc.rs
+++ b/src/precalc.rs
@@ -8,7 +8,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use crate::constants::{
     CRYPTO_BOX_BEFORENMBYTES, CRYPTO_BOX_PUBLICKEYBYTES, CRYPTO_BOX_SECRETKEYBYTES,
 };
-use crate::types::{ByteArray, StackByteArray};
+use crate::types::{ByteArray, Bytes, StackByteArray};
 
 type InnerKey = StackByteArray<CRYPTO_BOX_BEFORENMBYTES>;
 
@@ -24,6 +24,34 @@ type InnerKey = StackByteArray<CRYPTO_BOX_BEFORENMBYTES>;
 /// `crypto_box_beforenm`.
 #[derive(Zeroize, ZeroizeOnDrop, Debug, PartialEq, Eq, Clone)]
 pub struct PrecalcSecretKey<InnerKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize>(InnerKey);
+
+impl<InnerKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Bytes + Zeroize> Bytes
+    for PrecalcSecretKey<InnerKey>
+{
+    #[inline]
+    fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl<InnerKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize> ByteArray<CRYPTO_BOX_BEFORENMBYTES>
+    for PrecalcSecretKey<InnerKey>
+{
+    #[inline]
+    fn as_array(&self) -> &[u8; CRYPTO_BOX_BEFORENMBYTES] {
+        &self.0.as_array()
+    }
+}
 
 impl PrecalcSecretKey<InnerKey> {
     /// Computes a stack-allocated shared secret key for the given

--- a/src/precalc.rs
+++ b/src/precalc.rs
@@ -183,7 +183,8 @@ mod tests {
         let public_key = StackByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::default();
         let secret_key = StackByteArray::<CRYPTO_BOX_SECRETKEYBYTES>::default();
         let precalc_key = PrecalcSecretKey::precalculate(&public_key, &secret_key);
-        assert_eq!(precalc_key.0.len(), CRYPTO_BOX_BEFORENMBYTES);
+        assert!(!precalc_key.is_empty());
+        assert_eq!(precalc_key.len(), CRYPTO_BOX_BEFORENMBYTES);
     }
 
     #[cfg(feature = "nightly")]
@@ -191,8 +192,15 @@ mod tests {
     fn test_precalculate_locked() {
         let public_key = StackByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::default();
         let secret_key = StackByteArray::<CRYPTO_BOX_SECRETKEYBYTES>::default();
-        let precalc_key = PrecalcSecretKey::precalculate_locked(&public_key, &secret_key).unwrap();
-        assert_eq!(precalc_key.0.len(), CRYPTO_BOX_BEFORENMBYTES);
+        let mut precalc_key =
+            PrecalcSecretKey::precalculate_locked(&public_key, &secret_key).unwrap();
+        assert!(!precalc_key.is_empty());
+        assert_eq!(precalc_key.len(), CRYPTO_BOX_BEFORENMBYTES);
+
+        // should be able to write now without blowing up
+        precalc_key.as_mut_slice()[0] = 0;
+        precalc_key.as_mut_array()[0] = 1;
+        precalc_key.copy_from_slice(&precalc_key.as_slice().to_owned());
     }
 
     #[cfg(feature = "nightly")]
@@ -202,6 +210,7 @@ mod tests {
         let secret_key = StackByteArray::<CRYPTO_BOX_SECRETKEYBYTES>::default();
         let precalc_key =
             PrecalcSecretKey::precalculate_readonly_locked(&public_key, &secret_key).unwrap();
-        assert_eq!(precalc_key.0.len(), CRYPTO_BOX_BEFORENMBYTES);
+        assert!(!precalc_key.is_empty());
+        assert_eq!(precalc_key.len(), CRYPTO_BOX_BEFORENMBYTES);
     }
 }

--- a/src/precalc.rs
+++ b/src/precalc.rs
@@ -49,7 +49,7 @@ impl<InnerKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize> ByteArray<CRYPTO_B
 {
     #[inline]
     fn as_array(&self) -> &[u8; CRYPTO_BOX_BEFORENMBYTES] {
-        &self.0.as_array()
+        self.0.as_array()
     }
 }
 

--- a/src/precalc.rs
+++ b/src/precalc.rs
@@ -8,7 +8,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use crate::constants::{
     CRYPTO_BOX_BEFORENMBYTES, CRYPTO_BOX_PUBLICKEYBYTES, CRYPTO_BOX_SECRETKEYBYTES,
 };
-use crate::types::{ByteArray, Bytes, StackByteArray};
+use crate::types::{ByteArray, Bytes, MutByteArray, MutBytes, StackByteArray};
 
 type InnerKey = StackByteArray<CRYPTO_BOX_BEFORENMBYTES>;
 
@@ -50,6 +50,29 @@ impl<InnerKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize> ByteArray<CRYPTO_B
     #[inline]
     fn as_array(&self) -> &[u8; CRYPTO_BOX_BEFORENMBYTES] {
         self.0.as_array()
+    }
+}
+
+impl<InnerKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize + MutBytes> MutBytes
+    for PrecalcSecretKey<InnerKey>
+{
+    #[inline]
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.0.as_mut_slice()
+    }
+
+    #[inline]
+    fn copy_from_slice(&mut self, other: &[u8]) {
+        self.0.copy_from_slice(other);
+    }
+}
+
+impl<InnerKey: MutByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize>
+    MutByteArray<CRYPTO_BOX_BEFORENMBYTES> for PrecalcSecretKey<InnerKey>
+{
+    #[inline]
+    fn as_mut_array(&mut self) -> &mut [u8; CRYPTO_BOX_BEFORENMBYTES] {
+        self.0.as_mut_array()
     }
 }
 


### PR DESCRIPTION
Hi! This is a continuation of my last [PR](https://github.com/brndnmtthws/dryoc/pull/82) with things I should have added back then. (Implemented some traits for `precalc::PrecalcSecretKey` and made precalc dryocbox interface less coupled)