### PR TITLE
test: add fuzz targets for parsing boundaries

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,6 +15,9 @@ libfuzzer-sys = "0.4"
 [dependencies.dryoc]
 path = ".."
 
+[features]
+base64 = ["dryoc/base64"]
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
@@ -22,5 +25,23 @@ members = ["."]
 [[bin]]
 name = "fuzz_target_1"
 path = "fuzz_targets/fuzz_target_1.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_secretstream_pull"
+path = "fuzz_targets/fuzz_secretstream_pull.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_pwhash_str"
+path = "fuzz_targets/fuzz_pwhash_str.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_from_bytes"
+path = "fuzz_targets/fuzz_from_bytes.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/fuzz_from_bytes.rs
+++ b/fuzz/fuzz_targets/fuzz_from_bytes.rs
@@ -1,0 +1,39 @@
+#![no_main]
+use dryoc::dryocbox::{DryocBox, VecBox as VecDryocBox};
+use dryoc::dryocsecretbox::{DryocSecretBox, VecBox as VecSecretBox};
+use dryoc::sign::{SignedMessage, VecSignedMessage};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = VecDryocBox::from_bytes(data);
+    let _ = VecDryocBox::from_sealed_bytes(data);
+    let _ = VecSecretBox::from_bytes(data);
+    let _ = VecSignedMessage::from_bytes(data);
+
+    if let Ok(dryocbox) = VecDryocBox::from_bytes(data) {
+        let bytes = dryocbox.to_vec();
+        let reparsed: VecDryocBox = DryocBox::from_bytes(&bytes).expect("box round trip");
+        assert_eq!(bytes, reparsed.to_vec());
+    }
+
+    if let Ok(dryocbox) = VecDryocBox::from_sealed_bytes(data) {
+        let bytes = dryocbox.to_vec();
+        let reparsed: VecDryocBox =
+            DryocBox::from_sealed_bytes(&bytes).expect("sealed box round trip");
+        assert_eq!(bytes, reparsed.to_vec());
+    }
+
+    if let Ok(secretbox) = VecSecretBox::from_bytes(data) {
+        let bytes = secretbox.to_vec();
+        let reparsed: VecSecretBox =
+            DryocSecretBox::from_bytes(&bytes).expect("secretbox round trip");
+        assert_eq!(bytes, reparsed.to_vec());
+    }
+
+    if let Ok(signed_message) = VecSignedMessage::from_bytes(data) {
+        let bytes = signed_message.to_vec();
+        let reparsed: VecSignedMessage =
+            SignedMessage::from_bytes(&bytes).expect("signed message round trip");
+        assert_eq!(bytes, reparsed.to_vec());
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_pwhash_str.rs
+++ b/fuzz/fuzz_targets/fuzz_pwhash_str.rs
@@ -1,0 +1,24 @@
+#![no_main]
+#[cfg(feature = "base64")]
+use dryoc::classic::crypto_pwhash::crypto_pwhash_str_needs_rehash;
+#[cfg(feature = "base64")]
+use dryoc::constants::{CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE, CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE};
+#[cfg(feature = "base64")]
+use dryoc::pwhash::PwHash;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    #[cfg(feature = "base64")]
+    {
+        let hashed_password = String::from_utf8_lossy(data);
+        let _ = crypto_pwhash_str_needs_rehash(
+            &hashed_password,
+            CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE,
+            CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE,
+        );
+        let _ = PwHash::<Vec<u8>, Vec<u8>>::from_string(&hashed_password);
+    }
+
+    #[cfg(not(feature = "base64"))]
+    let _ = data;
+});

