### PR TITLE
fix: protect full memory regions

### DIFF
--- a/src/protected.rs
+++ b/src/protected.rs
@@ -336,7 +336,7 @@ fn dryoc_mprotect_readonly(data: &[u8]) -> Result<(), std::io::Error> {
     #[cfg(unix)]
     {
         use libc::{PROT_READ, c_void, mprotect as c_mprotect};
-        let ret = unsafe { c_mprotect(data.as_ptr() as *mut c_void, data.len() - 1, PROT_READ) };
+        let ret = unsafe { c_mprotect(data.as_ptr() as *mut c_void, data.len(), PROT_READ) };
         match ret {
             0 => Ok(()),
             _ => Err(std::io::Error::last_os_error()),
@@ -350,14 +350,8 @@ fn dryoc_mprotect_readonly(data: &[u8]) -> Result<(), std::io::Error> {
 
         let mut old: DWORD = 0;
 
-        let res = unsafe {
-            VirtualProtect(
-                data.as_ptr() as LPVOID,
-                data.len() - 1,
-                PAGE_READONLY,
-                &mut old,
-            )
-        };
+        let res =
+            unsafe { VirtualProtect(data.as_ptr() as LPVOID, data.len(), PAGE_READONLY, &mut old) };
         match res {
             1 => Ok(()),
             _ => Err(std::io::Error::last_os_error()),
@@ -376,7 +370,7 @@ fn dryoc_mprotect_readwrite(data: &[u8]) -> Result<(), std::io::Error> {
         let ret = unsafe {
             c_mprotect(
                 data.as_ptr() as *mut c_void,
-                data.len() - 1,
+                data.len(),
                 PROT_READ | PROT_WRITE,
             )
         };
@@ -396,7 +390,7 @@ fn dryoc_mprotect_readwrite(data: &[u8]) -> Result<(), std::io::Error> {
         let res = unsafe {
             VirtualProtect(
                 data.as_ptr() as LPVOID,
-                data.len() - 1,
+                data.len(),
                 PAGE_READWRITE,
                 &mut old,
             )
@@ -416,7 +410,7 @@ fn dryoc_mprotect_noaccess(data: &[u8]) -> Result<(), std::io::Error> {
     #[cfg(unix)]
     {
         use libc::{PROT_NONE, c_void, mprotect as c_mprotect};
-        let ret = unsafe { c_mprotect(data.as_ptr() as *mut c_void, data.len() - 1, PROT_NONE) };
+        let ret = unsafe { c_mprotect(data.as_ptr() as *mut c_void, data.len(), PROT_NONE) };
         match ret {
             0 => Ok(()),
             _ => Err(std::io::Error::last_os_error()),
@@ -430,14 +424,8 @@ fn dryoc_mprotect_noaccess(data: &[u8]) -> Result<(), std::io::Error> {
 
         let mut old: DWORD = 0;
 
-        let res = unsafe {
-            VirtualProtect(
-                data.as_ptr() as LPVOID,
-                data.len() - 1,
-                PAGE_NOACCESS,
-                &mut old,
-            )
-        };
+        let res =
+            unsafe { VirtualProtect(data.as_ptr() as LPVOID, data.len(), PAGE_NOACCESS, &mut old) };
         match res {
             1 => Ok(()),
             _ => Err(std::io::Error::last_os_error()),
@@ -693,15 +681,22 @@ lazy_static! {
     };
 }
 
-fn _page_round(size: usize, pagesize: usize) -> usize {
-    size + (pagesize - size % pagesize)
+fn _page_round(size: usize, pagesize: usize) -> Option<usize> {
+    let rem = size % pagesize;
+    if rem == 0 {
+        Some(size)
+    } else {
+        size.checked_add(pagesize - rem)
+    }
 }
 
 unsafe impl Allocator for PageAlignedAllocator {
     #[inline]
     fn allocate(&self, layout: Layout) -> Result<ptr::NonNull<[u8]>, AllocError> {
         let pagesize = *PAGESIZE;
-        let size = _page_round(layout.size(), pagesize) + 2 * pagesize;
+        let rounded_size = _page_round(layout.size(), pagesize).ok_or(AllocError)?;
+        let guard_size = pagesize.checked_mul(2).ok_or(AllocError)?;
+        let size = rounded_size.checked_add(guard_size).ok_or(AllocError)?;
         #[cfg(unix)]
         let out = {
             use libc::posix_memalign;
@@ -720,14 +715,18 @@ unsafe impl Allocator for PageAlignedAllocator {
         let out = {
             use winapi::um::memoryapi::VirtualAlloc;
             use winapi::um::winnt::{MEM_COMMIT, MEM_RESERVE, PAGE_READWRITE};
-            unsafe {
+            let out = unsafe {
                 VirtualAlloc(
                     ptr::null_mut(),
                     size,
                     MEM_COMMIT | MEM_RESERVE,
                     PAGE_READWRITE,
                 )
+            };
+            if out.is_null() {
+                return Err(AllocError);
             }
+            out
         };
 
         // lock the pages at the fore of the region
@@ -738,7 +737,7 @@ unsafe impl Allocator for PageAlignedAllocator {
             .ok();
 
         // lock the pages at the aft of the region
-        let aft_protected_region_offset = pagesize + _page_round(layout.size(), pagesize);
+        let aft_protected_region_offset = pagesize.checked_add(rounded_size).ok_or(AllocError)?;
         let aft_protected_region = unsafe {
             std::slice::from_raw_parts_mut(
                 out.add(aft_protected_region_offset) as *mut u8,
@@ -772,7 +771,14 @@ unsafe impl Allocator for PageAlignedAllocator {
             .ok();
 
         // unlock the aft protected region
-        let aft_protected_region_offset = pagesize + _page_round(layout.size(), pagesize);
+        let rounded_size = match _page_round(layout.size(), pagesize) {
+            Some(size) => size,
+            None => return,
+        };
+        let aft_protected_region_offset = match pagesize.checked_add(rounded_size) {
+            Some(offset) => offset,
+            None => return,
+        };
         let aft_protected_region =
             std::slice::from_raw_parts_mut(ptr.add(aft_protected_region_offset), pagesize);
 
@@ -1496,6 +1502,60 @@ mod tests {
         vec.resize(5, 0);
 
         assert_eq!([1, 2, 3, 0, 1], vec.as_slice());
+    }
+
+    #[test]
+    fn test_page_rounding() {
+        let pagesize = *PAGESIZE;
+
+        assert_eq!(_page_round(0, pagesize), Some(0));
+        assert_eq!(_page_round(1, pagesize), Some(pagesize));
+        assert_eq!(_page_round(pagesize, pagesize), Some(pagesize));
+        assert_eq!(_page_round(pagesize + 1, pagesize), Some(pagesize * 2));
+        assert_eq!(_page_round(usize::MAX, pagesize), None);
+    }
+
+    #[test]
+    fn test_mprotect_handles_single_byte_slice() {
+        let mut vec: Vec<u8, _> = Vec::new_in(PageAlignedAllocator);
+        vec.push(1);
+
+        dryoc_mprotect_readonly(vec.as_slice()).expect("readonly mprotect failed");
+        dryoc_mprotect_readwrite(vec.as_slice()).expect("readwrite mprotect failed");
+        vec[0] = 2;
+
+        assert_eq!(vec[0], 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_mprotect_noaccess_covers_page_boundary_tail() {
+        let pagesize = *PAGESIZE;
+        let mut vec: Vec<u8, _> = Vec::new_in(PageAlignedAllocator);
+        vec.resize(pagesize + 1, 0);
+
+        dryoc_mprotect_noaccess(vec.as_slice()).expect("noaccess mprotect failed");
+
+        let child = unsafe { libc::fork() };
+        assert!(child >= 0, "fork failed");
+
+        if child == 0 {
+            let tail = unsafe { vec.as_ptr().add(pagesize) as *mut u8 };
+            unsafe {
+                std::ptr::write_volatile(tail, 1);
+                libc::_exit(0);
+            }
+        }
+
+        let mut status = 0;
+        let wait_ret = unsafe { libc::waitpid(child, &mut status, 0) };
+        dryoc_mprotect_readwrite(vec.as_slice()).expect("readwrite mprotect failed");
+
+        assert_eq!(wait_ret, child);
+        assert!(
+            libc::WIFSIGNALED(status),
+            "child unexpectedly wrote to protected tail page"
+        );
     }
 
     // #[test]

--- a/src/protected.rs
+++ b/src/protected.rs
@@ -771,20 +771,16 @@ unsafe impl Allocator for PageAlignedAllocator {
             .ok();
 
         // unlock the aft protected region
-        let rounded_size = match _page_round(layout.size(), pagesize) {
-            Some(size) => size,
-            None => return,
-        };
-        let aft_protected_region_offset = match pagesize.checked_add(rounded_size) {
-            Some(offset) => offset,
-            None => return,
-        };
-        let aft_protected_region =
-            std::slice::from_raw_parts_mut(ptr.add(aft_protected_region_offset), pagesize);
+        if let Some(aft_protected_region_offset) =
+            _page_round(layout.size(), pagesize).and_then(|size| pagesize.checked_add(size))
+        {
+            let aft_protected_region =
+                std::slice::from_raw_parts_mut(ptr.add(aft_protected_region_offset), pagesize);
 
-        dryoc_mprotect_readwrite(aft_protected_region)
-            .map_err(|err| eprintln!("mprotect error = {:?}", err))
-            .ok();
+            dryoc_mprotect_readwrite(aft_protected_region)
+                .map_err(|err| eprintln!("mprotect error = {:?}", err))
+                .ok();
+        }
 
         #[cfg(unix)]
         {


### PR DESCRIPTION
## Summary

Fix protected-memory bounds handling so `mprotect`/`VirtualProtect` applies to the full target slice instead of one byte less than the slice length. This also hardens page rounding and allocation size calculations for the page-aligned allocator.

Closes #102.

## User Impact

Nightly protected-memory users can rely on protection calls covering the entire requested region, including one-byte regions and allocations that extend just past a page boundary. Allocation failure and extreme layout sizes now fail cleanly instead of risking invalid pointer/slice construction.

## Root Cause

The protected-memory wrappers passed `data.len() - 1` to the OS protection APIs, which could under-protect non-empty regions. The allocator also used unchecked size arithmetic and did not check Windows `VirtualAlloc` for null before constructing guard-page slices.

## Fix

Use `data.len()` for read-only, read-write, and no-access protection calls on Unix and Windows. Convert page rounding to checked arithmetic, add checked guard-page size calculations, check `VirtualAlloc` failure, and reuse the rounded size for guard-page placement.

## Validation

- `rustfmt +nightly --check src/protected.rs`
- `cargo +nightly test --features nightly protected::tests --lib`
- `cargo test --lib`
