### PR TITLE
feat: add wincode serialization support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,6 +25,7 @@ jobs:
         features:
           - serde
           - base64
+          - wincode
           - simd_backend
           - default
         os:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
             cargo-tarpaulin
             cargo-hold
       - run: cargo hold voyage
-      - run: cargo tarpaulin --features serde,nightly --out Xml
+      - run: cargo tarpaulin --features serde,nightly,wincode --out Xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
         if: github.repository == 'brndnmtthws/dryoc'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ salsa20 = { version = "0.11", features = ["zeroize"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 sha2 = "0.11"
 subtle = "2.6"
+wincode = { version = "0.5.3", optional = true, features = ["derive"] }
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 
 [target.'cfg(windows)'.dependencies]
@@ -55,7 +56,8 @@ default = ["u64_backend"]
 nightly = []
 simd_backend = []
 u64_backend = []
+wincode = ["dep:wincode"]
 
 [package.metadata.docs.rs]
 # docs.rs uses nightly, enable feature flag to get all the juicy docs
-features = ["nightly", "serde", "base64"]
+features = ["nightly", "serde", "base64", "wincode"]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ For example usage, refer to the
 * Many libsodium features implemented with both Classic and Rustaceous API
 * Protected memory handling (`mprotect()` + `mlock()`, along with Windows equivalents)
 * [Serde](https://serde.rs/) support (with `features = ["serde"]`)
+* [wincode](https://crates.io/crates/wincode) support for direct binary serialization of Rustaceous box types (with `features = ["wincode"]`)
 * [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html) implementation for Blake2b (used by generic hashing, password hashing, and key derivation) on nightly, with `features = ["simd_backend", "nightly"]`
 * SIMD backend for Curve25519 (used by public/private key functions) on nightly with `features = ["simd_backend", "nightly"]`
 * [SHA2](https://github.com/RustCrypto/hashes/tree/master/sha2) (used by sealed boxes) includes SIMD implementation for AVX2
@@ -59,6 +60,17 @@ _Note that eventually this project will converge on portable SIMD implementation
 for all the core algos which will work across all platforms supported by LLVM,
 rather than relying on hand-coded assembly or intrinsics, but this is a work in
 progress_.
+
+## Optional serialization
+
+Enable `serde` to derive [`serde::Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html)
+and [`serde::Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html)
+for supported data structures.
+
+Enable `wincode` to derive [`wincode::SchemaWrite`](https://docs.rs/wincode/latest/wincode/trait.SchemaWrite.html)
+and [`wincode::SchemaRead`](https://docs.rs/wincode/latest/wincode/trait.SchemaRead.html)
+for supported Rustaceous box types, including `DryocBox` and
+`DryocSecretBox`.
 
 ## Project status
 

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -18,7 +18,9 @@
 //! the sender's public key in the box.
 //!
 //! If the `serde` feature is enabled, the [`serde::Deserialize`] and
-//! [`serde::Serialize`] traits will be implemented for [`DryocBox`].
+//! [`serde::Serialize`] traits will be implemented for [`DryocBox`]. If the
+//! `wincode` feature is enabled, the [`wincode::SchemaRead`] and
+//! [`wincode::SchemaWrite`] traits will be implemented.
 //!
 //! ## Rustaceous API example
 //!
@@ -193,6 +195,7 @@ pub mod protected {
     feature = "serde",
     derive(Zeroize, Clone, Debug, Serialize, Deserialize)
 )]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[cfg_attr(not(feature = "serde"), derive(Zeroize, Clone, Debug))]
 /// A libsodium public-key authenticated encrypted box.
 ///

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -19,8 +19,8 @@
 //!
 //! If the `serde` feature is enabled, the [`serde::Deserialize`] and
 //! [`serde::Serialize`] traits will be implemented for [`DryocBox`]. If the
-//! `wincode` feature is enabled, the [`wincode::SchemaRead`] and
-//! [`wincode::SchemaWrite`] traits will be implemented.
+//! `wincode` feature is enabled, the `wincode::SchemaRead` and
+//! `wincode::SchemaWrite` traits will be implemented.
 //!
 //! ## Rustaceous API example
 //!
@@ -195,7 +195,6 @@ pub mod protected {
     feature = "serde",
     derive(Zeroize, Clone, Debug, Serialize, Deserialize)
 )]
-#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[cfg_attr(not(feature = "serde"), derive(Zeroize, Clone, Debug))]
 /// A libsodium public-key authenticated encrypted box.
 ///
@@ -212,6 +211,57 @@ pub struct DryocBox<
 
 /// [Vec]-based authenticated public-key box.
 pub type VecBox = DryocBox<PublicKey, Mac, Vec<u8>>;
+
+#[cfg(feature = "wincode")]
+unsafe impl<C: wincode::config::Config> wincode::SchemaWrite<C> for VecBox {
+    type Src = Self;
+
+    fn size_of(src: &Self::Src) -> wincode::WriteResult<usize> {
+        Ok(
+            <Option<[u8; CRYPTO_BOX_PUBLICKEYBYTES]> as wincode::SchemaWrite<C>>::size_of(
+                &src.ephemeral_pk.as_ref().map(|epk| *epk.as_array()),
+            )? + <[u8; CRYPTO_BOX_MACBYTES] as wincode::SchemaWrite<C>>::size_of(
+                src.tag.as_array(),
+            )? + <Vec<u8> as wincode::SchemaWrite<C>>::size_of(&src.data)?,
+        )
+    }
+
+    fn write(mut writer: impl wincode::io::Writer, src: &Self::Src) -> wincode::WriteResult<()> {
+        <Option<[u8; CRYPTO_BOX_PUBLICKEYBYTES]> as wincode::SchemaWrite<C>>::write(
+            writer.by_ref(),
+            &src.ephemeral_pk.as_ref().map(|epk| *epk.as_array()),
+        )?;
+        <[u8; CRYPTO_BOX_MACBYTES] as wincode::SchemaWrite<C>>::write(
+            writer.by_ref(),
+            src.tag.as_array(),
+        )?;
+        <Vec<u8> as wincode::SchemaWrite<C>>::write(writer, &src.data)
+    }
+}
+
+#[cfg(feature = "wincode")]
+unsafe impl<'de, C: wincode::config::Config> wincode::SchemaRead<'de, C> for VecBox {
+    type Dst = Self;
+
+    fn read(
+        mut reader: impl wincode::io::Reader<'de>,
+        dst: &mut std::mem::MaybeUninit<Self::Dst>,
+    ) -> wincode::ReadResult<()> {
+        let ephemeral_pk = <Option<[u8; CRYPTO_BOX_PUBLICKEYBYTES]> as wincode::SchemaRead<
+            'de,
+            C,
+        >>::get(reader.by_ref())?
+        .map(Into::into);
+        let tag = <[u8; CRYPTO_BOX_MACBYTES] as wincode::SchemaRead<'de, C>>::get(reader.by_ref())?;
+        let data = <Vec<u8> as wincode::SchemaRead<'de, C>>::get(reader)?;
+        dst.write(Self {
+            ephemeral_pk,
+            tag: tag.into(),
+            data,
+        });
+        Ok(())
+    }
+}
 
 impl<
     EphemeralPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,

--- a/src/dryocsecretbox.rs
+++ b/src/dryocsecretbox.rs
@@ -15,7 +15,9 @@
 //!     [`crypto_pwhash`](crate::classic::crypto_pwhash)
 //!
 //! If the `serde` feature is enabled, the [`serde::Deserialize`] and
-//! [`serde::Serialize`] traits will be implemented for [`DryocSecretBox`].
+//! [`serde::Serialize`] traits will be implemented for [`DryocSecretBox`]. If
+//! the `wincode` feature is enabled, the [`wincode::SchemaRead`] and
+//! [`wincode::SchemaWrite`] traits will be implemented.
 //!
 //! ## Rustaceous API example
 //!
@@ -128,6 +130,7 @@ pub mod protected {
     feature = "serde",
     derive(Zeroize, Clone, Debug, Serialize, Deserialize)
 )]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[cfg_attr(not(feature = "serde"), derive(Zeroize, Clone, Debug))]
 /// An authenticated secret-key encrypted box, compatible with a libsodium box.
 /// Use with either [`VecBox`] or [`protected::LockedBox`] type aliases.

--- a/src/dryocsecretbox.rs
+++ b/src/dryocsecretbox.rs
@@ -16,8 +16,8 @@
 //!
 //! If the `serde` feature is enabled, the [`serde::Deserialize`] and
 //! [`serde::Serialize`] traits will be implemented for [`DryocSecretBox`]. If
-//! the `wincode` feature is enabled, the [`wincode::SchemaRead`] and
-//! [`wincode::SchemaWrite`] traits will be implemented.
+//! the `wincode` feature is enabled, the `wincode::SchemaRead` and
+//! `wincode::SchemaWrite` traits will be implemented.
 //!
 //! ## Rustaceous API example
 //!
@@ -130,7 +130,6 @@ pub mod protected {
     feature = "serde",
     derive(Zeroize, Clone, Debug, Serialize, Deserialize)
 )]
-#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[cfg_attr(not(feature = "serde"), derive(Zeroize, Clone, Debug))]
 /// An authenticated secret-key encrypted box, compatible with a libsodium box.
 /// Use with either [`VecBox`] or [`protected::LockedBox`] type aliases.
@@ -146,6 +145,46 @@ pub struct DryocSecretBox<
 
 /// [Vec]-based authenticated secret box.
 pub type VecBox = DryocSecretBox<Mac, Vec<u8>>;
+
+#[cfg(feature = "wincode")]
+unsafe impl<C: wincode::config::Config> wincode::SchemaWrite<C> for VecBox {
+    type Src = Self;
+
+    fn size_of(src: &Self::Src) -> wincode::WriteResult<usize> {
+        Ok(
+            <[u8; CRYPTO_SECRETBOX_MACBYTES] as wincode::SchemaWrite<C>>::size_of(
+                src.tag.as_array(),
+            )? + <Vec<u8> as wincode::SchemaWrite<C>>::size_of(&src.data)?,
+        )
+    }
+
+    fn write(mut writer: impl wincode::io::Writer, src: &Self::Src) -> wincode::WriteResult<()> {
+        <[u8; CRYPTO_SECRETBOX_MACBYTES] as wincode::SchemaWrite<C>>::write(
+            writer.by_ref(),
+            src.tag.as_array(),
+        )?;
+        <Vec<u8> as wincode::SchemaWrite<C>>::write(writer, &src.data)
+    }
+}
+
+#[cfg(feature = "wincode")]
+unsafe impl<'de, C: wincode::config::Config> wincode::SchemaRead<'de, C> for VecBox {
+    type Dst = Self;
+
+    fn read(
+        mut reader: impl wincode::io::Reader<'de>,
+        dst: &mut std::mem::MaybeUninit<Self::Dst>,
+    ) -> wincode::ReadResult<()> {
+        let tag =
+            <[u8; CRYPTO_SECRETBOX_MACBYTES] as wincode::SchemaRead<'de, C>>::get(reader.by_ref())?;
+        let data = <Vec<u8> as wincode::SchemaRead<'de, C>>::get(reader)?;
+        dst.write(Self {
+            tag: tag.into(),
+            data,
+        });
+        Ok(())
+    }
+}
 
 impl<
     Mac: NewByteArray<CRYPTO_SECRETBOX_MACBYTES> + Zeroize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@
 //!
 //! This crate includes optional [wincode](https://crates.io/crates/wincode)
 //! support which can be enabled with the `wincode` feature flag. When enabled,
-//! [`wincode::SchemaWrite`] and [`wincode::SchemaRead`] are provided for
+//! `wincode::SchemaWrite` and `wincode::SchemaRead` are provided for
 //! supported Rustaceous box types, including [`DryocBox`](dryocbox::DryocBox)
 //! and [`DryocSecretBox`](dryocsecretbox::DryocSecretBox).
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@
 //! * Protected memory handling (`mprotect()` + `mlock()`, along with Windows
 //!   equivalents)
 //! * [Serde](https://serde.rs/) support (with `features = ["serde"]`)
+//! * [wincode](https://crates.io/crates/wincode) support for direct binary
+//!   serialization of Rustaceous box types (with `features = ["wincode"]`)
 //! * [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html)
 //!   implementation for Blake2b (used by generic hashing, password hashing, and
 //!   key derivation) on nightly, with `features = ["simd_backend", "nightly"]`
@@ -97,6 +99,14 @@
 //! [`Serialize`](serde::ser::Serialize) and
 //! [`Deserialize`](serde::de::Deserialize) traits are provided for data
 //! structures.
+//!
+//! ## Using wincode
+//!
+//! This crate includes optional [wincode](https://crates.io/crates/wincode)
+//! support which can be enabled with the `wincode` feature flag. When enabled,
+//! [`wincode::SchemaWrite`] and [`wincode::SchemaRead`] are provided for
+//! supported Rustaceous box types, including [`DryocBox`](dryocbox::DryocBox)
+//! and [`DryocSecretBox`](dryocsecretbox::DryocSecretBox).
 //!
 //! ## Security notes
 //!

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,8 +4,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use crate::rng::copy_randombytes;
 
 /// A stack-allocated fixed-length byte array for working with data, with
-/// optional [Serde](https://serde.rs) and `wincode` features.
-#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
+/// optional [Serde](https://serde.rs) features.
 #[derive(Zeroize, ZeroizeOnDrop, Debug, PartialEq, Eq, Clone)]
 pub struct StackByteArray<const LENGTH: usize>([u8; LENGTH]);
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,8 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use crate::rng::copy_randombytes;
 
 /// A stack-allocated fixed-length byte array for working with data, with
-/// optional [Serde](https://serde.rs) features.
+/// optional [Serde](https://serde.rs) and `wincode` features.
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Zeroize, ZeroizeOnDrop, Debug, PartialEq, Eq, Clone)]
 pub struct StackByteArray<const LENGTH: usize>([u8; LENGTH]);
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -151,6 +151,59 @@ fn test_dryocbox_wincode_bytes() {
     assert_eq!(message, decrypted.as_slice());
 }
 
+#[cfg(feature = "wincode")]
+#[test]
+fn test_dryocbox_wincode() {
+    use dryoc::dryocbox::*;
+
+    let sender_keypair = KeyPair::gen();
+    let recipient_keypair = KeyPair::gen();
+    let nonce = Nonce::gen();
+    let message = b"hey friend";
+
+    let dryocbox: VecBox = DryocBox::encrypt(
+        message,
+        &nonce,
+        &recipient_keypair.public_key,
+        &sender_keypair.secret_key,
+    )
+    .expect("unable to encrypt");
+
+    let encoded = wincode::serialize(&dryocbox).expect("doesn't serialize");
+    let dryocbox: VecBox = wincode::deserialize(&encoded).expect("doesn't deserialize");
+
+    let decrypted: Vec<u8> = dryocbox
+        .decrypt(
+            &nonce,
+            &sender_keypair.public_key,
+            &recipient_keypair.secret_key,
+        )
+        .expect("decrypt failed");
+
+    assert_eq!(message, decrypted.as_slice());
+}
+
+#[cfg(feature = "wincode")]
+#[test]
+fn test_dryocbox_sealed_wincode() {
+    use dryoc::dryocbox::*;
+
+    let recipient_keypair = KeyPair::gen();
+    let message = b"hey sealed friend";
+
+    let dryocbox: VecBox =
+        DryocBox::seal(message, &recipient_keypair.public_key).expect("unable to seal");
+
+    let encoded = wincode::serialize(&dryocbox).expect("doesn't serialize");
+    let dryocbox: VecBox = wincode::deserialize(&encoded).expect("doesn't deserialize");
+
+    let decrypted: Vec<u8> = dryocbox
+        .unseal(&recipient_keypair)
+        .expect("unable to unseal");
+
+    assert_eq!(message, decrypted.as_slice());
+}
+
 #[test]
 fn test_dryocsecretbox_wincode_bytes() {
     use dryoc::dryocsecretbox::*;
@@ -165,6 +218,27 @@ fn test_dryocsecretbox_wincode_bytes() {
 
     let bytes: Vec<u8> = wincode::deserialize(&encoded).unwrap();
     let dryocsecretbox = VecBox::from_bytes(&bytes).expect("doesn't deserialize");
+
+    let decrypted: Vec<u8> = dryocsecretbox
+        .decrypt(&nonce, &secret_key)
+        .expect("unable to decrypt");
+
+    assert_eq!(message, decrypted.as_slice());
+}
+
+#[cfg(feature = "wincode")]
+#[test]
+fn test_dryocsecretbox_wincode() {
+    use dryoc::dryocsecretbox::*;
+
+    let secret_key = Key::gen();
+    let nonce = Nonce::gen();
+    let message = b"hey buddy bro";
+
+    let dryocsecretbox: VecBox = DryocSecretBox::encrypt(message, &nonce, &secret_key);
+
+    let encoded = wincode::serialize(&dryocsecretbox).expect("doesn't serialize");
+    let dryocsecretbox: VecBox = wincode::deserialize(&encoded).expect("doesn't deserialize");
 
     let decrypted: Vec<u8> = dryocsecretbox
         .decrypt(&nonce, &secret_key)


### PR DESCRIPTION
## Summary

Adds a first-class optional `wincode` feature for dryoc's Rustaceous box types. When enabled, `DryocBox`, `DryocSecretBox`, and the fixed-size byte wrapper used by their key/tag fields derive `wincode::SchemaWrite` and `wincode::SchemaRead`.

## User Impact

Users who want binary serialization through wincode can now serialize and deserialize `VecBox` values directly instead of manually converting through libsodium-compatible byte vectors. Existing users are unaffected because the dependency is optional and the feature is disabled by default.

## Root Cause

The crate had wincode roundtrip coverage only by serializing raw byte vectors. That tested compatibility of the byte format, but it did not expose direct wincode trait implementations for the public box types.

## Fix

Adds the optional `wincode` dependency with derive support, wires a `wincode` crate feature, documents the new feature-gated trait implementations, and derives the wincode traits for the supported public data structures. Integration tests now cover direct wincode serialization for public-key boxes, sealed boxes, and secret boxes.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --features wincode -- -D warnings`
- `cargo test --features serde,base64,wincode`