--- a/fuzz/fuzz_targets/fuzz_secretstream_pull.rs
+++ b/fuzz/fuzz_targets/fuzz_secretstream_pull.rs
@@ -1,0 +1,59 @@
+#![no_main]
+use dryoc::classic::crypto_secretstream_xchacha20poly1305::{
+    State, crypto_secretstream_xchacha20poly1305_init_pull,
+    crypto_secretstream_xchacha20poly1305_pull,
+};
+use dryoc::constants::{
+    CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES,
+    CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_HEADERBYTES,
+    CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_KEYBYTES,
+};
+use dryoc::dryocstream::{DryocStream, Header, Key, Pull};
+use dryoc::types::ByteArray;
+use libfuzzer_sys::fuzz_target;
+
+fn fill<const N: usize>(data: &mut &[u8]) -> [u8; N] {
+    let mut out = [0u8; N];
+    let n = out.len().min(data.len());
+    out[..n].copy_from_slice(&data[..n]);
+    *data = &data[n..];
+    out
+}
+
+fuzz_target!(|data: &[u8]| {
+    let mut data = data;
+    let key = Key::from(fill::<CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_KEYBYTES>(
+        &mut data,
+    ));
+    let header = Header::from(fill::<CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_HEADERBYTES>(
+        &mut data,
+    ));
+    let aad_len = match data.split_first() {
+        Some((aad_len, rest)) => {
+            data = rest;
+            (*aad_len as usize).min(data.len())
+        }
+        None => 0,
+    };
+    let aad = data[..aad_len].to_vec();
+    let ciphertext = data[aad_len..].to_vec();
+    let aad = if aad.is_empty() { None } else { Some(&aad) };
+
+    let mut stream: DryocStream<Pull> = DryocStream::init_pull(&key, &header);
+    let _ = stream.pull_to_vec(&ciphertext, aad);
+
+    let mut state = State::new();
+    crypto_secretstream_xchacha20poly1305_init_pull(&mut state, header.as_array(), key.as_array());
+    let output_len = ciphertext
+        .len()
+        .saturating_sub(CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES);
+    let mut output = vec![0u8; output_len];
+    let mut tag = 0u8;
+    let _ = crypto_secretstream_xchacha20poly1305_pull(
+        &mut state,
+        &mut output,
+        &mut tag,
+        &ciphertext,
+        aad.map(|aad| aad.as_slice()),
+    );
+});

--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -370,6 +370,14 @@ pub fn crypto_secretstream_xchacha20poly1305_pull(
 
     let _pad0 = [0u8; 16];
 
+    if ciphertext.len() < CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES {
+        return Err(dryoc_error!(format!(
+            "Ciphertext length was {}, should be at least {}",
+            ciphertext.len(),
+            CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES
+        )));
+    }
+
     if message.len() < ciphertext.len() - CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES {
         return Err(dryoc_error!(format!(
             "Message length was {}, should be at least {}",

--- a/src/dryocstream.rs
+++ b/src/dryocstream.rs
@@ -313,6 +313,14 @@ impl DryocStream<Pull> {
         associated_data: Option<&Input>,
     ) -> Result<(Output, Tag), Error> {
         use crate::constants::CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES;
+        if ciphertext.as_slice().len() < CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES {
+            return Err(dryoc_error!(format!(
+                "Ciphertext length was {}, should be at least {}",
+                ciphertext.as_slice().len(),
+                CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES
+            )));
+        }
+
         let mut message = Output::default();
         message.resize(
             ciphertext.as_slice().len() - CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES,


### PR DESCRIPTION
## Summary

Adds focused fuzz coverage for high-risk parsing and decryption boundaries: secretstream pull paths, password-hash string parsing, and Rustaceous `from_bytes` constructors. The fuzz crate now exposes a `base64` feature so the password-hash parser target can exercise the feature-gated APIs.

## User Impact

Malformed or attacker-controlled inputs at these boundaries are more likely to be caught during fuzzing before release. Short secretstream ciphertexts now return a normal error instead of reaching length arithmetic that could underflow.

## Root Cause

The existing fuzz coverage only exercised generic hashing, leaving stateful decryptors and parser-style APIs without fuzz harnesses. The secretstream pull paths also computed plaintext lengths by subtracting authentication overhead before rejecting undersized ciphertexts.

## Fix

Adds `fuzz_secretstream_pull`, `fuzz_pwhash_str`, and `fuzz_from_bytes` targets. The secretstream target covers both Rustaceous and Classic pull APIs. The `from_bytes` target checks constructor acceptance and byte round trips. The password-hash target covers parser-style public APIs under `base64`. Both secretstream pull implementations now explicitly reject ciphertext shorter than `CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES`.

## Validation

- `cargo check`
- `cargo test secretstream`
- `cargo +nightly fuzz check fuzz_secretstream_pull`
- `cargo +nightly fuzz check fuzz_from_bytes`
- `cargo +nightly fuzz check fuzz_pwhash_str --features base64`
- `cargo +nightly fuzz run fuzz_secretstream_pull -- -runs=1000`
- `cargo +nightly fuzz run fuzz_from_bytes -- -runs=1000`
- `cargo +nightly fuzz run fuzz_pwhash_str --features base64 -- -runs=1000`
