### PR TITLE
feat: add generate aliases for random generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ For example usage, refer to the
 dryoc uses the Rust 2024 edition and requires Rust 1.89 or newer, as declared
 by `rust-version` in `Cargo.toml`.
 
-Rust 2024 reserves `gen` as a keyword. Existing generation APIs are still
-available, but Rust 2024 callers should use raw identifier syntax such as
-`Key::r#gen()`.
+Rust 2024 reserves `gen` as a keyword. Prefer generation APIs such as
+`Key::generate()`. Existing `gen` APIs remain available through raw identifier
+syntax, such as `Key::r#gen()`, for compatibility and will be deprecated in a
+future release.
 
 To enable all the SIMD backends through 3rd party crates, you'll need to also
 set `RUSTFLAGS`:

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -16,7 +16,7 @@
 //! use dryoc::types::*;
 //!
 //! // Generate a random key
-//! let key = Key::r#gen();
+//! let key = Key::generate();
 //!
 //! // Compute the mac in one shot. Here we clone the key for the purpose of this
 //! // example, but normally you would not do this as you never want to re-use a
@@ -34,7 +34,7 @@
 //! use dryoc::types::*;
 //!
 //! // Generate a random key
-//! let key = Key::r#gen();
+//! let key = Key::generate();
 //!
 //! // Initialize the MAC, clone the key (don't do this)
 //! let mut mac = Auth::new(key.clone());
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn test_single_part() {
-        let key = Key::r#gen();
+        let key = Key::generate();
         let mac = Auth::compute_to_vec(key.clone(), b"Data to authenticate");
 
         Auth::compute_and_verify(&mac, key, b"Data to authenticate").expect("verify failed");
@@ -216,7 +216,7 @@ mod tests {
 
     #[test]
     fn test_multi_part() {
-        let key = Key::r#gen();
+        let key = Key::generate();
 
         let mut mac = Auth::new(key.clone());
         mac.update(b"Multi-part");

--- a/src/classic/crypto_auth.rs
+++ b/src/classic/crypto_auth.rs
@@ -144,7 +144,7 @@ pub struct AuthState {
 ///
 /// Equivalent to libsodium's `crypto_auth_keygen`.
 pub fn crypto_auth_keygen() -> Key {
-    Key::r#gen()
+    Key::generate()
 }
 
 /// Initialize the incremental interface for HMAC-SHA512-256 secret-key.

--- a/src/classic/crypto_box.rs
+++ b/src/classic/crypto_box.rs
@@ -18,7 +18,7 @@
 //! let (recipient_pk, recipient_sk) = crypto_box_keypair();
 //!
 //! // Generate a random nonce
-//! let nonce = Nonce::r#gen();
+//! let nonce = Nonce::generate();
 //!
 //! let message = "hello".as_bytes();
 //! // Encrypt message
@@ -478,7 +478,7 @@ mod tests {
 
             let (sender_pk, sender_sk) = crypto_box_keypair();
             let (recipient_pk, recipient_sk) = crypto_box_keypair();
-            let nonce = Nonce::r#gen();
+            let nonce = Nonce::generate();
             let words = vec!["hello1".to_string(); i];
             let message = words.join(" :D ");
             let mut ciphertext = vec![0u8; message.len() + CRYPTO_BOX_MACBYTES];
@@ -535,7 +535,7 @@ mod tests {
 
             let (sender_pk, sender_sk) = crypto_box_keypair();
             let (recipient_pk, recipient_sk) = crypto_box_keypair();
-            let nonce = Nonce::r#gen();
+            let nonce = Nonce::generate();
             let words = vec!["hello1".to_string(); i];
             let message: Vec<u8> = words.join(" :D ").as_bytes().to_vec();
             let message_copy = message.clone();
@@ -585,7 +585,7 @@ mod tests {
         for _ in 0..20 {
             let (sender_pk, _sender_sk) = crypto_box_keypair();
             let (_recipient_pk, recipient_sk) = crypto_box_keypair();
-            let nonce = Nonce::r#gen();
+            let nonce = Nonce::generate();
 
             let mut ciphertext: Vec<u8> = vec![];
             let message: Vec<u8> = vec![];
@@ -602,7 +602,7 @@ mod tests {
 
             let (sender_pk, _sender_sk) = crypto_box_keypair();
             let (_recipient_pk, recipient_sk) = crypto_box_keypair();
-            let nonce = Nonce::r#gen();
+            let nonce = Nonce::generate();
 
             let mut ciphertext: Vec<u8> = vec![];
 

--- a/src/classic/crypto_kx.rs
+++ b/src/classic/crypto_kx.rs
@@ -75,7 +75,7 @@ pub fn crypto_kx_seed_keypair(
 ///
 /// Equivalent to libsodium's `crypto_kx_keypair`.
 pub fn crypto_kx_keypair() -> (PublicKey, SecretKey) {
-    let sk = SecretKey::r#gen();
+    let sk = SecretKey::generate();
     let mut pk = PublicKey::default();
 
     crypto_scalarmult_base(&mut pk, &sk);

--- a/src/classic/crypto_onetimeauth.rs
+++ b/src/classic/crypto_onetimeauth.rs
@@ -127,7 +127,7 @@ pub struct OnetimeauthState {
 ///
 /// Equivalent to libsodium's `crypto_onetimeauth_keygen`.
 pub fn crypto_onetimeauth_keygen() -> Key {
-    Key::r#gen()
+    Key::generate()
 }
 
 /// Initializes the incremental Poly1305-based one-time authentication.

--- a/src/classic/crypto_secretbox.rs
+++ b/src/classic/crypto_secretbox.rs
@@ -15,7 +15,7 @@
 //! use dryoc::types::*;
 //!
 //! let key: Key = crypto_secretbox_keygen();
-//! let nonce = Nonce::r#gen();
+//! let nonce = Nonce::generate();
 //!
 //! let message = "I Love Doge!";
 //!
@@ -54,7 +54,7 @@ pub fn crypto_secretbox_keygen_inplace(key: &mut Key) {
 /// Generates a random key using
 /// [`copy_randombytes`].
 pub fn crypto_secretbox_keygen() -> Key {
-    Key::r#gen()
+    Key::generate()
 }
 
 /// Detached version of [`crypto_secretbox_easy`].
@@ -185,7 +185,7 @@ mod tests {
             use sodiumoxide::crypto::secretbox::{Key as SOKey, Nonce as SONonce};
 
             let key: Key = crypto_secretbox_keygen();
-            let nonce = Nonce::r#gen();
+            let nonce = Nonce::generate();
 
             let words = vec!["love Doge".to_string(); i];
             let message = words.join(" <3 ");
@@ -227,7 +227,7 @@ mod tests {
             use sodiumoxide::crypto::secretbox::{Key as SOKey, Nonce as SONonce};
 
             let key = crypto_secretbox_keygen();
-            let nonce = Nonce::r#gen();
+            let nonce = Nonce::generate();
 
             let words = vec!["love Doge".to_string(); i];
             let message: Vec<u8> = words.join(" <3 ").into();

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -30,11 +30,11 @@
 //! // Randomly generate sender/recipient keypairs. Under normal circumstances, the
 //! // sender would only know the recipient's public key, and the recipient would
 //! // only know the sender's public key.
-//! let sender_keypair = KeyPair::r#gen();
-//! let recipient_keypair = KeyPair::r#gen();
+//! let sender_keypair = KeyPair::generate();
+//! let recipient_keypair = KeyPair::generate();
 //!
 //! // Randomly generate a nonce
-//! let nonce = Nonce::r#gen();
+//! let nonce = Nonce::generate();
 //!
 //! let message = b"All that glitters is not gold";
 //!
@@ -71,7 +71,7 @@
 //! ```
 //! use dryoc::dryocbox::*;
 //!
-//! let recipient_keypair = KeyPair::r#gen();
+//! let recipient_keypair = KeyPair::generate();
 //! let message = b"Now is the winter of our discontent.";
 //!
 //! let dryocbox = DryocBox::seal_to_vecbox(message, &recipient_keypair.public_key.clone())
@@ -741,11 +741,11 @@ mod tests {
             use sodiumoxide::crypto::box_;
             use sodiumoxide::crypto::box_::{Nonce as SONonce, PublicKey, SecretKey};
 
-            let keypair_sender = KeyPair::r#gen();
-            let keypair_recipient = KeyPair::r#gen();
+            let keypair_sender = KeyPair::generate();
+            let keypair_recipient = KeyPair::generate();
             let keypair_sender_copy = keypair_sender.clone();
             let keypair_recipient_copy = keypair_recipient.clone();
-            let nonce = Nonce::r#gen();
+            let nonce = Nonce::generate();
             let words = vec!["hello1".to_string(); i];
             let message = words.join(" :D ");
             let message_copy = message.clone();
@@ -804,11 +804,11 @@ mod tests {
                 Nonce as SONonce, PublicKey as SOPublicKey, SecretKey as SOSecretKey,
             };
 
-            let keypair_sender = KeyPair::r#gen();
-            let keypair_recipient = KeyPair::r#gen();
+            let keypair_sender = KeyPair::generate();
+            let keypair_recipient = KeyPair::generate();
             let keypair_sender_copy = keypair_sender.clone();
             let keypair_recipient_copy = keypair_recipient.clone();
-            let nonce = Nonce::r#gen();
+            let nonce = Nonce::generate();
             let words = vec!["hello1".to_string(); i];
             let message = words.join(" :D ");
             let message_copy = message.clone();
@@ -834,7 +834,7 @@ mod tests {
                 general_purpose::STANDARD.encode(&so_ciphertext)
             );
 
-            let invalid_key = KeyPair::r#gen();
+            let invalid_key = KeyPair::generate();
             let invalid_key_copy_1 = invalid_key.clone();
             let invalid_key_copy_2 = invalid_key.clone();
 
@@ -860,10 +860,10 @@ mod tests {
         for _ in 0..20 {
             use crate::keypair::*;
 
-            let invalid_key = KeyPair::r#gen();
+            let invalid_key = KeyPair::generate();
             let invalid_key_copy_1 = invalid_key.clone();
             let invalid_key_copy_2 = invalid_key.clone();
-            let nonce = Nonce::r#gen();
+            let nonce = Nonce::generate();
 
             let dryocbox: VecBox =
                 DryocBox::from_bytes(b"trollolllololololollollolololololol").expect("ok");
@@ -912,7 +912,7 @@ mod tests {
             use sodiumoxide::crypto::box_::{PublicKey as SOPublicKey, SecretKey as SOSecretKey};
             use sodiumoxide::crypto::sealedbox::curve25519blake2bxsalsa20poly1305;
 
-            let keypair_recipient = KeyPair::r#gen();
+            let keypair_recipient = KeyPair::generate();
             let words = vec!["hello1".to_string(); i];
             let message = words.join(" :D ");
             let message_copy = message.clone();
@@ -941,7 +941,7 @@ mod tests {
             use sodiumoxide::crypto::box_::PublicKey as SOPublicKey;
             use sodiumoxide::crypto::sealedbox::curve25519blake2bxsalsa20poly1305;
 
-            let keypair_recipient = KeyPair::r#gen();
+            let keypair_recipient = KeyPair::generate();
             let words = vec!["hello1".to_string(); i];
             let message = words.join(" :D ");
 
@@ -961,9 +961,9 @@ mod tests {
 
     #[test]
     fn test_precalc_encrypt_decrypt() {
-        let keypair_sender = KeyPair::r#gen();
-        let keypair_recipient = KeyPair::r#gen();
-        let nonce = Nonce::r#gen();
+        let keypair_sender = KeyPair::generate();
+        let keypair_recipient = KeyPair::generate();
+        let nonce = Nonce::generate();
 
         let message = b"To be, or not to be, that is the question:";
         let precalc_secret_key = PrecalcSecretKey::precalculate(
@@ -983,9 +983,9 @@ mod tests {
 
     #[test]
     fn test_precalc_encrypt_to_vecbox_decrypt_to_vecbox() {
-        let keypair_sender = KeyPair::r#gen();
-        let keypair_recipient = KeyPair::r#gen();
-        let nonce = Nonce::r#gen();
+        let keypair_sender = KeyPair::generate();
+        let keypair_recipient = KeyPair::generate();
+        let nonce = Nonce::generate();
 
         let message = b"All the world's a stage, and all the men and women merely players:";
         let precalc_secret_key = PrecalcSecretKey::precalculate(
@@ -1005,9 +1005,9 @@ mod tests {
 
     #[test]
     fn test_precalc_encrypt_decrypt_with_different_messages() {
-        let keypair_sender = KeyPair::r#gen();
-        let keypair_recipient = KeyPair::r#gen();
-        let nonce = Nonce::r#gen();
+        let keypair_sender = KeyPair::generate();
+        let keypair_recipient = KeyPair::generate();
+        let nonce = Nonce::generate();
 
         let messages: Vec<&[u8]> = vec![
             b"Now is the winter of our discontent, made glorious summer by this sun of York;",
@@ -1035,9 +1035,9 @@ mod tests {
 
     #[test]
     fn test_precalc_encrypt_to_vecbox_decrypt_to_vecbox_with_different_messages() {
-        let keypair_sender = KeyPair::r#gen();
-        let keypair_recipient = KeyPair::r#gen();
-        let nonce = Nonce::r#gen();
+        let keypair_sender = KeyPair::generate();
+        let keypair_recipient = KeyPair::generate();
+        let nonce = Nonce::generate();
 
         let messages: Vec<&[u8]> = vec![
             b"Out, out brief candle! Life's but a walking shadow, a poor player that struts and frets his hour upon the stage and then is heard no more.",

--- a/src/dryocsecretbox.rs
+++ b/src/dryocsecretbox.rs
@@ -25,8 +25,8 @@
 //! use dryoc::dryocsecretbox::*;
 //!
 //! // Generate a random secret key and nonce
-//! let secret_key = Key::r#gen();
-//! let nonce = Nonce::r#gen();
+//! let secret_key = Key::generate();
+//! let nonce = Nonce::generate();
 //! let message = b"Why hello there, fren";
 //!
 //! // Encrypt `message`, into a Vec-based box
@@ -406,8 +406,8 @@ mod tests {
 
             use crate::dryocsecretbox::*;
 
-            let secret_key = Key::r#gen();
-            let nonce = Nonce::r#gen();
+            let secret_key = Key::generate();
+            let nonce = Nonce::generate();
             let words = vec!["hello1".to_string(); i];
             let message = words.join(" :D ").into_bytes();
             let message_copy = message.clone();
@@ -456,8 +456,8 @@ mod tests {
 
             use crate::dryocsecretbox::*;
 
-            let secret_key = Key::r#gen();
-            let nonce = Nonce::r#gen();
+            let secret_key = Key::generate();
+            let nonce = Nonce::generate();
             let words = vec!["hello1".to_string(); i];
             let message = words.join(" :D ").into_bytes();
             let message_copy = message.clone();

--- a/src/dryocstream.rs
+++ b/src/dryocstream.rs
@@ -27,7 +27,7 @@
 //! let message3 = b"three messages";
 //!
 //! // Generate a random secret key for this stream
-//! let key = Key::r#gen();
+//! let key = Key::generate();
 //!
 //! // Initialize the push side, type annotations required on return type
 //! let (mut push_stream, header): (_, Header) = DryocStream::init_push(&key);
@@ -356,7 +356,7 @@ mod tests {
         let message3 = b"three messages";
 
         // Generate a random secret key for this stream
-        let key = Key::r#gen();
+        let key = Key::generate();
 
         // Initialize the push side, type annotations required on return type
         let (mut push_stream, header): (_, Header) = DryocStream::init_push(&key);
@@ -402,7 +402,7 @@ mod tests {
         let message3 = b"three messages";
 
         // Generate a random secret key for this stream
-        let key = Key::r#gen();
+        let key = Key::generate();
 
         // Initialize the push side, type annotations required on return type
         let (mut so_push_stream, so_header) =

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -19,7 +19,7 @@
 //!
 //! // Randomly generate a main key and context, using the default stack-allocated
 //! // types
-//! let key = Kdf::gen_with_defaults();
+//! let key = StackKdf::generate();
 //! let subkey_id = 0;
 //!
 //! let subkey = key.derive_subkey_to_vec(subkey_id).expect("derive failed");
@@ -85,7 +85,7 @@ pub mod protected {
     //! use dryoc::kdf::protected::*;
     //!
     //! // Randomly generate a main key and context, using locked memory
-    //! let key: LockedKdf = Kdf::r#gen();
+    //! let key: LockedKdf = Kdf::generate();
     //! let subkey_id = 0;
     //!
     //! let subkey: Locked<Key> = key.derive_subkey(subkey_id).expect("derive failed");
@@ -115,11 +115,19 @@ impl<
 > Kdf<Key, Context>
 {
     /// Randomly generates a new pair of main key and context.
-    pub fn r#gen() -> Self {
+    pub fn generate() -> Self {
         Self {
-            main_key: Key::r#gen(),
-            context: Context::r#gen(),
+            main_key: Key::generate(),
+            context: Context::generate(),
         }
+    }
+
+    /// Randomly generates a new pair of main key and context.
+    ///
+    /// Prefer [`generate`](Self::generate). `gen` is retained for compatibility
+    /// and will be deprecated in a future release.
+    pub fn r#gen() -> Self {
+        Self::generate()
     }
 }
 
@@ -163,11 +171,19 @@ impl<
 
 impl Kdf<Key, Context> {
     /// Randomly generates a new pair of main key and context.
-    pub fn gen_with_defaults() -> Self {
+    pub fn generate_with_defaults() -> Self {
         Self {
-            main_key: Key::r#gen(),
-            context: Context::r#gen(),
+            main_key: Key::generate(),
+            context: Context::generate(),
         }
+    }
+
+    /// Randomly generates a new pair of main key and context.
+    ///
+    /// Prefer [`generate_with_defaults`](Self::generate_with_defaults). This
+    /// method is retained for compatibility.
+    pub fn gen_with_defaults() -> Self {
+        Self::generate_with_defaults()
     }
 }
 
@@ -177,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_kdf() {
-        let key = StackKdf::r#gen();
+        let key = StackKdf::generate();
 
         let _subkey = key.derive_subkey_to_vec(0).expect("derive failed");
     }

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -58,7 +58,7 @@ impl<
     }
 
     /// Generates a random keypair.
-    pub fn r#gen() -> Self {
+    pub fn generate() -> Self {
         use crate::classic::crypto_box::crypto_box_keypair_inplace;
 
         let mut public_key = PublicKey::new_byte_array();
@@ -69,6 +69,14 @@ impl<
             public_key,
             secret_key,
         }
+    }
+
+    /// Generates a random keypair.
+    ///
+    /// Prefer [`generate`](Self::generate). `gen` is retained for compatibility
+    /// and will be deprecated in a future release.
+    pub fn r#gen() -> Self {
+        Self::generate()
     }
 
     /// Derives a keypair from `secret_key`, and consumes it, and returns a new
@@ -107,8 +115,17 @@ impl<
 impl KeyPair<StackByteArray<CRYPTO_BOX_PUBLICKEYBYTES>, StackByteArray<CRYPTO_BOX_SECRETKEYBYTES>> {
     /// Randomly generates a new keypair, using default types
     /// (stack-allocated byte arrays). Provided for convenience.
+    pub fn generate_with_defaults() -> Self {
+        Self::generate()
+    }
+
+    /// Randomly generates a new keypair, using default types
+    /// (stack-allocated byte arrays). Provided for convenience.
+    ///
+    /// Prefer [`generate_with_defaults`](Self::generate_with_defaults). This
+    /// method is retained for compatibility.
     pub fn gen_with_defaults() -> Self {
-        Self::r#gen()
+        Self::generate_with_defaults()
     }
 }
 
@@ -426,7 +443,7 @@ mod tests {
         let keypair = KeyPair::<
             StackByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
             StackByteArray<CRYPTO_BOX_SECRETKEYBYTES>,
-        >::r#gen();
+        >::generate();
 
         let mut public_key = [0u8; CRYPTO_BOX_PUBLICKEYBYTES];
         crypto_scalarmult_base(&mut public_key, keypair.secret_key.as_array());
@@ -443,7 +460,7 @@ mod tests {
         let keypair_1 = KeyPair::<
             StackByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
             StackByteArray<CRYPTO_BOX_SECRETKEYBYTES>,
-        >::r#gen();
+        >::generate();
         let keypair_2 = KeyPair::from_secret_key(keypair_1.secret_key.clone());
 
         assert_eq!(keypair_1.public_key, keypair_2.public_key);
@@ -451,8 +468,8 @@ mod tests {
 
     #[test]
     fn test_keypair_precalculate() {
-        let kp1 = KeyPair::gen_with_defaults();
-        let kp2 = KeyPair::gen_with_defaults();
+        let kp1 = KeyPair::generate_with_defaults();
+        let kp2 = KeyPair::generate_with_defaults();
         let precalc = kp1.precalculate(&kp2.public_key);
         assert_eq!(precalc.len(), crate::constants::CRYPTO_BOX_BEFORENMBYTES);
     }
@@ -469,8 +486,8 @@ mod tests {
 
     #[test]
     fn test_keypair_kx_new_client_session() {
-        let server_kp = KeyPair::gen_with_defaults();
-        let client_kp = KeyPair::gen_with_defaults();
+        let server_kp = KeyPair::generate_with_defaults();
+        let client_kp = KeyPair::generate_with_defaults();
         let session: Session<StackByteArray<CRYPTO_KX_SESSIONKEYBYTES>> = client_kp
             .kx_new_client_session(&server_kp.public_key)
             .unwrap();
@@ -486,8 +503,8 @@ mod tests {
 
     #[test]
     fn test_keypair_kx_new_server_session() {
-        let client_kp = KeyPair::gen_with_defaults();
-        let server_kp = KeyPair::gen_with_defaults();
+        let client_kp = KeyPair::generate_with_defaults();
+        let server_kp = KeyPair::generate_with_defaults();
         let session: Session<StackByteArray<CRYPTO_KX_SESSIONKEYBYTES>> = server_kp
             .kx_new_server_session(&client_kp.public_key)
             .unwrap();
@@ -509,8 +526,8 @@ mod tests {
     }
 
     #[test]
-    fn test_keypair_gen_with_defaults() {
-        let kp = KeyPair::gen_with_defaults();
+    fn test_keypair_generate_with_defaults() {
+        let kp = KeyPair::generate_with_defaults();
         assert!(!kp.public_key.iter().all(|x| *x == 0));
     }
 
@@ -549,7 +566,7 @@ mod tests {
         // unlike Ed25519 validation. We don't explicitly test its rejection here.
 
         // Generated key should be valid
-        let kp = KeyPair::gen_with_defaults();
+        let kp = KeyPair::generate_with_defaults();
         assert!(
             KeyPair::<PublicKey, SecretKey>::is_valid_public_key(&kp.public_key),
             "Generated key failed validation"

--- a/src/kx.rs
+++ b/src/kx.rs
@@ -18,8 +18,8 @@
 //! use dryoc::kx::*;
 //!
 //! // Generate random client/server keypairs
-//! let client_keypair = KeyPair::r#gen();
-//! let server_keypair = KeyPair::r#gen();
+//! let client_keypair = KeyPair::generate();
+//! let server_keypair = KeyPair::generate();
 //!
 //! // Compute client session keys, into default stack-allocated byte array
 //! let client_session_keys =
@@ -256,8 +256,8 @@ mod tests {
 
     #[test]
     fn test_kx() {
-        let client_keypair = KeyPair::r#gen();
-        let server_keypair = KeyPair::r#gen();
+        let client_keypair = KeyPair::generate();
+        let server_keypair = KeyPair::generate();
 
         let client_session_keys =
             Session::new_client_with_defaults(&client_keypair, &server_keypair.public_key)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,10 @@
 //! This crate uses the Rust 2024 edition. The minimum supported Rust version
 //! (MSRV) is **Rust 1.89** or newer.
 //!
-//! Rust 2024 reserves `gen` as a keyword, so generation APIs are called with
-//! raw identifier syntax such as `Key::r#gen()`.
+//! Rust 2024 reserves `gen` as a keyword. Prefer generation APIs such as
+//! `Key::generate()`. Existing `gen` APIs remain available through raw
+//! identifier syntax, such as `Key::r#gen()`, for compatibility and will be
+//! deprecated in a future release.
 //!
 //! ## Features
 //!

--- a/src/onetimeauth.rs
+++ b/src/onetimeauth.rs
@@ -20,7 +20,7 @@
 //! use dryoc::types::*;
 //!
 //! // Generate a random key
-//! let key = Key::r#gen();
+//! let key = Key::generate();
 //!
 //! // Compute the mac in one shot. Here we clone the key for the purpose of this
 //! // example, but normally you would not do this as you never want to re-use a
@@ -38,7 +38,7 @@
 //! use dryoc::types::*;
 //!
 //! // Generate a random key
-//! let key = Key::r#gen();
+//! let key = Key::generate();
 //!
 //! // Initialize the MAC, clone the key (don't do this)
 //! let mut mac = OnetimeAuth::new(key.clone());
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn test_single_part() {
-        let key = Key::r#gen();
+        let key = Key::generate();
         let mac = OnetimeAuth::compute_to_vec(key.clone(), b"Data to authenticate");
 
         OnetimeAuth::compute_and_verify(&mac, key, b"Data to authenticate").expect("verify failed");
@@ -220,7 +220,7 @@ mod tests {
 
     #[test]
     fn test_multi_part() {
-        let key = Key::r#gen();
+        let key = Key::generate();
 
         let mut mac = OnetimeAuth::new(key.clone());
         mac.update(b"Multi-part");

--- a/src/poly1305/poly1305_soft.rs
+++ b/src/poly1305/poly1305_soft.rs
@@ -377,7 +377,7 @@ mod tests {
 
         use crate::rng::copy_randombytes;
 
-        let key = Key::r#gen();
+        let key = Key::generate();
 
         let so_key = SOKey::from_slice(&key).unwrap();
 

--- a/src/protected.rs
+++ b/src/protected.rs
@@ -1457,7 +1457,7 @@ mod tests {
     fn test_lock_unlock() {
         use crate::dryocstream::Key;
 
-        let key = Key::r#gen();
+        let key = Key::generate();
         let key_clone = key.clone();
 
         let locked_key = key.mlock().expect("lock failed");
@@ -1471,7 +1471,7 @@ mod tests {
     fn test_protect_unprotect() {
         use crate::dryocstream::Key;
 
-        let key = Key::r#gen();
+        let key = Key::generate();
         let key_clone = key.clone();
 
         let readonly_key = key.mprotect_readonly().expect("mprotect failed");

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -33,7 +33,7 @@
 //! use dryoc::sign::*;
 //!
 //! // Generate a random keypair, using default types
-//! let keypair = SigningKeyPair::gen_with_defaults();
+//! let keypair = SigningKeyPair::<PublicKey, SecretKey>::generate();
 //! let message = b"Fair is foul, and foul is fair: Hover through the fog and filthy air.";
 //!
 //! // Sign the message, using default types (stack-allocated byte array, Vec<u8>)
@@ -51,7 +51,7 @@
 //! use dryoc::sign::*;
 //!
 //! // Generate a random keypair, using default types
-//! let keypair = SigningKeyPair::gen_with_defaults();
+//! let keypair = SigningKeyPair::<PublicKey, SecretKey>::generate();
 //!
 //! // Initialize the incremental signer interface
 //! let mut signer = IncrementalSigner::new();
@@ -129,7 +129,7 @@ impl<
     }
 
     /// Generates a random signing keypair.
-    pub fn r#gen() -> Self {
+    pub fn generate() -> Self {
         let mut public_key = PublicKey::new_byte_array();
         let mut secret_key = SecretKey::new_byte_array();
         crypto_sign_keypair_inplace(public_key.as_mut_array(), secret_key.as_mut_array());
@@ -137,6 +137,14 @@ impl<
             public_key,
             secret_key,
         }
+    }
+
+    /// Generates a random signing keypair.
+    ///
+    /// Prefer [`generate`](Self::generate). `gen` is retained for compatibility
+    /// and will be deprecated in a future release.
+    pub fn r#gen() -> Self {
+        Self::generate()
     }
 
     /// Derives a signing keypair from `secret_key`, and consumes it, returning
@@ -175,8 +183,17 @@ impl
 {
     /// Randomly generates a new signing keypair, using default types
     /// (stack-allocated byte arrays). Provided for convenience.
+    pub fn generate_with_defaults() -> Self {
+        Self::generate()
+    }
+
+    /// Randomly generates a new signing keypair, using default types
+    /// (stack-allocated byte arrays). Provided for convenience.
+    ///
+    /// Prefer [`generate_with_defaults`](Self::generate_with_defaults). This
+    /// method is retained for compatibility.
     pub fn gen_with_defaults() -> Self {
-        Self::r#gen()
+        Self::generate_with_defaults()
     }
 }
 
@@ -527,7 +544,7 @@ mod tests {
 
     #[test]
     fn test_message_signing() {
-        let keypair = SigningKeyPair::gen_with_defaults();
+        let keypair = SigningKeyPair::generate_with_defaults();
         let message = b"hello my frens";
 
         let signed_message = keypair.sign_with_defaults(message).expect("signing failed");

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,6 +35,16 @@ pub trait NewByteArray<const LENGTH: usize>: MutByteArray<LENGTH> + NewBytes {
     /// Returns a new fixed-length byte array, initialized with zeroes.
     fn new_byte_array() -> Self;
     /// Returns a new fixed-length byte array, filled with random values.
+    fn generate() -> Self
+    where
+        Self: Sized,
+    {
+        Self::r#gen()
+    }
+    /// Returns a new fixed-length byte array, filled with random values.
+    ///
+    /// Prefer [`generate`](Self::generate). `gen` is retained for compatibility
+    /// and will be deprecated in a future release.
     fn r#gen() -> Self;
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6,9 +6,9 @@ use dryoc::precalc::PrecalcSecretKey;
 fn test_dryocbox() {
     use dryoc::dryocbox::*;
 
-    let sender_keypair = KeyPair::r#gen();
-    let recipient_keypair = KeyPair::r#gen();
-    let nonce = Nonce::r#gen();
+    let sender_keypair = KeyPair::generate();
+    let recipient_keypair = KeyPair::generate();
+    let nonce = Nonce::generate();
     let message = b"hey";
 
     let dryocbox = DryocBox::encrypt_to_vecbox(
@@ -50,8 +50,8 @@ fn test_dryocbox() {
 fn test_dryocsecretbox() {
     use dryoc::dryocsecretbox::*;
 
-    let secret_key = Key::r#gen();
-    let nonce = Nonce::r#gen();
+    let secret_key = Key::generate();
+    let nonce = Nonce::generate();
     let message = b"hey";
 
     let dryocsecretbox: VecBox = DryocSecretBox::encrypt(message, &nonce, &secret_key);
@@ -68,9 +68,9 @@ fn test_dryocsecretbox() {
 fn test_dryocbox_serde_json() {
     use dryoc::dryocbox::*;
 
-    let sender_keypair = KeyPair::r#gen();
-    let recipient_keypair = KeyPair::r#gen();
-    let nonce = Nonce::r#gen();
+    let sender_keypair = KeyPair::generate();
+    let recipient_keypair = KeyPair::generate();
+    let nonce = Nonce::generate();
     let message = b"hey friend";
 
     let dryocbox: VecBox = DryocBox::encrypt(
@@ -101,8 +101,8 @@ fn test_dryocbox_serde_json() {
 fn test_dryocsecretbox_serde_json() {
     use dryoc::dryocsecretbox::*;
 
-    let secret_key = Key::r#gen();
-    let nonce = Nonce::r#gen();
+    let secret_key = Key::generate();
+    let nonce = Nonce::generate();
     let message = b"hey buddy bro";
 
     let dryocsecretbox: VecBox = DryocSecretBox::encrypt(message, &nonce, &secret_key);
@@ -122,9 +122,9 @@ fn test_dryocsecretbox_serde_json() {
 fn test_dryocbox_wincode_bytes() {
     use dryoc::dryocbox::*;
 
-    let sender_keypair = KeyPair::r#gen();
-    let recipient_keypair = KeyPair::r#gen();
-    let nonce = Nonce::r#gen();
+    let sender_keypair = KeyPair::generate();
+    let recipient_keypair = KeyPair::generate();
+    let nonce = Nonce::generate();
     let message = b"hey friend";
 
     let dryocbox: VecBox = DryocBox::encrypt(
@@ -156,9 +156,9 @@ fn test_dryocbox_wincode_bytes() {
 fn test_dryocbox_wincode() {
     use dryoc::dryocbox::*;
 
-    let sender_keypair = KeyPair::r#gen();
-    let recipient_keypair = KeyPair::r#gen();
-    let nonce = Nonce::r#gen();
+    let sender_keypair = KeyPair::generate();
+    let recipient_keypair = KeyPair::generate();
+    let nonce = Nonce::generate();
     let message = b"hey friend";
 
     let dryocbox: VecBox = DryocBox::encrypt(
@@ -188,7 +188,7 @@ fn test_dryocbox_wincode() {
 fn test_dryocbox_sealed_wincode() {
     use dryoc::dryocbox::*;
 
-    let recipient_keypair = KeyPair::r#gen();
+    let recipient_keypair = KeyPair::generate();
     let message = b"hey sealed friend";
 
     let dryocbox: VecBox =
@@ -208,8 +208,8 @@ fn test_dryocbox_sealed_wincode() {
 fn test_dryocsecretbox_wincode_bytes() {
     use dryoc::dryocsecretbox::*;
 
-    let secret_key = Key::r#gen();
-    let nonce = Nonce::r#gen();
+    let secret_key = Key::generate();
+    let nonce = Nonce::generate();
     let message = b"hey buddy bro";
 
     let dryocsecretbox: VecBox = DryocSecretBox::encrypt(message, &nonce, &secret_key);
@@ -231,8 +231,8 @@ fn test_dryocsecretbox_wincode_bytes() {
 fn test_dryocsecretbox_wincode() {
     use dryoc::dryocsecretbox::*;
 
-    let secret_key = Key::r#gen();
-    let nonce = Nonce::r#gen();
+    let secret_key = Key::generate();
+    let nonce = Nonce::generate();
     let message = b"hey buddy bro";
 
     let dryocsecretbox: VecBox = DryocSecretBox::encrypt(message, &nonce, &secret_key);
@@ -369,7 +369,7 @@ fn test_streams_rustaceous() {
     let message2 = b"split into";
     let message3 = b"three messages";
 
-    let key = Key::r#gen();
+    let key = Key::generate();
 
     let (mut push_stream, header): (_, Header) = DryocStream::init_push(&key);
     let c1: Vec<u8> = push_stream
@@ -579,7 +579,7 @@ fn test_streams_protected() {
 fn test_dryocbox_seal() {
     use dryoc::dryocbox::*;
 
-    let recipient_keypair = KeyPair::r#gen();
+    let recipient_keypair = KeyPair::generate();
     let message = b"juicybox";
 
     let dryocbox =


### PR DESCRIPTION
## Summary

Adds preferred `generate()` APIs alongside the existing `gen` generation APIs so Rust 2024 callers can avoid raw identifier syntax while compatibility remains intact.

## User Impact

Users can now call APIs like `Key::generate()`, `Nonce::generate()`, `KeyPair::generate()`, and `Kdf::generate()` directly. Existing `r#gen()` and `gen_with_defaults()` callers continue to compile.

## Root Cause

Rust 2024 reserves `gen` as a keyword, which forces existing generation examples and callers to use raw identifier syntax such as `Key::r#gen()`.

## Fix

Adds `generate()` to `NewByteArray` and matching inherent generation methods for keypair, signing keypair, and KDF types. Updates examples, tests, and documentation to prefer `generate()`, and documents that `gen` remains for compatibility but will be deprecated in a future release.

## Validation

- `cargo check`
- `cargo test`
- `cargo test --features serde`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --features default -- -D warnings`
