### PR TITLE
fix: satisfy clippy explicit-counter-loop in argon2

### DIFF
--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -363,7 +363,7 @@ fn fill_segment(instance: &mut Argon2Instance, position: &mut Argon2Position) {
         0
     };
 
-    let mut curr_offset = position.lane * instance.lane_length
+    let curr_offset = position.lane * instance.lane_length
         + position.slice as u32 * instance.segment_length
         + starting_index;
 
@@ -373,7 +373,7 @@ fn fill_segment(instance: &mut Argon2Instance, position: &mut Argon2Position) {
         curr_offset - 1
     };
 
-    for i in starting_index..instance.segment_length {
+    for (curr_offset, i) in (curr_offset..).zip(starting_index..instance.segment_length) {
         if curr_offset % instance.lane_length == 1 {
             prev_offset = curr_offset - 1;
         }
@@ -406,8 +406,6 @@ fn fill_segment(instance: &mut Argon2Instance, position: &mut Argon2Position) {
         fill_block(prev_block, ref_block, &mut next_block, position.pass != 0);
 
         instance.region.memory[curr_offset as usize] = next_block;
-
-        curr_offset += 1;
         prev_offset += 1;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@
     all(feature = "simd_backend", feature = "nightly"),
     feature(portable_simd)
 )]
-#![cfg_attr(feature = "nightly", feature(test))]
+#![cfg_attr(all(test, feature = "nightly"), feature(test))]
 #[macro_use]
 mod error;
 #[cfg(any(feature = "nightly", all(doc, not(doctest))))]


### PR DESCRIPTION
## Summary

Fix the nightly Clippy failures reported by CI for the `serde,nightly` and `base64,nightly` feature combinations.

## User Impact

The affected nightly CI jobs can run with `-D warnings` without failing on the Argon2 loop lint or the crate-level unused nightly `test` feature warning.

## Root Cause

`fill_segment` manually incremented `curr_offset` while iterating over segment indexes, which Clippy reports as `explicit-counter-loop` when warnings are denied.

The crate also enabled `#![feature(test)]` for every `nightly` library build even though the unstable `test` crate is only used inside `#[cfg(test)]` benchmark modules. On current nightly, that unused feature is denied by the CI command.

## Fix

Derive `curr_offset` from the loop iterator by zipping the offset range with the existing segment index range.

Gate `#![feature(test)]` behind `all(test, feature = "nightly")` so normal library Clippy builds do not declare the feature unless test/bench code is being compiled.

## Validation

Ran `cargo +nightly clippy --features base64,nightly -- -D warnings` successfully.

Ran `cargo +nightly clippy --features serde,nightly -- -D warnings` successfully.
