### PR TITLE
chore: update Rust dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,22 +9,22 @@ license = "MIT"
 name = "dryoc"
 readme = "README.md"
 repository = "https://github.com/brndnmtthws/dryoc"
-rust-version = "1.56"
+rust-version = "1.89"
 version = "0.8.0"
 
 [dependencies]
-base64 = { version = "0.21", optional = true }
-bitflags = "2.3"
-chacha20 = { version = "0.9", features = ["zeroize"] }
+base64 = { version = "0.22", optional = true }
+bitflags = "2.11"
+chacha20 = { version = "0.10", features = ["zeroize"] }
 curve25519-dalek = "4.1.3"
-generic-array = "0.14"
 lazy_static = "1"
-rand_core = { version = "0.9", features = ["os_rng"] }
-salsa20 = { version = "0.10", features = ["zeroize"] }
+rand = { version = "0.10", default-features = false, features = ["sys_rng"] }
+rand_core = "0.10"
+salsa20 = { version = "0.11", features = ["zeroize"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
-sha2 = "0.10"
-subtle = "2.4"
-zeroize = { version = "1.6", features = ["zeroize_derive"] }
+sha2 = "0.11"
+subtle = "2.6"
+zeroize = { version = "1.8", features = ["zeroize_derive"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = [
@@ -40,8 +40,7 @@ winapi = { version = "0.3", features = [
 libc = "0.2"
 
 [dev-dependencies]
-base64 = "0.21"
-bincode = "1"
+base64 = "0.22"
 hex = "0.4"
 libc = "0.2"
 libsodium-sys = "0.2"
@@ -50,12 +49,12 @@ serde_json = "1"
 sodiumoxide = "0.2"
 static_assertions = "1.1"
 num-bigint = { version = "0.4", features = ["rand"] }
-rand = "0.9"
+wincode = "0.5.3"
 
 [features]
 default = ["u64_backend"]
 nightly = []
-simd_backend = ["sha2/asm"]
+simd_backend = []
 u64_backend = []
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ chacha20 = { version = "0.10", features = ["zeroize"] }
 curve25519-dalek = "4.1.3"
 lazy_static = "1"
 rand = { version = "0.10", default-features = false, features = ["sys_rng"] }
-rand_core = "0.10"
 salsa20 = { version = "0.11", features = ["zeroize"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 sha2 = "0.11"

--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -367,7 +367,7 @@ fn fill_segment(instance: &mut Argon2Instance, position: &mut Argon2Position) {
         + position.slice as u32 * instance.segment_length
         + starting_index;
 
-    let mut prev_offset = if curr_offset % instance.lane_length == 0 {
+    let mut prev_offset = if curr_offset.is_multiple_of(instance.lane_length) {
         curr_offset + instance.lane_length - 1
     } else {
         curr_offset - 1
@@ -486,7 +486,7 @@ fn generate_addresses(instance: &mut Argon2Instance, position: &Argon2Position) 
     input_block.v[5] = instance.type_ as u64;
 
     for i in 0..instance.segment_length {
-        if i % ARGON2_ADDRESSES_IN_BLOCK == 0 {
+        if i.is_multiple_of(ARGON2_ADDRESSES_IN_BLOCK) {
             input_block.v[6] += 1;
             tmp_block.v.fill(0);
             address_block.v.fill(0);

--- a/src/blake2b/blake2b_simd.rs
+++ b/src/blake2b/blake2b_simd.rs
@@ -697,7 +697,7 @@ mod tests {
     extern crate test;
     use lazy_static::lazy_static;
     use libc::*;
-    use rand::TryRngCore;
+    use rand::TryRng;
     use serde::{Deserialize, Serialize};
 
     use super::*;
@@ -877,13 +877,13 @@ mod tests {
 
     #[test]
     fn test_blake2b_long_rand_length_simd() {
-        use rand_core::OsRng;
+        use rand::rngs::SysRng;
 
         use crate::rng::copy_randombytes;
 
         for _ in 0..25 {
-            let mut input = vec![0u8; (OsRng.try_next_u32().unwrap() % 1000) as usize];
-            let mut output = vec![0u8; (OsRng.try_next_u32().unwrap() % 1000 + 64) as usize];
+            let mut input = vec![0u8; (SysRng.try_next_u32().unwrap() % 1000) as usize];
+            let mut output = vec![0u8; (SysRng.try_next_u32().unwrap() % 1000 + 64) as usize];
             let mut so_output = output.clone();
             copy_randombytes(&mut input);
 

--- a/src/blake2b/blake2b_simd.rs
+++ b/src/blake2b/blake2b_simd.rs
@@ -12,7 +12,7 @@ const KEYBYTES: usize = 64;
 const SALTBYTES: usize = 16;
 const PERSONALBYTES: usize = 16;
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(dead_code)]
 struct Params {
     digest_length: u8,
@@ -519,7 +519,7 @@ impl State {
                 0
             };
             let remaining = input.len() - start;
-            let end = if remaining > BLOCKBYTES && remaining % BLOCKBYTES == 0 {
+            let end = if remaining > BLOCKBYTES && remaining.is_multiple_of(BLOCKBYTES) {
                 input.len() - BLOCKBYTES
             } else if remaining > BLOCKBYTES {
                 input.len() - remaining % BLOCKBYTES
@@ -671,7 +671,7 @@ pub fn longhash(output: &mut [u8], input: &[u8]) -> Result<(), Error> {
         in_buffer.copy_from_slice(&output[..OUTBYTES]);
 
         let outlen = output.len() - HALFOUTBYTES;
-        let chunk_count = if outlen % HALFOUTBYTES == 0 {
+        let chunk_count = if outlen.is_multiple_of(HALFOUTBYTES) {
             outlen / HALFOUTBYTES - 2
         } else {
             outlen / HALFOUTBYTES - 1

--- a/src/blake2b/blake2b_soft.rs
+++ b/src/blake2b/blake2b_soft.rs
@@ -575,13 +575,13 @@ mod tests {
 
     #[test]
     fn test_blake2b_long_rand_length() {
-        use rand_core::{OsRng, TryRngCore};
+        use rand::{TryRng, rngs::SysRng};
 
         use crate::rng::copy_randombytes;
 
         for _ in 0..25 {
-            let mut input = vec![0u8; (OsRng.try_next_u32().unwrap() % 1000) as usize];
-            let mut output = vec![0u8; (OsRng.try_next_u32().unwrap() % 1000 + 64) as usize];
+            let mut input = vec![0u8; (SysRng.try_next_u32().unwrap() % 1000) as usize];
+            let mut output = vec![0u8; (SysRng.try_next_u32().unwrap() % 1000 + 64) as usize];
             let mut so_output = output.clone();
             copy_randombytes(&mut input);
 

--- a/src/blake2b/blake2b_soft.rs
+++ b/src/blake2b/blake2b_soft.rs
@@ -10,7 +10,7 @@ const KEYBYTES: usize = 64;
 const SALTBYTES: usize = 16;
 const PERSONALBYTES: usize = 16;
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(dead_code)]
 struct Params {
     digest_length: u8,
@@ -233,7 +233,7 @@ impl State {
                 0
             };
             let remaining = input.len() - start;
-            let end = if remaining > BLOCKBYTES && remaining % BLOCKBYTES == 0 {
+            let end = if remaining > BLOCKBYTES && remaining.is_multiple_of(BLOCKBYTES) {
                 input.len() - BLOCKBYTES
             } else if remaining > BLOCKBYTES {
                 input.len() - remaining % BLOCKBYTES
@@ -371,7 +371,7 @@ pub fn longhash(output: &mut [u8], input: &[u8]) -> Result<(), Error> {
         in_buffer.copy_from_slice(&output[..OUTBYTES]);
 
         let outlen = output.len() - HALFOUTBYTES;
-        let chunk_count = if outlen % HALFOUTBYTES == 0 {
+        let chunk_count = if outlen.is_multiple_of(HALFOUTBYTES) {
             outlen / HALFOUTBYTES - 2
         } else {
             outlen / HALFOUTBYTES - 1
@@ -575,7 +575,8 @@ mod tests {
 
     #[test]
     fn test_blake2b_long_rand_length() {
-        use rand::{TryRng, rngs::SysRng};
+        use rand::TryRng;
+        use rand::rngs::SysRng;
 
         use crate::rng::copy_randombytes;
 

--- a/src/classic/crypto_auth.rs
+++ b/src/classic/crypto_auth.rs
@@ -173,20 +173,20 @@ pub fn crypto_auth_final(state: AuthState, output: &mut [u8; CRYPTO_AUTH_BYTES])
 
 #[cfg(test)]
 mod tests {
-    use rand::TryRngCore;
+    use rand::TryRng;
 
     use super::*;
 
     #[test]
     fn test_crypto_auth() {
-        use rand_core::OsRng;
+        use rand::rngs::SysRng;
         use sodiumoxide::crypto::auth;
         use sodiumoxide::crypto::auth::Key as SOKey;
 
         use crate::rng::copy_randombytes;
 
         for _ in 0..20 {
-            let mlen = (OsRng.try_next_u32().unwrap() % 5000) as usize;
+            let mlen = (SysRng.try_next_u32().unwrap() % 5000) as usize;
             let mut message = vec![0u8; mlen];
             copy_randombytes(&mut message);
             let key = crypto_auth_keygen();

--- a/src/classic/crypto_box.rs
+++ b/src/classic/crypto_box.rs
@@ -77,7 +77,7 @@ pub fn crypto_box_seed_keypair_inplace(
 }
 
 /// Generates a public/secret key pair using OS provided data using
-/// [`rand_core::OsRng`].
+/// [`rand::rngs::SysRng`].
 pub fn crypto_box_keypair() -> (PublicKey, SecretKey) {
     crypto_box_curve25519xsalsa20poly1305_keypair()
 }

--- a/src/classic/crypto_generichash.rs
+++ b/src/classic/crypto_generichash.rs
@@ -123,25 +123,25 @@ pub fn crypto_generichash_keygen() -> [u8; CRYPTO_GENERICHASH_KEYBYTES] {
 
 #[cfg(test)]
 mod tests {
-    use rand::TryRngCore;
+    use rand::TryRng;
 
     use super::*;
 
     #[test]
     fn test_generichash() {
         use libsodium_sys::crypto_generichash as so_crypto_generichash;
-        use rand_core::OsRng;
+        use rand::rngs::SysRng;
 
         use crate::constants::{CRYPTO_GENERICHASH_BYTES_MAX, CRYPTO_GENERICHASH_BYTES_MIN};
         use crate::rng::copy_randombytes;
 
         for _ in 0..20 {
             let outlen = CRYPTO_GENERICHASH_BYTES_MIN
-                + (OsRng.try_next_u32().unwrap() as usize
+                + (SysRng.try_next_u32().unwrap() as usize
                     % (CRYPTO_GENERICHASH_BYTES_MAX - CRYPTO_GENERICHASH_BYTES_MIN));
             let mut output = vec![0u8; outlen];
 
-            let mut input = vec![0u8; (OsRng.try_next_u32().unwrap() % 5000) as usize];
+            let mut input = vec![0u8; (SysRng.try_next_u32().unwrap() % 5000) as usize];
 
             copy_randombytes(&mut input);
 
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn test_generichash_key() {
         use libsodium_sys::crypto_generichash as so_crypto_generichash;
-        use rand_core::OsRng;
+        use rand::rngs::SysRng;
 
         use crate::constants::{
             CRYPTO_GENERICHASH_BYTES_MAX, CRYPTO_GENERICHASH_BYTES_MIN,
@@ -177,14 +177,14 @@ mod tests {
 
         for _ in 0..20 {
             let outlen = CRYPTO_GENERICHASH_BYTES_MIN
-                + (OsRng.try_next_u32().unwrap() as usize
+                + (SysRng.try_next_u32().unwrap() as usize
                     % (CRYPTO_GENERICHASH_BYTES_MAX - CRYPTO_GENERICHASH_BYTES_MIN));
             let mut output = vec![0u8; outlen];
 
-            let mut input = vec![0u8; (OsRng.try_next_u32().unwrap() % 5000) as usize];
+            let mut input = vec![0u8; (SysRng.try_next_u32().unwrap() % 5000) as usize];
 
             let keylen = CRYPTO_GENERICHASH_KEYBYTES_MIN
-                + (OsRng.try_next_u32().unwrap() as usize
+                + (SysRng.try_next_u32().unwrap() as usize
                     % (CRYPTO_GENERICHASH_KEYBYTES_MAX - CRYPTO_GENERICHASH_KEYBYTES_MIN));
             let mut key = vec![0u8; keylen];
 

--- a/src/classic/crypto_secretbox_impl.rs
+++ b/src/classic/crypto_secretbox_impl.rs
@@ -1,6 +1,5 @@
-use generic_array::GenericArray;
-use salsa20::XSalsa20;
 use salsa20::cipher::{KeyIvInit, StreamCipher};
+use salsa20::{Key as SalsaKey, XNonce, XSalsa20};
 use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
 
@@ -14,10 +13,9 @@ pub(crate) fn crypto_secretbox_detached_inplace(
     nonce: &Nonce,
     key: &Key,
 ) {
-    let mut cipher = XSalsa20::new(
-        GenericArray::from_slice(key),
-        GenericArray::from_slice(nonce),
-    );
+    let key = SalsaKey::from(*key);
+    let nonce = XNonce::from(*nonce);
+    let mut cipher = XSalsa20::new(&key, &nonce);
 
     let mut mac_key = crate::poly1305::Key::new();
     cipher.apply_keystream(&mut mac_key);
@@ -38,10 +36,9 @@ pub(crate) fn crypto_secretbox_open_detached_inplace(
     nonce: &Nonce,
     key: &Key,
 ) -> Result<(), Error> {
-    let mut cipher = XSalsa20::new(
-        GenericArray::from_slice(key),
-        GenericArray::from_slice(nonce),
-    );
+    let key = SalsaKey::from(*key);
+    let nonce = XNonce::from(*nonce);
+    let mut cipher = XSalsa20::new(&key, &nonce);
 
     let mut mac_key = crate::poly1305::Key::new();
     cipher.apply_keystream(&mut mac_key);

--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -218,8 +218,8 @@ pub fn crypto_secretstream_xchacha20poly1305_init_pull(
 /// Compatible with libsodium's
 /// `crypto_secretstream_xchacha20poly1305_init_push`.
 pub fn crypto_secretstream_xchacha20poly1305_rekey(state: &mut State) {
+    use chacha20::ChaCha20;
     use chacha20::cipher::{KeyIvInit, StreamCipher};
-    use chacha20::{ChaCha20, Key, Nonce};
 
     let mut new_state = [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES
         + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_INONCEBYTES];
@@ -228,9 +228,9 @@ pub fn crypto_secretstream_xchacha20poly1305_rekey(state: &mut State) {
     new_state[CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES..]
         .copy_from_slice(state_inonce(&mut state.nonce));
 
-    let key = Key::from_slice(&state.k);
-    let nonce = Nonce::from_slice(&state.nonce);
-    let mut cipher = ChaCha20::new(key, nonce);
+    let key = state.k.into();
+    let nonce = state.nonce.into();
+    let mut cipher = ChaCha20::new(&key, &nonce);
     cipher.apply_keystream(&mut new_state);
 
     state
@@ -258,8 +258,8 @@ pub fn crypto_secretstream_xchacha20poly1305_push(
     associated_data: Option<&[u8]>,
     tag: u8,
 ) -> Result<(), Error> {
+    use chacha20::ChaCha20;
     use chacha20::cipher::{KeyIvInit, StreamCipher, StreamCipherSeek};
-    use chacha20::{ChaCha20, Key, Nonce};
 
     use crate::poly1305::Poly1305;
 
@@ -286,9 +286,9 @@ pub fn crypto_secretstream_xchacha20poly1305_push(
     let mut mac_key = crate::poly1305::Key::new();
     let _pad0 = [0u8; 16];
 
-    let key = Key::from_slice(&state.k);
-    let nonce = Nonce::from_slice(&state.nonce);
-    let mut cipher = ChaCha20::new(key, nonce);
+    let key = state.k.into();
+    let nonce = state.nonce.into();
+    let mut cipher = ChaCha20::new(&key, &nonce);
 
     cipher.apply_keystream(&mut mac_key);
     let mut mac = Poly1305::new(&mac_key);
@@ -363,8 +363,8 @@ pub fn crypto_secretstream_xchacha20poly1305_pull(
     ciphertext: &[u8],
     associated_data: Option<&[u8]>,
 ) -> Result<usize, Error> {
+    use chacha20::ChaCha20;
     use chacha20::cipher::{KeyIvInit, StreamCipher, StreamCipherSeek};
-    use chacha20::{ChaCha20, Key, Nonce};
 
     use crate::poly1305::Poly1305;
 
@@ -390,9 +390,9 @@ pub fn crypto_secretstream_xchacha20poly1305_pull(
 
     let mut mac_key = crate::poly1305::Key::new();
 
-    let key = Key::from_slice(&state.k);
-    let nonce = Nonce::from_slice(&state.nonce);
-    let mut cipher = ChaCha20::new(key, nonce);
+    let key = state.k.into();
+    let nonce = state.nonce.into();
+    let mut cipher = ChaCha20::new(&key, &nonce);
 
     cipher.apply_keystream(&mut mac_key);
     let mut mac = Poly1305::new(&mac_key);

--- a/src/classic/crypto_shorthash.rs
+++ b/src/classic/crypto_shorthash.rs
@@ -59,18 +59,18 @@ pub fn crypto_shorthash(output: &mut Hash, input: &[u8], key: &Key) {
 
 #[cfg(test)]
 mod tests {
-    use rand::TryRngCore;
+    use rand::TryRng;
 
     use super::*;
 
     #[test]
     fn test_shorthash() {
-        use rand_core::OsRng;
+        use rand::rngs::SysRng;
         use sodiumoxide::crypto::shorthash;
 
         for _ in 0..20 {
             let key = crypto_shorthash_keygen();
-            let mut input = vec![0u8; (OsRng.try_next_u32().unwrap() % 69) as usize];
+            let mut input = vec![0u8; (SysRng.try_next_u32().unwrap() % 69) as usize];
             copy_randombytes(&mut input);
             let mut output = Hash::default();
 

--- a/src/poly1305/poly1305_soft.rs
+++ b/src/poly1305/poly1305_soft.rs
@@ -164,7 +164,7 @@ impl Poly1305 {
         // process any remaining block
         if !self.buffer.is_empty() {
             self.buffer.push(1);
-            if self.buffer.len() % BLOCK_SIZE != 0 {
+            if !self.buffer.len().is_multiple_of(BLOCK_SIZE) {
                 self.buffer.resize(
                     self.buffer.len() + (BLOCK_SIZE - self.buffer.len() % BLOCK_SIZE),
                     0,

--- a/src/poly1305/poly1305_soft.rs
+++ b/src/poly1305/poly1305_soft.rs
@@ -244,7 +244,7 @@ impl Poly1305 {
 
 #[cfg(test)]
 mod tests {
-    use rand::TryRngCore;
+    use rand::TryRng;
 
     use super::*;
 
@@ -372,7 +372,7 @@ mod tests {
 
     #[test]
     fn test_libsodium() {
-        use rand_core::OsRng;
+        use rand::rngs::SysRng;
         use sodiumoxide::crypto::onetimeauth::poly1305::{Key as SOKey, authenticate};
 
         use crate::rng::copy_randombytes;
@@ -382,7 +382,7 @@ mod tests {
         let so_key = SOKey::from_slice(&key).unwrap();
 
         for _ in 0..20 {
-            let rand_usize = (OsRng.try_next_u32().unwrap() % 1000) as usize;
+            let rand_usize = (SysRng.try_next_u32().unwrap() % 1000) as usize;
             let mut data = vec![0u8; rand_usize];
             copy_randombytes(&mut data);
 

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,6 +1,7 @@
 /// Provides random data up to `len` from the OS's random number generator.
 pub fn randombytes_buf(len: usize) -> Vec<u8> {
-    use rand::{TryRng, rngs::SysRng};
+    use rand::TryRng;
+    use rand::rngs::SysRng;
 
     let mut r: Vec<u8> = vec![0; len];
     SysRng
@@ -13,7 +14,8 @@ pub fn randombytes_buf(len: usize) -> Vec<u8> {
 /// Provides random data up to length of `data` from the OS's random number
 /// generator.
 pub fn copy_randombytes(dest: &mut [u8]) {
-    use rand::{TryRng, rngs::SysRng};
+    use rand::TryRng;
+    use rand::rngs::SysRng;
 
     SysRng
         .try_fill_bytes(dest)

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,9 +1,9 @@
 /// Provides random data up to `len` from the OS's random number generator.
 pub fn randombytes_buf(len: usize) -> Vec<u8> {
-    use rand_core::{OsRng, TryRngCore};
+    use rand::{TryRng, rngs::SysRng};
 
     let mut r: Vec<u8> = vec![0; len];
-    OsRng
+    SysRng
         .try_fill_bytes(r.as_mut_slice())
         .expect("failed to fill random bytes");
 
@@ -13,9 +13,9 @@ pub fn randombytes_buf(len: usize) -> Vec<u8> {
 /// Provides random data up to length of `data` from the OS's random number
 /// generator.
 pub fn copy_randombytes(dest: &mut [u8]) {
-    use rand_core::{OsRng, TryRngCore};
+    use rand::{TryRng, rngs::SysRng};
 
-    OsRng
+    SysRng
         .try_fill_bytes(dest)
         .expect("failed to fill random bytes");
 }

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -11,8 +11,6 @@
 //! state.update(b"bytes");
 //! let hash = state.finalize_to_vec();
 //! ```
-use generic_array::GenericArray;
-use generic_array::typenum::U64;
 use sha2::{Digest as DigestImpl, Sha512 as Sha512Impl};
 
 use crate::constants::CRYPTO_HASH_SHA512_BYTES;
@@ -77,11 +75,11 @@ impl Sha512 {
 
     /// Consumes hasher and writes final computed hash into `output`.
     pub fn finalize_into_bytes<Output: MutByteArray<CRYPTO_HASH_SHA512_BYTES>>(
-        mut self,
+        self,
         output: &mut Output,
     ) {
-        let arr = GenericArray::<_, U64>::from_mut_slice(output.as_mut_slice());
-        self.hasher.finalize_into_reset(arr);
+        let digest = self.hasher.finalize();
+        output.as_mut_slice().copy_from_slice(&digest);
     }
 
     /// Consumes hasher and returns final computed hash as a [`Vec`].

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,7 +56,7 @@ pub(crate) fn pad16(n: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use rand::TryRngCore;
+    use rand::TryRng;
 
     use super::*;
 
@@ -122,12 +122,12 @@ mod tests {
     #[test]
     fn test_sodium_increment() {
         use libsodium_sys::sodium_increment as so_sodium_increment;
-        use rand_core::OsRng;
+        use rand::rngs::SysRng;
 
         use crate::rng::copy_randombytes;
 
         for _ in 0..20 {
-            let rand_usize = (OsRng.try_next_u32().unwrap() % 1000) as usize;
+            let rand_usize = (SysRng.try_next_u32().unwrap() % 1000) as usize;
             let mut data = vec![0u8; rand_usize];
             copy_randombytes(&mut data);
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -118,9 +118,8 @@ fn test_dryocsecretbox_serde_json() {
     assert_eq!(message, decrypted.as_slice());
 }
 
-#[cfg(feature = "serde")]
 #[test]
-fn test_dryocbox_serde_bincode() {
+fn test_dryocbox_wincode_bytes() {
     use dryoc::dryocbox::*;
 
     let sender_keypair = KeyPair::gen();
@@ -136,9 +135,10 @@ fn test_dryocbox_serde_bincode() {
     )
     .expect("unable to encrypt");
 
-    let encoded = bincode::serialize(&dryocbox).expect("doesn't serialize");
+    let encoded = wincode::serialize(&dryocbox.to_vec()).expect("doesn't serialize");
 
-    let dryocbox: VecBox = bincode::deserialize(&encoded).unwrap();
+    let bytes: Vec<u8> = wincode::deserialize(&encoded).unwrap();
+    let dryocbox = VecBox::from_bytes(&bytes).expect("doesn't deserialize");
 
     let decrypted: Vec<u8> = dryocbox
         .decrypt(
@@ -151,9 +151,8 @@ fn test_dryocbox_serde_bincode() {
     assert_eq!(message, decrypted.as_slice());
 }
 
-#[cfg(feature = "serde")]
 #[test]
-fn test_dryocsecretbox_serde_bincode() {
+fn test_dryocsecretbox_wincode_bytes() {
     use dryoc::dryocsecretbox::*;
 
     let secret_key = Key::gen();
@@ -162,9 +161,10 @@ fn test_dryocsecretbox_serde_bincode() {
 
     let dryocsecretbox: VecBox = DryocSecretBox::encrypt(message, &nonce, &secret_key);
 
-    let encoded = bincode::serialize(&dryocsecretbox).expect("doesn't serialize");
+    let encoded = wincode::serialize(&dryocsecretbox.to_vec()).expect("doesn't serialize");
 
-    let dryocsecretbox: VecBox = bincode::deserialize(&encoded).unwrap();
+    let bytes: Vec<u8> = wincode::deserialize(&encoded).unwrap();
+    let dryocsecretbox = VecBox::from_bytes(&bytes).expect("doesn't deserialize");
 
     let decrypted: Vec<u8> = dryocsecretbox
         .decrypt(&nonce, &secret_key)
@@ -173,9 +173,10 @@ fn test_dryocsecretbox_serde_bincode() {
     assert_eq!(message, decrypted.as_slice());
 }
 
-#[cfg(all(feature = "serde", feature = "nightly"))]
+#[cfg(feature = "nightly")]
 #[test]
-fn test_dryocsecretbox_serde_protected_bincode() {
+fn test_dryocsecretbox_protected_wincode_bytes() {
+    use dryoc::constants::CRYPTO_SECRETBOX_MACBYTES;
     use dryoc::dryocsecretbox::protected::*;
     use dryoc::dryocsecretbox::*;
 
@@ -192,9 +193,15 @@ fn test_dryocsecretbox_serde_protected_bincode() {
     let dryocsecretbox: protected::LockedBox =
         DryocSecretBox::encrypt(&message, &nonce, &secret_key);
 
-    let encoded = bincode::serialize(&dryocsecretbox).expect("doesn't serialize");
+    let bytes: Vec<u8> = dryocsecretbox.to_bytes();
+    let encoded = wincode::serialize(&bytes).expect("doesn't serialize");
 
-    let dryocsecretbox: protected::LockedBox = bincode::deserialize(&encoded).unwrap();
+    let bytes: Vec<u8> = wincode::deserialize(&encoded).unwrap();
+    let (tag, data) = bytes.split_at(CRYPTO_SECRETBOX_MACBYTES);
+    let tag = protected::Mac::from_slice_into_locked(tag).expect("doesn't deserialize tag");
+    let data = HeapBytes::from_slice_into_locked(data).expect("doesn't deserialize data");
+    let dryocsecretbox: protected::LockedBox =
+        protected::LockedBox::from_parts(tag, data);
 
     let decrypted: LockedBytes = dryocsecretbox
         .decrypt(&nonce, &secret_key)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -200,8 +200,7 @@ fn test_dryocsecretbox_protected_wincode_bytes() {
     let (tag, data) = bytes.split_at(CRYPTO_SECRETBOX_MACBYTES);
     let tag = protected::Mac::from_slice_into_locked(tag).expect("doesn't deserialize tag");
     let data = HeapBytes::from_slice_into_locked(data).expect("doesn't deserialize data");
-    let dryocsecretbox: protected::LockedBox =
-        protected::LockedBox::from_parts(tag, data);
+    let dryocsecretbox: protected::LockedBox = protected::LockedBox::from_parts(tag, data);
 
     let decrypted: LockedBytes = dryocsecretbox
         .decrypt(&nonce, &secret_key)


### PR DESCRIPTION
## Summary

Updates dryoc's Rust dependency set to current stable releases, including RustCrypto stream/hash crates, rand/rand_core, base64, bitflags, subtle, and zeroize. The crate MSRV is raised to Rust 1.89 to match the selected dependency set, and dead dev-only bincode coverage is replaced with wincode-based byte round-trip tests.

## User Impact

Consumers building newer dependency graphs can use current stable crate versions. The release is incompatible for users pinned to older Rust toolchains because the supported Rust version moves from 1.56 to 1.89.

## Root Cause

Several direct dependencies were behind current stable releases, and the existing bincode dev dependency is no longer a good maintenance target. Newer RustCrypto and rand versions changed some APIs and feature surfaces, requiring small source updates.

## Fix

Bumps direct dependencies, migrates OS randomness from rand_core::OsRng to rand::rngs::SysRng, updates RustCrypto array construction for chacha20/salsa20/sha2, removes the stale sha2/asm feature mapping, and replaces bincode integration tests with wincode tests over dryoc's canonical byte representation.

## Validation

- cargo check --all-targets --features serde,base64
- cargo test --features serde,base64
- cargo check --manifest-path fuzz/Cargo.toml
