### PR TITLE
feat: add portable SIMD Salsa20 secretbox backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ than convenience refactors.
 
 ## Toolchain And Features
 
-- The crate uses Rust 2021. `Cargo.toml` declares `rust-version = "1.56"`;
+- The crate uses Rust 2021. `Cargo.toml` declares `rust-version = "1.89"`;
   avoid newer language features unless the MSRV is intentionally changed.
 - Default features are `u64_backend`.
 - Optional features:
@@ -105,8 +105,11 @@ cargo fuzz run fuzz_target_1
 - `src/rng.rs`: random byte generation.
 - `src/protected.rs`: nightly-only protected memory allocator and locked bytes.
 - `src/classic/`: libsodium-compatible API modules.
-- `src/blake2b/`, `src/poly1305/`, `src/argon2.rs`, `src/scalarmult_curve25519.rs`:
-  primitive implementations and backend selection.
+- `src/blake2b/`, `src/poly1305/`, `src/argon2.rs`,
+  `src/scalarmult_curve25519.rs`: primitive implementations and backend
+  selection.
+- `src/classic/salsa20_simd.rs`: nightly-only portable SIMD Salsa20 backend
+  used internally by `crypto_secretbox` when `simd_backend` is enabled.
 - `tests/integration_tests.rs`: public behavior and feature integration.
 - `fuzz/`: cargo-fuzz target workspace.
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,74 @@
+# Benchmarks
+
+This page collects `dryoc` benchmark results by algorithm and implementation.
+Results are meant to show relative performance for the same API surface on the
+same machine; they are not portable guarantees.
+
+## Environment
+
+These results were collected on:
+
+| Item | Value |
+| --- | --- |
+| Machine | MacBook M3 Max |
+| Architecture | `aarch64-apple-darwin` |
+| OS | Darwin `25.5.0` |
+| Rust | `rustc 1.97.0-nightly (ff9a9ea07 2026-05-13)` |
+| Cargo | `cargo 1.97.0-nightly (a343accce 2026-05-08)` |
+| Target CPU | `native` (`apple-m3`) |
+
+Commands used for the rows below:
+
+```sh
+RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features nightly blake2b_bench
+RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features simd_backend,nightly blake2b_bench
+RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features nightly crypto_secretbox_detached
+RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features simd_backend,nightly crypto_secretbox_detached
+```
+
+`neon` is already reported by `rustc +nightly --print cfg` on this target, but
+the benchmark commands include it explicitly along with `target-cpu=native`.
+Run `cargo +nightly bench` without a benchmark-name filter to collect the full
+suite.
+
+## Generic Hashing: BLAKE2b
+
+Benchmark: hash a 694,200-byte buffer and produce a 64-byte output.
+
+| Implementation | Feature set | Time | Relative |
+| --- | --- | ---: | ---: |
+| Software | `nightly` | `779,302.60 ns/iter` | `1.00x` |
+| Portable SIMD | `simd_backend,nightly` | `588,802.05 ns/iter` | `1.32x faster` |
+
+The portable SIMD backend is about 32.4% faster than the software backend for
+this workload on this machine.
+
+## Secretbox: XSalsa20-Poly1305
+
+Benchmark: `crypto_secretbox_detached` encrypts a fixed-size message into a
+preallocated ciphertext buffer and computes the Poly1305 tag. This measures the
+combined XSalsa20 stream and Poly1305 authentication path used by secretbox.
+
+| Message size | Software time | Software throughput | SIMD time | SIMD throughput | Relative |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 64 B | `289.63 ns/iter` | `221 MB/s` | `290.30 ns/iter` | `220 MB/s` | `1.00x` |
+| 1 KiB | `1,611.67 ns/iter` | `635 MB/s` | `1,491.38 ns/iter` | `686 MB/s` | `1.08x faster` |
+| 16 KiB | `22,620.50 ns/iter` | `724 MB/s` | `18,951.23 ns/iter` | `864 MB/s` | `1.19x faster` |
+| 1 MiB | `1,472,677.08 ns/iter` | `712 MB/s` | `1,214,131.25 ns/iter` | `863 MB/s` | `1.21x faster` |
+
+The portable SIMD Salsa20 path helps larger messages by processing four
+independent Salsa20 counter blocks in parallel. Small messages mostly measure
+fixed XSalsa20 setup plus Poly1305 overhead, so the SIMD advantage grows with
+payload size.
+
+## Benchmark Coverage
+
+Current side-by-side software/SIMD benchmark coverage:
+
+| Algorithm | Software implementation | SIMD implementation | Benchmarked |
+| --- | --- | --- | --- |
+| BLAKE2b | `blake2b_soft` | `blake2b_simd` | Yes |
+| XSalsa20-Poly1305 secretbox | RustCrypto `salsa20` + `poly1305_soft` | portable-SIMD Salsa20 + `poly1305_soft` | Yes |
+
+Algorithms without side-by-side benchmark coverage should get their own section
+when a second implementation is added or when performance work begins.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -51,10 +51,10 @@ combined XSalsa20 stream and Poly1305 authentication path used by secretbox.
 
 | Message size | Software time | Software throughput | SIMD time | SIMD throughput | Relative |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 64 B | `289.63 ns/iter` | `221 MB/s` | `290.30 ns/iter` | `220 MB/s` | `1.00x` |
-| 1 KiB | `1,611.67 ns/iter` | `635 MB/s` | `1,491.38 ns/iter` | `686 MB/s` | `1.08x faster` |
-| 16 KiB | `22,620.50 ns/iter` | `724 MB/s` | `18,951.23 ns/iter` | `864 MB/s` | `1.19x faster` |
-| 1 MiB | `1,472,677.08 ns/iter` | `712 MB/s` | `1,214,131.25 ns/iter` | `863 MB/s` | `1.21x faster` |
+| 64 B | `294.64 ns/iter` | `217 MB/s` | `295.54 ns/iter` | `216 MB/s` | `1.00x` |
+| 1 KiB | `1,639.56 ns/iter` | `624 MB/s` | `1,499.19 ns/iter` | `683 MB/s` | `1.09x faster` |
+| 16 KiB | `23,103.33 ns/iter` | `709 MB/s` | `18,906.71 ns/iter` | `866 MB/s` | `1.22x faster` |
+| 1 MiB | `1,461,518.75 ns/iter` | `717 MB/s` | `1,206,953.14 ns/iter` | `868 MB/s` | `1.21x faster` |
 
 The portable SIMD Salsa20 path helps larger messages by processing four
 independent Salsa20 counter blocks in parallel. Small messages mostly measure

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ base64 = "0.22"
 hex = "0.4"
 libc = "0.2"
 libsodium-sys = "0.2"
+proptest = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 sodiumoxide = "0.2"

