### PR TITLE
ci: use crates.io trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,10 @@ permissions:
 jobs:
   build-test-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      discussions: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: brndnmtthws/rust-action@v1
@@ -21,8 +25,12 @@ jobs:
           toolchain: stable
       - run: cargo build
       - run: cargo test
-      - run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
       - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary

Ports the crates.io publish workflow to trusted publishing so release tags use GitHub Actions OIDC to request a short-lived crates.io token instead of relying on a long-lived repository secret.

## User Impact

Maintainers can publish releases from the existing tag-based workflow without storing or rotating a persistent `CRATES_IO_TOKEN` secret in GitHub Actions.

## Root Cause

The previous publish workflow authenticated with `cargo login ${{ secrets.CRATES_IO_TOKEN }}`, which required a manually managed crates.io API token to remain configured as a repository secret.

## Fix

The publish job now grants `id-token: write`, authenticates with `rust-lang/crates-io-auth-action@v1`, and passes the returned temporary token to `cargo publish` through `CARGO_REGISTRY_TOKEN`.

## Validation

- `cargo test`
- Reviewed the staged and committed workflow diff before pushing.