--- a/README.md
+++ b/README.md
@@ -45,20 +45,30 @@ For example usage, refer to the
 * Protected memory handling (`mprotect()` + `mlock()`, along with Windows equivalents)
 * [Serde](https://serde.rs/) support (with `features = ["serde"]`)
 * [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html) implementation for Blake2b (used by generic hashing, password hashing, and key derivation) on nightly, with `features = ["simd_backend", "nightly"]`
-* SIMD backend for Curve25519 (used by public/private key functions) on nightly with `features = ["simd_backend", "nightly"]`
+* [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html) implementation for Salsa20 (used by XSalsa20-Poly1305 secretbox) on nightly, with `features = ["simd_backend", "nightly"]`
+* [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek) (used by public/private key functions) selects its own serial or x86_64 vector backend at build time
 * [SHA2](https://github.com/RustCrypto/hashes/tree/master/sha2) (used by sealed boxes) includes SIMD implementation for AVX2
 * [ChaCha20](https://github.com/RustCrypto/stream-ciphers/tree/master/chacha20) (used by streaming interface) includes SIMD implementations for Neon, AVX2, and SSE2
 
-To enable all the SIMD backends through 3rd party crates, you'll need to also
-set `RUSTFLAGS`:
+The `simd_backend` and `nightly` features enable dryoc's portable SIMD
+backends. CPU-specific dependency backends and local benchmarking may also
+benefit from target-specific `RUSTFLAGS`:
 * For AVX2 set `RUSTFLAGS=-Ctarget-cpu=haswell -Ctarget-feature=+avx2`
 * For SSE2 set `RUSTFLAGS=-Ctarget-feature=+sse2`
 * For Neon set `RUSTFLAGS=-Ctarget-feature=+neon`
+* For local Apple silicon benchmarks, use
+  `RUSTFLAGS=-Ctarget-cpu=native -Ctarget-feature=+neon`
+
+The Curve25519 backend is selected by `curve25519-dalek`, not by dryoc's
+`simd_backend` feature.
 
 _Note that eventually this project will converge on portable SIMD implementations
 for all the core algos which will work across all platforms supported by LLVM,
 rather than relying on hand-coded assembly or intrinsics, but this is a work in
 progress_.
+
+See [BENCHMARKS.md](BENCHMARKS.md) for side-by-side software and SIMD benchmark
+results.
 
 ## Project status
 
@@ -88,7 +98,7 @@ The following libsodium features are either incomplete, not exposed as public
 APIs, or not implemented; you may find equivalent functionality in other
 crates:
 
-* [Stream ciphers](https://doc.libsodium.org/advanced/stream_ciphers) (use [salsa20](https://crates.io/crates/salsa20) crate directly instead)
+* Standalone [stream cipher](https://doc.libsodium.org/advanced/stream_ciphers) APIs (use the [salsa20](https://crates.io/crates/salsa20) crate directly instead)
 * [Helpers](https://doc.libsodium.org/helpers) and [padding](https://doc.libsodium.org/padding) utilities
 * [Advanced features](https://doc.libsodium.org/advanced):
   * [Scrypt](https://doc.libsodium.org/advanced/scrypt) (use [scrypt](https://crates.io/crates/scrypt) crate directly instead)
@@ -107,7 +117,8 @@ crates:
 
 [^2]: The protected memory features described in the [protected] mod require
 custom memory allocation, system calls, and pointer arithmetic, which are unsafe
-in Rust. Some of the 3rd party libraries used by this crate, such as those with
-SIMD, may contain unsafe code. In particular, most SIMD implementations are
-considered "unsafe" due to their use of assembly or intrinsics, however without
-SIMD-based cryptography you may be exposed to timing attacks.
+in Rust. Some optional SIMD code, including dependency-provided SIMD
+implementations and small internal helpers, may contain unsafe code. In
+particular, many SIMD implementations are considered "unsafe" due to their use
+of assembly or intrinsics, however without SIMD-based cryptography you may be
+exposed to timing attacks.

--- a/src/classic/crypto_secretbox.rs
+++ b/src/classic/crypto_secretbox.rs
@@ -174,6 +174,9 @@ pub fn crypto_secretbox_open_easy_inplace(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "nightly")]
+    extern crate test;
+
     use super::*;
 
     #[test]
@@ -260,5 +263,50 @@ mod tests {
             assert_eq!(&decrypted, &message_copy);
             assert_eq!(decrypted, so_decrypted);
         }
+    }
+
+    #[cfg(feature = "nightly")]
+    fn bench_crypto_secretbox_detached(b: &mut test::Bencher, message_len: usize) {
+        let key: Key = crypto_secretbox_keygen();
+        let nonce = Nonce::gen();
+        let mut message = vec![0u8; message_len];
+        crate::rng::copy_randombytes(&mut message);
+        let mut ciphertext = vec![0u8; message_len];
+        let mut mac = Mac::default();
+
+        b.bytes = message_len as u64;
+        b.iter(|| {
+            crypto_secretbox_detached(
+                test::black_box(&mut ciphertext),
+                test::black_box(&mut mac),
+                test::black_box(&message),
+                test::black_box(&nonce),
+                test::black_box(&key),
+            );
+        });
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn crypto_secretbox_detached_64b_bench(b: &mut test::Bencher) {
+        bench_crypto_secretbox_detached(b, 64);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn crypto_secretbox_detached_1kib_bench(b: &mut test::Bencher) {
+        bench_crypto_secretbox_detached(b, 1024);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn crypto_secretbox_detached_16kib_bench(b: &mut test::Bencher) {
+        bench_crypto_secretbox_detached(b, 16 * 1024);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn crypto_secretbox_detached_1mib_bench(b: &mut test::Bencher) {
+        bench_crypto_secretbox_detached(b, 1024 * 1024);
     }
 }

--- a/src/classic/crypto_secretbox_impl.rs
+++ b/src/classic/crypto_secretbox_impl.rs
@@ -87,18 +87,20 @@ pub(crate) fn crypto_secretbox_open_detached_inplace(
     nonce: &Nonce,
     key: &Key,
 ) -> Result<(), Error> {
-    let mut cipher = SecretBoxCipher::new(nonce, key);
-    let mut mac_key = Poly1305Key::new();
-    cipher.poly1305_key(&mut mac_key);
+    let computed_mac = {
+        let mut cipher = SecretBoxCipher::new(nonce, key);
+        let mut mac_key = Poly1305Key::new();
+        cipher.poly1305_key(&mut mac_key);
 
-    let mut computed_mac = Poly1305::new(&mac_key);
-    mac_key.zeroize();
+        let mut computed_mac = Poly1305::new(&mac_key);
+        mac_key.zeroize();
 
-    computed_mac.update(data);
-    let computed_mac = computed_mac.finalize_to_array();
+        computed_mac.update(data);
+        let computed_mac = computed_mac.finalize_to_array();
 
-    cipher.xor(data);
-    drop(cipher);
+        cipher.xor(data);
+        computed_mac
+    };
 
     if mac.ct_eq(&computed_mac).unwrap_u8() == 1 {
         Ok(())

--- a/src/classic/crypto_secretbox_impl.rs
+++ b/src/classic/crypto_secretbox_impl.rs
@@ -1,11 +1,65 @@
+#[cfg(not(all(feature = "simd_backend", feature = "nightly")))]
 use salsa20::cipher::{KeyIvInit, StreamCipher};
+#[cfg(not(all(feature = "simd_backend", feature = "nightly")))]
 use salsa20::{Key as SalsaKey, XNonce, XSalsa20};
 use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
 
 use crate::classic::crypto_secretbox::{Key, Mac, Nonce};
 use crate::error::Error;
-use crate::poly1305::Poly1305;
+use crate::poly1305::{Key as Poly1305Key, Poly1305};
+
+#[cfg(all(feature = "simd_backend", feature = "nightly"))]
+struct SecretBoxCipher {
+    cipher: crate::classic::salsa20_simd::XSalsa20,
+    first_block: crate::classic::salsa20_simd::FirstBlock,
+}
+
+#[cfg(not(all(feature = "simd_backend", feature = "nightly")))]
+struct SecretBoxCipher {
+    cipher: XSalsa20,
+}
+
+#[cfg(all(feature = "simd_backend", feature = "nightly"))]
+impl SecretBoxCipher {
+    fn new(nonce: &Nonce, key: &Key) -> Self {
+        let cipher = crate::classic::salsa20_simd::XSalsa20::new(nonce, key);
+        let first_block = cipher.first_block();
+
+        Self {
+            cipher,
+            first_block,
+        }
+    }
+
+    fn poly1305_key(&mut self, mac_key: &mut Poly1305Key) {
+        self.first_block.poly1305_key(mac_key);
+    }
+
+    fn xor(&mut self, data: &mut [u8]) {
+        self.cipher.xor_after_first_block(data, &self.first_block);
+    }
+}
+
+#[cfg(not(all(feature = "simd_backend", feature = "nightly")))]
+impl SecretBoxCipher {
+    fn new(nonce: &Nonce, key: &Key) -> Self {
+        let key = SalsaKey::from(*key);
+        let nonce = XNonce::from(*nonce);
+
+        Self {
+            cipher: XSalsa20::new(&key, &nonce),
+        }
+    }
+
+    fn poly1305_key(&mut self, mac_key: &mut Poly1305Key) {
+        self.cipher.apply_keystream(mac_key);
+    }
+
+    fn xor(&mut self, data: &mut [u8]) {
+        self.cipher.apply_keystream(data);
+    }
+}
 
 pub(crate) fn crypto_secretbox_detached_inplace(
     data: &mut [u8],
@@ -13,18 +67,15 @@ pub(crate) fn crypto_secretbox_detached_inplace(
     nonce: &Nonce,
     key: &Key,
 ) {
-    let key = SalsaKey::from(*key);
-    let nonce = XNonce::from(*nonce);
-    let mut cipher = XSalsa20::new(&key, &nonce);
-
-    let mut mac_key = crate::poly1305::Key::new();
-    cipher.apply_keystream(&mut mac_key);
+    let mut mac_key = Poly1305Key::new();
+    {
+        let mut cipher = SecretBoxCipher::new(nonce, key);
+        cipher.poly1305_key(&mut mac_key);
+        cipher.xor(data);
+    }
 
     let mut computed_mac = Poly1305::new(&mac_key);
-
     mac_key.zeroize();
-
-    cipher.apply_keystream(data);
 
     computed_mac.update(data);
     computed_mac.finalize(mac);
@@ -36,12 +87,9 @@ pub(crate) fn crypto_secretbox_open_detached_inplace(
     nonce: &Nonce,
     key: &Key,
 ) -> Result<(), Error> {
-    let key = SalsaKey::from(*key);
-    let nonce = XNonce::from(*nonce);
-    let mut cipher = XSalsa20::new(&key, &nonce);
-
-    let mut mac_key = crate::poly1305::Key::new();
-    cipher.apply_keystream(&mut mac_key);
+    let mut cipher = SecretBoxCipher::new(nonce, key);
+    let mut mac_key = Poly1305Key::new();
+    cipher.poly1305_key(&mut mac_key);
 
     let mut computed_mac = Poly1305::new(&mac_key);
     mac_key.zeroize();
@@ -49,7 +97,8 @@ pub(crate) fn crypto_secretbox_open_detached_inplace(
     computed_mac.update(data);
     let computed_mac = computed_mac.finalize_to_array();
 
-    cipher.apply_keystream(data);
+    cipher.xor(data);
+    drop(cipher);
 
     if mac.ct_eq(&computed_mac).unwrap_u8() == 1 {
         Ok(())

--- a/src/classic/salsa20_simd.rs
+++ b/src/classic/salsa20_simd.rs
@@ -1,0 +1,446 @@
+use std::ptr;
+use std::simd::{Simd, simd_swizzle};
+use std::sync::atomic::{Ordering, compiler_fence};
+
+use zeroize::Zeroize;
+
+use crate::classic::crypto_core::crypto_core_hsalsa20;
+use crate::classic::crypto_secretbox::{Key, Nonce};
+use crate::poly1305::Key as Poly1305Key;
+use crate::utils::load_u32_le;
+
+type U32x4 = Simd<u32, 4>;
+
+const SIGMA: [u32; 4] = [0x61707865, 0x3320646e, 0x79622d32, 0x6b206574];
+
+#[inline]
+fn rotl32(x: U32x4, n: u32) -> U32x4 {
+    (x << U32x4::splat(n)) | (x >> U32x4::splat(32 - n))
+}
+
+#[inline]
+fn rotl_sum(y0: U32x4, y1: U32x4, rot: u32) -> U32x4 {
+    rotl32(y0 + y1, rot)
+}
+
+#[inline]
+fn salsa20_rounds(x: &mut [U32x4; 16]) {
+    for _ in (0..20).step_by(2) {
+        x[4] ^= rotl_sum(x[0], x[12], 7);
+        x[8] ^= rotl_sum(x[4], x[0], 9);
+        x[12] ^= rotl_sum(x[8], x[4], 13);
+        x[0] ^= rotl_sum(x[12], x[8], 18);
+        x[9] ^= rotl_sum(x[5], x[1], 7);
+        x[13] ^= rotl_sum(x[9], x[5], 9);
+        x[1] ^= rotl_sum(x[13], x[9], 13);
+        x[5] ^= rotl_sum(x[1], x[13], 18);
+        x[14] ^= rotl_sum(x[10], x[6], 7);
+        x[2] ^= rotl_sum(x[14], x[10], 9);
+        x[6] ^= rotl_sum(x[2], x[14], 13);
+        x[10] ^= rotl_sum(x[6], x[2], 18);
+        x[3] ^= rotl_sum(x[15], x[11], 7);
+        x[7] ^= rotl_sum(x[3], x[15], 9);
+        x[11] ^= rotl_sum(x[7], x[3], 13);
+        x[15] ^= rotl_sum(x[11], x[7], 18);
+        x[1] ^= rotl_sum(x[0], x[3], 7);
+        x[2] ^= rotl_sum(x[1], x[0], 9);
+        x[3] ^= rotl_sum(x[2], x[1], 13);
+        x[0] ^= rotl_sum(x[3], x[2], 18);
+        x[6] ^= rotl_sum(x[5], x[4], 7);
+        x[7] ^= rotl_sum(x[6], x[5], 9);
+        x[4] ^= rotl_sum(x[7], x[6], 13);
+        x[5] ^= rotl_sum(x[4], x[7], 18);
+        x[11] ^= rotl_sum(x[10], x[9], 7);
+        x[8] ^= rotl_sum(x[11], x[10], 9);
+        x[9] ^= rotl_sum(x[8], x[11], 13);
+        x[10] ^= rotl_sum(x[9], x[8], 18);
+        x[12] ^= rotl_sum(x[15], x[14], 7);
+        x[13] ^= rotl_sum(x[12], x[15], 9);
+        x[14] ^= rotl_sum(x[13], x[12], 13);
+        x[15] ^= rotl_sum(x[14], x[13], 18);
+    }
+}
+
+fn salsa20_block(input: &[u32; 16], counter: u64) -> [u8; 64] {
+    let mut state = *input;
+    state[8] = counter as u32;
+    state[9] = (counter >> 32) as u32;
+    let orig = state;
+
+    for _ in (0..20).step_by(2) {
+        state[4] ^= state[0].wrapping_add(state[12]).rotate_left(7);
+        state[8] ^= state[4].wrapping_add(state[0]).rotate_left(9);
+        state[12] ^= state[8].wrapping_add(state[4]).rotate_left(13);
+        state[0] ^= state[12].wrapping_add(state[8]).rotate_left(18);
+        state[9] ^= state[5].wrapping_add(state[1]).rotate_left(7);
+        state[13] ^= state[9].wrapping_add(state[5]).rotate_left(9);
+        state[1] ^= state[13].wrapping_add(state[9]).rotate_left(13);
+        state[5] ^= state[1].wrapping_add(state[13]).rotate_left(18);
+        state[14] ^= state[10].wrapping_add(state[6]).rotate_left(7);
+        state[2] ^= state[14].wrapping_add(state[10]).rotate_left(9);
+        state[6] ^= state[2].wrapping_add(state[14]).rotate_left(13);
+        state[10] ^= state[6].wrapping_add(state[2]).rotate_left(18);
+        state[3] ^= state[15].wrapping_add(state[11]).rotate_left(7);
+        state[7] ^= state[3].wrapping_add(state[15]).rotate_left(9);
+        state[11] ^= state[7].wrapping_add(state[3]).rotate_left(13);
+        state[15] ^= state[11].wrapping_add(state[7]).rotate_left(18);
+        state[1] ^= state[0].wrapping_add(state[3]).rotate_left(7);
+        state[2] ^= state[1].wrapping_add(state[0]).rotate_left(9);
+        state[3] ^= state[2].wrapping_add(state[1]).rotate_left(13);
+        state[0] ^= state[3].wrapping_add(state[2]).rotate_left(18);
+        state[6] ^= state[5].wrapping_add(state[4]).rotate_left(7);
+        state[7] ^= state[6].wrapping_add(state[5]).rotate_left(9);
+        state[4] ^= state[7].wrapping_add(state[6]).rotate_left(13);
+        state[5] ^= state[4].wrapping_add(state[7]).rotate_left(18);
+        state[11] ^= state[10].wrapping_add(state[9]).rotate_left(7);
+        state[8] ^= state[11].wrapping_add(state[10]).rotate_left(9);
+        state[9] ^= state[8].wrapping_add(state[11]).rotate_left(13);
+        state[10] ^= state[9].wrapping_add(state[8]).rotate_left(18);
+        state[12] ^= state[15].wrapping_add(state[14]).rotate_left(7);
+        state[13] ^= state[12].wrapping_add(state[15]).rotate_left(9);
+        state[14] ^= state[13].wrapping_add(state[12]).rotate_left(13);
+        state[15] ^= state[14].wrapping_add(state[13]).rotate_left(18);
+    }
+
+    let mut output = [0u8; 64];
+    for (i, word) in state.iter_mut().enumerate() {
+        *word = word.wrapping_add(orig[i]);
+        output[i * 4..(i + 1) * 4].copy_from_slice(&word.to_le_bytes());
+    }
+    state.zeroize();
+    output
+}
+
+#[inline]
+fn counter_lanes(counter: u64) -> (U32x4, U32x4) {
+    let counters = [
+        counter,
+        counter.wrapping_add(1),
+        counter.wrapping_add(2),
+        counter.wrapping_add(3),
+    ];
+    (
+        U32x4::from([
+            counters[0] as u32,
+            counters[1] as u32,
+            counters[2] as u32,
+            counters[3] as u32,
+        ]),
+        U32x4::from([
+            (counters[0] >> 32) as u32,
+            (counters[1] >> 32) as u32,
+            (counters[2] >> 32) as u32,
+            (counters[3] >> 32) as u32,
+        ]),
+    )
+}
+
+#[inline]
+fn input_lanes(input: &[u32; 16]) -> [U32x4; 16] {
+    let mut lanes = input.map(U32x4::splat);
+    lanes[8] = U32x4::splat(0);
+    lanes[9] = U32x4::splat(0);
+    lanes
+}
+
+#[inline]
+fn xor_4words(data: &mut [u8], offset: usize, words: U32x4) {
+    let data_words = U32x4::from([
+        load_u32_le(&data[offset..offset + 4]),
+        load_u32_le(&data[offset + 4..offset + 8]),
+        load_u32_le(&data[offset + 8..offset + 12]),
+        load_u32_le(&data[offset + 12..offset + 16]),
+    ]);
+    for (i, word) in (data_words ^ words).to_array().iter().enumerate() {
+        data[offset + i * 4..offset + (i + 1) * 4].copy_from_slice(&word.to_le_bytes());
+    }
+}
+
+#[inline]
+fn transpose_and_xor_4words(
+    data: &mut [u8],
+    word_offset: usize,
+    w0: U32x4,
+    w1: U32x4,
+    w2: U32x4,
+    w3: U32x4,
+) {
+    let b01_lo = simd_swizzle!(w0, w1, [0, 4, 1, 5]);
+    let b01_hi = simd_swizzle!(w0, w1, [2, 6, 3, 7]);
+    let b23_lo = simd_swizzle!(w2, w3, [0, 4, 1, 5]);
+    let b23_hi = simd_swizzle!(w2, w3, [2, 6, 3, 7]);
+
+    xor_4words(
+        data,
+        word_offset,
+        simd_swizzle!(b01_lo, b23_lo, [0, 1, 4, 5]),
+    );
+    xor_4words(
+        data,
+        64 + word_offset,
+        simd_swizzle!(b01_lo, b23_lo, [2, 3, 6, 7]),
+    );
+    xor_4words(
+        data,
+        128 + word_offset,
+        simd_swizzle!(b01_hi, b23_hi, [0, 1, 4, 5]),
+    );
+    xor_4words(
+        data,
+        192 + word_offset,
+        simd_swizzle!(b01_hi, b23_hi, [2, 3, 6, 7]),
+    );
+}
+
+fn salsa20_xor_4blocks(data: &mut [u8], input_lanes: &[U32x4; 16], counter: u64) {
+    debug_assert_eq!(data.len(), 256);
+
+    let mut state = *input_lanes;
+    let (counter_low, counter_high) = counter_lanes(counter);
+    state[8] = counter_low;
+    state[9] = counter_high;
+
+    let orig = state;
+    salsa20_rounds(&mut state);
+
+    for word_offset in (0..16).step_by(4) {
+        transpose_and_xor_4words(
+            data,
+            word_offset * 4,
+            state[word_offset] + orig[word_offset],
+            state[word_offset + 1] + orig[word_offset + 1],
+            state[word_offset + 2] + orig[word_offset + 2],
+            state[word_offset + 3] + orig[word_offset + 3],
+        );
+    }
+}
+
+pub(crate) struct XSalsa20 {
+    input: [u32; 16],
+    input_lanes: [U32x4; 16],
+}
+
+pub(crate) struct FirstBlock {
+    block: [u8; 64],
+}
+
+impl FirstBlock {
+    pub(crate) fn poly1305_key(&self, mac_key: &mut Poly1305Key) {
+        mac_key.copy_from_slice(&self.block[..32]);
+    }
+}
+
+impl XSalsa20 {
+    pub(crate) fn new(nonce: &Nonce, key: &Key) -> Self {
+        let mut hsalsa20_input = [0u8; 16];
+        hsalsa20_input.copy_from_slice(&nonce[..16]);
+
+        let mut subkey = [0u8; 32];
+        crypto_core_hsalsa20(&mut subkey, &hsalsa20_input, key, None);
+
+        let input = [
+            SIGMA[0],
+            load_u32_le(&subkey[0..4]),
+            load_u32_le(&subkey[4..8]),
+            load_u32_le(&subkey[8..12]),
+            load_u32_le(&subkey[12..16]),
+            SIGMA[1],
+            load_u32_le(&nonce[16..20]),
+            load_u32_le(&nonce[20..24]),
+            0,
+            0,
+            SIGMA[2],
+            load_u32_le(&subkey[16..20]),
+            load_u32_le(&subkey[20..24]),
+            load_u32_le(&subkey[24..28]),
+            load_u32_le(&subkey[28..32]),
+            SIGMA[3],
+        ];
+
+        hsalsa20_input.zeroize();
+        subkey.zeroize();
+
+        let input_lanes = input_lanes(&input);
+
+        Self { input, input_lanes }
+    }
+
+    pub(crate) fn first_block(&self) -> FirstBlock {
+        FirstBlock {
+            block: salsa20_block(&self.input, 0),
+        }
+    }
+
+    pub(crate) fn xor_after_first_block(&self, data: &mut [u8], first_block: &FirstBlock) {
+        let first_xor_len = data.len().min(32);
+        for (byte, keystream) in data
+            .iter_mut()
+            .take(first_xor_len)
+            .zip(first_block.block[32..].iter())
+        {
+            *byte ^= keystream;
+        }
+
+        let mut remaining = &mut data[first_xor_len..];
+        let mut counter = 1u64;
+        while remaining.len() >= 256 {
+            let (chunk, rest) = remaining.split_at_mut(256);
+            salsa20_xor_4blocks(chunk, &self.input_lanes, counter);
+            counter = counter.wrapping_add(4);
+            remaining = rest;
+        }
+        while !remaining.is_empty() {
+            let mut block = salsa20_block(&self.input, counter);
+            let xor_len = remaining.len().min(64);
+            for (byte, keystream) in remaining.iter_mut().take(xor_len).zip(block.iter()) {
+                *byte ^= keystream;
+            }
+            block.zeroize();
+            counter = counter.wrapping_add(1);
+            remaining = &mut remaining[xor_len..];
+        }
+    }
+}
+
+impl Drop for XSalsa20 {
+    fn drop(&mut self) {
+        self.input.zeroize();
+        zeroize_lanes(&mut self.input_lanes);
+    }
+}
+
+impl Drop for FirstBlock {
+    fn drop(&mut self) {
+        self.block.zeroize();
+    }
+}
+
+fn zeroize_lanes(lanes: &mut [U32x4; 16]) {
+    for lane in lanes.iter_mut() {
+        // SAFETY: `lane` is a valid, aligned, unique pointer derived from
+        // `&mut lanes`. A volatile write is used so duplicated subkey material
+        // in the SIMD lane cache is cleared even if the value is not read again.
+        unsafe { ptr::write_volatile(lane, U32x4::splat(0)) };
+    }
+    compiler_fence(Ordering::SeqCst);
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use salsa20::cipher::{KeyIvInit, StreamCipher};
+    use salsa20::{Key as SalsaKey, XNonce, XSalsa20 as RustCryptoXSalsa20};
+
+    use super::*;
+    use crate::classic::crypto_secretbox::{
+        crypto_secretbox_detached, crypto_secretbox_open_detached,
+    };
+
+    fn rustcrypto_xsalsa20_poly1305_key_and_xor(
+        data: &mut [u8],
+        mac_key: &mut Poly1305Key,
+        nonce: &Nonce,
+        key: &Key,
+    ) {
+        let mut cipher = RustCryptoXSalsa20::new(&SalsaKey::from(*key), &XNonce::from(*nonce));
+        cipher.apply_keystream(mac_key);
+        cipher.apply_keystream(data);
+    }
+
+    fn simd_xsalsa20_poly1305_key_and_xor(
+        data: &mut [u8],
+        mac_key: &mut Poly1305Key,
+        nonce: &Nonce,
+        key: &Key,
+    ) {
+        let cipher = super::XSalsa20::new(nonce, key);
+        let first_block = cipher.first_block();
+        first_block.poly1305_key(mac_key);
+        cipher.xor_after_first_block(data, &first_block);
+    }
+
+    fn key_strategy() -> impl Strategy<Value = Key> {
+        any::<[u8; 32]>()
+    }
+
+    fn nonce_strategy() -> impl Strategy<Value = Nonce> {
+        any::<[u8; 24]>()
+    }
+
+    fn message_strategy() -> impl Strategy<Value = Vec<u8>> {
+        prop_oneof![
+            Just(0usize),
+            Just(1),
+            Just(31),
+            Just(32),
+            Just(33),
+            Just(63),
+            Just(64),
+            Just(65),
+            Just(255),
+            Just(256),
+            Just(257),
+            Just(511),
+            Just(512),
+            Just(513),
+            0usize..4096,
+        ]
+        .prop_flat_map(|len| prop::collection::vec(any::<u8>(), len))
+    }
+
+    proptest! {
+        #[test]
+        fn test_xsalsa20_simd_matches_rustcrypto_for_random_inputs(
+            key in key_strategy(),
+            nonce in nonce_strategy(),
+            message in message_strategy(),
+        ) {
+            let mut simd_data = message.clone();
+            let mut rustcrypto_data = message;
+            let mut simd_mac_key = Poly1305Key::new();
+            let mut rustcrypto_mac_key = Poly1305Key::new();
+
+            simd_xsalsa20_poly1305_key_and_xor(&mut simd_data, &mut simd_mac_key, &nonce, &key);
+            rustcrypto_xsalsa20_poly1305_key_and_xor(
+                &mut rustcrypto_data,
+                &mut rustcrypto_mac_key,
+                &nonce,
+                &key,
+            );
+
+            prop_assert_eq!(simd_mac_key, rustcrypto_mac_key);
+            prop_assert_eq!(simd_data, rustcrypto_data);
+        }
+
+        #[test]
+        fn test_secretbox_simd_matches_rustcrypto_for_random_inputs(
+            key in key_strategy(),
+            nonce in nonce_strategy(),
+            message in message_strategy(),
+        ) {
+            let mut simd_ciphertext = message.clone();
+            let mut simd_mac = [0u8; 16];
+            crypto_secretbox_detached(&mut simd_ciphertext, &mut simd_mac, &message, &nonce, &key);
+
+            let mut rustcrypto_ciphertext = message.clone();
+            let mut rustcrypto_mac_key = Poly1305Key::new();
+            rustcrypto_xsalsa20_poly1305_key_and_xor(
+                &mut rustcrypto_ciphertext,
+                &mut rustcrypto_mac_key,
+                &nonce,
+                &key,
+            );
+            let mut poly1305 = crate::poly1305::Poly1305::new(&rustcrypto_mac_key);
+            poly1305.update(&rustcrypto_ciphertext);
+            let rustcrypto_mac = poly1305.finalize_to_array();
+
+            prop_assert_eq!(simd_mac, rustcrypto_mac);
+            prop_assert_eq!(&simd_ciphertext, &rustcrypto_ciphertext);
+
+            let mut decrypted = vec![0u8; rustcrypto_ciphertext.len()];
+            crypto_secretbox_open_detached(&mut decrypted, &simd_mac, &rustcrypto_ciphertext, &nonce, &key)
+                .expect("valid generated secretbox should decrypt");
+            prop_assert_eq!(decrypted, message);
+        }
+    }
+}

--- a/src/classic/salsa20_simd.rs
+++ b/src/classic/salsa20_simd.rs
@@ -1,6 +1,6 @@
+use std::ops::BitXorAssign;
 use std::ptr;
 use std::simd::{Simd, simd_swizzle};
-use std::sync::atomic::{Ordering, compiler_fence};
 
 use zeroize::Zeroize;
 
@@ -13,51 +13,64 @@ type U32x4 = Simd<u32, 4>;
 
 const SIGMA: [u32; 4] = [0x61707865, 0x3320646e, 0x79622d32, 0x6b206574];
 
+trait SalsaWord: BitXorAssign + Copy {
+    fn rotl_sum(y0: Self, y1: Self, rot: u32) -> Self;
+}
+
+impl SalsaWord for u32 {
+    #[inline]
+    fn rotl_sum(y0: Self, y1: Self, rot: u32) -> Self {
+        y0.wrapping_add(y1).rotate_left(rot)
+    }
+}
+
+impl SalsaWord for U32x4 {
+    #[inline]
+    fn rotl_sum(y0: Self, y1: Self, rot: u32) -> Self {
+        rotl32(y0 + y1, rot)
+    }
+}
+
 #[inline]
 fn rotl32(x: U32x4, n: u32) -> U32x4 {
     (x << U32x4::splat(n)) | (x >> U32x4::splat(32 - n))
 }
 
 #[inline]
-fn rotl_sum(y0: U32x4, y1: U32x4, rot: u32) -> U32x4 {
-    rotl32(y0 + y1, rot)
-}
-
-#[inline]
-fn salsa20_rounds(x: &mut [U32x4; 16]) {
+fn salsa20_rounds<T: SalsaWord>(x: &mut [T; 16]) {
     for _ in (0..20).step_by(2) {
-        x[4] ^= rotl_sum(x[0], x[12], 7);
-        x[8] ^= rotl_sum(x[4], x[0], 9);
-        x[12] ^= rotl_sum(x[8], x[4], 13);
-        x[0] ^= rotl_sum(x[12], x[8], 18);
-        x[9] ^= rotl_sum(x[5], x[1], 7);
-        x[13] ^= rotl_sum(x[9], x[5], 9);
-        x[1] ^= rotl_sum(x[13], x[9], 13);
-        x[5] ^= rotl_sum(x[1], x[13], 18);
-        x[14] ^= rotl_sum(x[10], x[6], 7);
-        x[2] ^= rotl_sum(x[14], x[10], 9);
-        x[6] ^= rotl_sum(x[2], x[14], 13);
-        x[10] ^= rotl_sum(x[6], x[2], 18);
-        x[3] ^= rotl_sum(x[15], x[11], 7);
-        x[7] ^= rotl_sum(x[3], x[15], 9);
-        x[11] ^= rotl_sum(x[7], x[3], 13);
-        x[15] ^= rotl_sum(x[11], x[7], 18);
-        x[1] ^= rotl_sum(x[0], x[3], 7);
-        x[2] ^= rotl_sum(x[1], x[0], 9);
-        x[3] ^= rotl_sum(x[2], x[1], 13);
-        x[0] ^= rotl_sum(x[3], x[2], 18);
-        x[6] ^= rotl_sum(x[5], x[4], 7);
-        x[7] ^= rotl_sum(x[6], x[5], 9);
-        x[4] ^= rotl_sum(x[7], x[6], 13);
-        x[5] ^= rotl_sum(x[4], x[7], 18);
-        x[11] ^= rotl_sum(x[10], x[9], 7);
-        x[8] ^= rotl_sum(x[11], x[10], 9);
-        x[9] ^= rotl_sum(x[8], x[11], 13);
-        x[10] ^= rotl_sum(x[9], x[8], 18);
-        x[12] ^= rotl_sum(x[15], x[14], 7);
-        x[13] ^= rotl_sum(x[12], x[15], 9);
-        x[14] ^= rotl_sum(x[13], x[12], 13);
-        x[15] ^= rotl_sum(x[14], x[13], 18);
+        x[4] ^= T::rotl_sum(x[0], x[12], 7);
+        x[8] ^= T::rotl_sum(x[4], x[0], 9);
+        x[12] ^= T::rotl_sum(x[8], x[4], 13);
+        x[0] ^= T::rotl_sum(x[12], x[8], 18);
+        x[9] ^= T::rotl_sum(x[5], x[1], 7);
+        x[13] ^= T::rotl_sum(x[9], x[5], 9);
+        x[1] ^= T::rotl_sum(x[13], x[9], 13);
+        x[5] ^= T::rotl_sum(x[1], x[13], 18);
+        x[14] ^= T::rotl_sum(x[10], x[6], 7);
+        x[2] ^= T::rotl_sum(x[14], x[10], 9);
+        x[6] ^= T::rotl_sum(x[2], x[14], 13);
+        x[10] ^= T::rotl_sum(x[6], x[2], 18);
+        x[3] ^= T::rotl_sum(x[15], x[11], 7);
+        x[7] ^= T::rotl_sum(x[3], x[15], 9);
+        x[11] ^= T::rotl_sum(x[7], x[3], 13);
+        x[15] ^= T::rotl_sum(x[11], x[7], 18);
+        x[1] ^= T::rotl_sum(x[0], x[3], 7);
+        x[2] ^= T::rotl_sum(x[1], x[0], 9);
+        x[3] ^= T::rotl_sum(x[2], x[1], 13);
+        x[0] ^= T::rotl_sum(x[3], x[2], 18);
+        x[6] ^= T::rotl_sum(x[5], x[4], 7);
+        x[7] ^= T::rotl_sum(x[6], x[5], 9);
+        x[4] ^= T::rotl_sum(x[7], x[6], 13);
+        x[5] ^= T::rotl_sum(x[4], x[7], 18);
+        x[11] ^= T::rotl_sum(x[10], x[9], 7);
+        x[8] ^= T::rotl_sum(x[11], x[10], 9);
+        x[9] ^= T::rotl_sum(x[8], x[11], 13);
+        x[10] ^= T::rotl_sum(x[9], x[8], 18);
+        x[12] ^= T::rotl_sum(x[15], x[14], 7);
+        x[13] ^= T::rotl_sum(x[12], x[15], 9);
+        x[14] ^= T::rotl_sum(x[13], x[12], 13);
+        x[15] ^= T::rotl_sum(x[14], x[13], 18);
     }
 }
 
@@ -67,40 +80,7 @@ fn salsa20_block(input: &[u32; 16], counter: u64) -> [u8; 64] {
     state[9] = (counter >> 32) as u32;
     let orig = state;
 
-    for _ in (0..20).step_by(2) {
-        state[4] ^= state[0].wrapping_add(state[12]).rotate_left(7);
-        state[8] ^= state[4].wrapping_add(state[0]).rotate_left(9);
-        state[12] ^= state[8].wrapping_add(state[4]).rotate_left(13);
-        state[0] ^= state[12].wrapping_add(state[8]).rotate_left(18);
-        state[9] ^= state[5].wrapping_add(state[1]).rotate_left(7);
-        state[13] ^= state[9].wrapping_add(state[5]).rotate_left(9);
-        state[1] ^= state[13].wrapping_add(state[9]).rotate_left(13);
-        state[5] ^= state[1].wrapping_add(state[13]).rotate_left(18);
-        state[14] ^= state[10].wrapping_add(state[6]).rotate_left(7);
-        state[2] ^= state[14].wrapping_add(state[10]).rotate_left(9);
-        state[6] ^= state[2].wrapping_add(state[14]).rotate_left(13);
-        state[10] ^= state[6].wrapping_add(state[2]).rotate_left(18);
-        state[3] ^= state[15].wrapping_add(state[11]).rotate_left(7);
-        state[7] ^= state[3].wrapping_add(state[15]).rotate_left(9);
-        state[11] ^= state[7].wrapping_add(state[3]).rotate_left(13);
-        state[15] ^= state[11].wrapping_add(state[7]).rotate_left(18);
-        state[1] ^= state[0].wrapping_add(state[3]).rotate_left(7);
-        state[2] ^= state[1].wrapping_add(state[0]).rotate_left(9);
-        state[3] ^= state[2].wrapping_add(state[1]).rotate_left(13);
-        state[0] ^= state[3].wrapping_add(state[2]).rotate_left(18);
-        state[6] ^= state[5].wrapping_add(state[4]).rotate_left(7);
-        state[7] ^= state[6].wrapping_add(state[5]).rotate_left(9);
-        state[4] ^= state[7].wrapping_add(state[6]).rotate_left(13);
-        state[5] ^= state[4].wrapping_add(state[7]).rotate_left(18);
-        state[11] ^= state[10].wrapping_add(state[9]).rotate_left(7);
-        state[8] ^= state[11].wrapping_add(state[10]).rotate_left(9);
-        state[9] ^= state[8].wrapping_add(state[11]).rotate_left(13);
-        state[10] ^= state[9].wrapping_add(state[8]).rotate_left(18);
-        state[12] ^= state[15].wrapping_add(state[14]).rotate_left(7);
-        state[13] ^= state[12].wrapping_add(state[15]).rotate_left(9);
-        state[14] ^= state[13].wrapping_add(state[12]).rotate_left(13);
-        state[15] ^= state[14].wrapping_add(state[13]).rotate_left(18);
-    }
+    salsa20_rounds(&mut state);
 
     let mut output = [0u8; 64];
     for (i, word) in state.iter_mut().enumerate() {
@@ -112,12 +92,19 @@ fn salsa20_block(input: &[u32; 16], counter: u64) -> [u8; 64] {
 }
 
 #[inline]
+fn checked_counter_add(counter: u64, blocks: u64) -> u64 {
+    counter
+        .checked_add(blocks)
+        .expect("XSalsa20 block counter overflow")
+}
+
+#[inline]
 fn counter_lanes(counter: u64) -> (U32x4, U32x4) {
     let counters = [
         counter,
-        counter.wrapping_add(1),
-        counter.wrapping_add(2),
-        counter.wrapping_add(3),
+        checked_counter_add(counter, 1),
+        checked_counter_add(counter, 2),
+        checked_counter_add(counter, 3),
     ];
     (
         U32x4::from([
@@ -143,6 +130,23 @@ fn input_lanes(input: &[u32; 16]) -> [U32x4; 16] {
     lanes
 }
 
+#[cfg(target_endian = "little")]
+#[inline]
+fn xor_4words(data: &mut [u8], offset: usize, words: U32x4) {
+    debug_assert!(offset + 16 <= data.len());
+
+    // SAFETY: `offset..offset + 16` is in bounds for all call sites in the
+    // 256-byte four-block loop. The unaligned read/write operate on initialized
+    // bytes, `u32` has no invalid bit patterns, and native word order is the
+    // required little-endian Salsa20 order on this cfg path.
+    unsafe {
+        let data_ptr = data.as_mut_ptr().add(offset).cast::<[u32; 4]>();
+        let data_words = U32x4::from(ptr::read_unaligned(data_ptr));
+        ptr::write_unaligned(data_ptr, (data_words ^ words).to_array());
+    }
+}
+
+#[cfg(not(target_endian = "little"))]
 #[inline]
 fn xor_4words(data: &mut [u8], offset: usize, words: U32x4) {
     let data_words = U32x4::from([
@@ -286,7 +290,7 @@ impl XSalsa20 {
         while remaining.len() >= 256 {
             let (chunk, rest) = remaining.split_at_mut(256);
             salsa20_xor_4blocks(chunk, &self.input_lanes, counter);
-            counter = counter.wrapping_add(4);
+            counter = checked_counter_add(counter, 4);
             remaining = rest;
         }
         while !remaining.is_empty() {
@@ -296,7 +300,7 @@ impl XSalsa20 {
                 *byte ^= keystream;
             }
             block.zeroize();
-            counter = counter.wrapping_add(1);
+            counter = checked_counter_add(counter, 1);
             remaining = &mut remaining[xor_len..];
         }
     }
@@ -322,7 +326,6 @@ fn zeroize_lanes(lanes: &mut [U32x4; 16]) {
         // in the SIMD lane cache is cleared even if the value is not read again.
         unsafe { ptr::write_volatile(lane, U32x4::splat(0)) };
     }
-    compiler_fence(Ordering::SeqCst);
 }
 
 #[cfg(test)]
@@ -389,6 +392,8 @@ mod tests {
     }
 
     proptest! {
+        #![proptest_config(ProptestConfig::with_cases(96))]
+
         #[test]
         fn test_xsalsa20_simd_matches_rustcrypto_for_random_inputs(
             key in key_strategy(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! own crypto", as it often results in avoidable mistakes. In the context of
 //! cryptography, mistakes can be very costly.
 //!
-//! The minimum supported Rust version (MSRV) for this crate is **Rust 1.51** or
+//! The minimum supported Rust version (MSRV) for this crate is **Rust 1.89** or
 //! newer.
 //!
 //! ## Features
@@ -36,24 +36,34 @@
 //! * [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html)
 //!   implementation for Blake2b (used by generic hashing, password hashing, and
 //!   key derivation) on nightly, with `features = ["simd_backend", "nightly"]`
-//! * SIMD backend for Curve25519 (used by public/private key functions) on
-//!   nightly with `features = ["simd_backend", "nightly"]`
+//! * [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html)
+//!   implementation for Salsa20 (used by XSalsa20-Poly1305 secretbox) on
+//!   nightly, with `features = ["simd_backend", "nightly"]`
+//! * [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek)
+//!   (used by public/private key functions) selects its own serial or x86_64
+//!   vector backend at build time
 //! * [SHA2](https://github.com/RustCrypto/hashes/tree/master/sha2) (used by
 //!   sealed boxes) includes SIMD implementation for AVX2
 //! * [ChaCha20](https://github.com/RustCrypto/stream-ciphers/tree/master/chacha20)
 //!   (used by streaming interface) includes SIMD implementations for Neon,
 //!   AVX2, and SSE2
 //!
-//! To enable all the SIMD backends through 3rd party crates, you'll need to
-//! also set `RUSTFLAGS`:
+//! The `simd_backend` and `nightly` features enable dryoc's portable SIMD
+//! backends. CPU-specific dependency backends and local benchmarking may also
+//! benefit from target-specific `RUSTFLAGS`:
 //! * For AVX2 set `RUSTFLAGS=-Ctarget-cpu=haswell -Ctarget-feature=+avx2`
 //! * For SSE2 set `RUSTFLAGS=-Ctarget-feature=+sse2`
 //! * For Neon set `RUSTFLAGS=-Ctarget-feature=+neon`
+//! * For local Apple silicon benchmarks, use `RUSTFLAGS=-Ctarget-cpu=native
+//!   -Ctarget-feature=+neon`
+//!
+//! The Curve25519 backend is selected by `curve25519-dalek`, not by dryoc's
+//! `simd_backend` feature.
 //!
 //! _Note that eventually this project will converge on portable SIMD
 //! implementations for all the core algos which will work across all platforms
 //! supported by LLVM, rather than relying on hand-coded assembly or intrinsics,
-//! but his is a work in progress_.
+//! but this is a work in progress_.
 //!
 //! ## APIs
 //!
@@ -120,11 +130,11 @@
 //!
 //! [^2]: The protected memory features described in the [protected] mod require
 //! custom memory allocation, system calls, and pointer arithmetic, which are
-//! unsafe in Rust. Some of the 3rd party libraries used by this crate, such as
-//! those with SIMD, may contain unsafe code. In particular, most SIMD
-//! implementations are considered "unsafe" due to their use of assembly or
-//! intrinsics, however without SIMD-based cryptography you may be exposed to
-//! timing attacks.
+//! unsafe in Rust. Some optional SIMD code, including dependency-provided SIMD
+//! implementations and small internal helpers, may contain unsafe code. In
+//! particular, many SIMD implementations are considered "unsafe" due to their
+//! use of assembly or intrinsics, however without SIMD-based cryptography you
+//! may be exposed to timing attacks.
 //!
 //! [^3]: The Rustaceous API is designed to protect users of this library from
 //! making mistakes, however the Classic API allows one to do as one pleases.
@@ -167,6 +177,8 @@ pub mod classic {
     mod crypto_box_impl;
     mod crypto_secretbox_impl;
     mod generichash_blake2b;
+    #[cfg(all(feature = "simd_backend", feature = "nightly"))]
+    mod salsa20_simd;
 
     pub mod crypto_auth;
     pub mod crypto_box;


### PR DESCRIPTION
## Summary

Adds a nightly-gated portable SIMD Salsa20/XSalsa20 backend for `crypto_secretbox`, plus side-by-side tests, benches, and benchmark documentation for the software and SIMD paths.

## User Impact

Users who enable `features = ["simd_backend", "nightly"]` get the new Salsa20 SIMD path for XSalsa20-Poly1305 secretbox while the default stable software path remains unchanged. On the MacBook M3 Max benchmark host, the SIMD path is roughly even for 64-byte messages and 1.08x to 1.21x faster for 1 KiB through 1 MiB messages.

## Root Cause

Secretbox previously always used the RustCrypto XSalsa20 stream implementation, so dryoc had no internal portable SIMD path to compare or benchmark for XSalsa20-Poly1305.

## Fix

Introduces `src/classic/salsa20_simd.rs`, routes secretbox through a backend wrapper selected by `simd_backend,nightly`, zeroizes cached SIMD state, and adds property tests that compare the SIMD path against RustCrypto with random keys, nonces, and messages. The branch also adds `crypto_secretbox_detached` benches, documents benchmark commands and results in `BENCHMARKS.md`, and updates README/rustdoc feature wording for Salsa20, BLAKE2b, Curve25519, and target CPU flags.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly test --features simd_backend,nightly salsa20_simd`
- `cargo +nightly test --features simd_backend,nightly crypto_secretbox`
- `cargo +nightly clippy --features simd_backend,nightly,serde,base64 -- -D warnings`
- `cargo +nightly doc --no-deps --features simd_backend,nightly,serde,base64`
- Benchmarks refreshed on MacBook M3 Max (`aarch64-apple-darwin`) with `RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon"`; results are recorded in `BENCHMARKS.md`.
