### PR TITLE
perf: add portable SIMD Poly1305 backend

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -99,10 +99,10 @@ combined XSalsa20 stream and Poly1305 authentication path used by secretbox.
 
 | Message size | Software time | Software throughput | SIMD time | SIMD throughput | Relative |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 64 B | `282.73 ns/iter` | `226 MB/s` | `327.27 ns/iter` | `195 MB/s` | `1.16x slower` |
-| 1 KiB | `1,619.71 ns/iter` | `632 MB/s` | `1,505.93 ns/iter` | `680 MB/s` | `1.08x faster` |
-| 16 KiB | `22,647.52 ns/iter` | `723 MB/s` | `18,721.46 ns/iter` | `875 MB/s` | `1.21x faster` |
-| 1 MiB | `1,466,233.40 ns/iter` | `715 MB/s` | `1,183,574.90 ns/iter` | `885 MB/s` | `1.24x faster` |
+| 64 B | `281.52 ns/iter` | `227 MB/s` | `327.97 ns/iter` | `195 MB/s` | `1.17x slower` |
+| 1 KiB | `1,607.85 ns/iter` | `637 MB/s` | `1,516.26 ns/iter` | `675 MB/s` | `1.06x faster` |
+| 16 KiB | `22,886.41 ns/iter` | `715 MB/s` | `18,726.82 ns/iter` | `874 MB/s` | `1.22x faster` |
+| 1 MiB | `1,433,748.95 ns/iter` | `731 MB/s` | `1,175,895.90 ns/iter` | `891 MB/s` | `1.22x faster` |
 
 The SIMD build uses portable SIMD for both Salsa20 and Poly1305. Larger
 messages benefit from the Salsa20 path processing four independent counter

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -22,12 +22,16 @@ Commands used for the rows below:
 ```sh
 RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features nightly blake2b_bench
 RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features simd_backend,nightly blake2b_bench
+RUSTFLAGS="-Ctarget-cpu=native" cargo +nightly bench --features nightly poly1305
+RUSTFLAGS="-Ctarget-cpu=native" cargo +nightly bench --features simd_backend,nightly poly1305
 RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features nightly crypto_secretbox_detached
 RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features simd_backend,nightly crypto_secretbox_detached
 ```
 
-`neon` is already reported by `rustc +nightly --print cfg` on this target, but
-the benchmark commands include it explicitly along with `target-cpu=native`.
+`neon` is already reported by `rustc +nightly --print cfg` on this target.
+Some commands include it explicitly along with `target-cpu=native`; adding
+`-Ctarget-feature=+neon` is not expected to change native Apple Silicon
+results.
 Run `cargo +nightly bench` without a benchmark-name filter to collect the full
 suite.
 
@@ -37,11 +41,55 @@ Benchmark: hash a 694,200-byte buffer and produce a 64-byte output.
 
 | Implementation | Feature set | Time | Relative |
 | --- | --- | ---: | ---: |
-| Software | `nightly` | `779,302.60 ns/iter` | `1.00x` |
-| Portable SIMD | `simd_backend,nightly` | `588,802.05 ns/iter` | `1.32x faster` |
+| Software | `nightly` | `795,501.04 ns/iter` | `1.00x` |
+| Portable SIMD | `simd_backend,nightly` | `612,945.90 ns/iter` | `1.30x faster` |
 
-The portable SIMD backend is about 32.4% faster than the software backend for
+The portable SIMD backend is about 29.8% faster than the software backend for
 this workload on this machine.
+
+## One-Time Authentication: Poly1305
+
+Benchmark: authenticate fixed-size messages with Poly1305. The scalar rows come
+from the scalar/default build, and the SIMD rows come from the
+`simd_backend,nightly` build.
+
+| Message size | Software time | Software throughput | SIMD time | SIMD throughput | Relative |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 64 B | `26.81 ns/iter` | `2461 MB/s` | `52.38 ns/iter` | `1230 MB/s` | `1.95x slower` |
+| 1 KiB | `384.91 ns/iter` | `2666 MB/s` | `399.52 ns/iter` | `2566 MB/s` | `1.04x slower` |
+| 16 KiB | `5,980.91 ns/iter` | `2739 MB/s` | `5,906.60 ns/iter` | `2774 MB/s` | `1.01x faster` |
+| 1 MiB | `385,375.05 ns/iter` | `2720 MB/s` | `376,518.75 ns/iter` | `2784 MB/s` | `1.02x faster` |
+
+The portable SIMD backend uses a 4-way decimated Horner evaluation with 5x26-bit
+limbs. On this Apple Silicon target it is close to scalar for large messages,
+but the large-input edge is small enough to treat as benchmark noise rather than
+a reliable production speedup. It remains intentionally opt-in.
+
+External libsodium baseline from the scalar/default run:
+
+| Message size | dryoc software time | dryoc throughput | libsodium time | libsodium throughput | Relative |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 64 B | `26.81 ns/iter` | `2461 MB/s` | `29.21 ns/iter` | `2206 MB/s` | `1.09x slower` |
+| 1 KiB | `384.91 ns/iter` | `2666 MB/s` | `361.69 ns/iter` | `2836 MB/s` | `1.06x faster` |
+| 16 KiB | `5,980.91 ns/iter` | `2739 MB/s` | `5,735.08 ns/iter` | `2856 MB/s` | `1.04x faster` |
+| 1 MiB | `385,375.05 ns/iter` | `2720 MB/s` | `366,554.15 ns/iter` | `2860 MB/s` | `1.05x faster` |
+
+The useful portable SIMD shape is narrower than it first appears:
+
+- The direct RFC formulation is serial:
+  `a = (r * (a + block)) % p` for every 16-byte block. SIMD implementations
+  have to rewrite this as decimated Horner streams and fold those streams back
+  together.
+- Fast target-specific implementations use a 5x26-bit representation, precompute
+  key powers such as `r^2` and `r^4`, and process multiple blocks per
+  iteration.
+- On AArch64, Rust portable SIMD cannot express the widening
+  multiply-accumulate shape exposed by target-specific NEON intrinsics such as
+  `vmull_u32`, `vmlal_u32`, and `vmlal_high_u32`.
+
+References: [RFC 8439](https://www.rfc-editor.org/rfc/rfc8439),
+[Improved SIMD Implementation of Poly1305, ePrint 2019/842](https://eprint.iacr.org/2019/842.pdf),
+and [BoringSSL's Poly1305 NEON source](https://boringssl.googlesource.com/boringssl/+/8e5174b1186e/crypto/poly1305/poly1305_arm.cc).
 
 ## Secretbox: XSalsa20-Poly1305
 
@@ -51,15 +99,15 @@ combined XSalsa20 stream and Poly1305 authentication path used by secretbox.
 
 | Message size | Software time | Software throughput | SIMD time | SIMD throughput | Relative |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 64 B | `294.64 ns/iter` | `217 MB/s` | `295.54 ns/iter` | `216 MB/s` | `1.00x` |
-| 1 KiB | `1,639.56 ns/iter` | `624 MB/s` | `1,499.19 ns/iter` | `683 MB/s` | `1.09x faster` |
-| 16 KiB | `23,103.33 ns/iter` | `709 MB/s` | `18,906.71 ns/iter` | `866 MB/s` | `1.22x faster` |
-| 1 MiB | `1,461,518.75 ns/iter` | `717 MB/s` | `1,206,953.14 ns/iter` | `868 MB/s` | `1.21x faster` |
+| 64 B | `282.73 ns/iter` | `226 MB/s` | `327.27 ns/iter` | `195 MB/s` | `1.16x slower` |
+| 1 KiB | `1,619.71 ns/iter` | `632 MB/s` | `1,505.93 ns/iter` | `680 MB/s` | `1.08x faster` |
+| 16 KiB | `22,647.52 ns/iter` | `723 MB/s` | `18,721.46 ns/iter` | `875 MB/s` | `1.21x faster` |
+| 1 MiB | `1,466,233.40 ns/iter` | `715 MB/s` | `1,183,574.90 ns/iter` | `885 MB/s` | `1.24x faster` |
 
-The portable SIMD Salsa20 path helps larger messages by processing four
-independent Salsa20 counter blocks in parallel. Small messages mostly measure
-fixed XSalsa20 setup plus Poly1305 overhead, so the SIMD advantage grows with
-payload size.
+The SIMD build uses portable SIMD for both Salsa20 and Poly1305. Larger
+messages benefit from the Salsa20 path processing four independent counter
+blocks in parallel. Small messages are slower in this run because fixed XSalsa20
+setup plus Poly1305 SIMD overhead dominates the short payload.
 
 ## Benchmark Coverage
 
@@ -68,7 +116,8 @@ Current side-by-side software/SIMD benchmark coverage:
 | Algorithm | Software implementation | SIMD implementation | Benchmarked |
 | --- | --- | --- | --- |
 | BLAKE2b | `blake2b_soft` | `blake2b_simd` | Yes |
-| XSalsa20-Poly1305 secretbox | RustCrypto `salsa20` + `poly1305_soft` | portable-SIMD Salsa20 + `poly1305_soft` | Yes |
+| Poly1305 | `poly1305_soft` | `poly1305_simd` | Yes |
+| XSalsa20-Poly1305 secretbox | RustCrypto `salsa20` + `poly1305_soft` | portable-SIMD Salsa20 + `poly1305_simd` | Yes |
 
 Algorithms without side-by-side benchmark coverage should get their own section
 when a second implementation is added or when performance work begins.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ simd_backend = []
 u64_backend = []
 wincode = ["dep:wincode"]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin)"] }
+
 [package.metadata.docs.rs]
 # docs.rs uses nightly, enable feature flag to get all the juicy docs
 features = ["nightly", "serde", "base64", "wincode"]

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ For example usage, refer to the
 * [wincode](https://crates.io/crates/wincode) support for direct binary serialization of Rustaceous box types (with `features = ["wincode"]`)
 * [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html) implementation for Blake2b (used by generic hashing, password hashing, and key derivation) on nightly, with `features = ["simd_backend", "nightly"]`
 * [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html) implementation for Salsa20 (used by XSalsa20-Poly1305 secretbox) on nightly, with `features = ["simd_backend", "nightly"]`
+* [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html) implementation for Poly1305 (used by one-time authentication and secret boxes) on nightly, with `features = ["simd_backend", "nightly"]`
 * [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek) (used by public/private key functions) selects its own serial or x86_64 vector backend at build time
 * [SHA2](https://github.com/RustCrypto/hashes/tree/master/sha2) (used by sealed boxes) includes SIMD implementation for AVX2
-* [ChaCha20](https://github.com/RustCrypto/stream-ciphers/tree/master/chacha20) (used by streaming interface) includes SIMD implementations for Neon, AVX2, and SSE2
+* [ChaCha20](https://github.com/RustCrypto/stream-ciphers/tree/master/chacha20) (used by streaming interface) includes SIMD implementations for NEON, AVX2, and SSE2
 
 ## Rust version
 
@@ -66,9 +67,10 @@ backends. CPU-specific dependency backends and local benchmarking may also
 benefit from target-specific `RUSTFLAGS`:
 * For AVX2 set `RUSTFLAGS=-Ctarget-cpu=haswell -Ctarget-feature=+avx2`
 * For SSE2 set `RUSTFLAGS=-Ctarget-feature=+sse2`
-* For Neon set `RUSTFLAGS=-Ctarget-feature=+neon`
-* For local Apple silicon benchmarks, use
-  `RUSTFLAGS=-Ctarget-cpu=native -Ctarget-feature=+neon`
+* For NEON set `RUSTFLAGS=-Ctarget-feature=+neon`
+* For local Apple Silicon benchmarks, use `RUSTFLAGS=-Ctarget-cpu=native`.
+  NEON is part of the AArch64 macOS baseline target, so adding
+  `-Ctarget-feature=+neon` is not expected to change native results.
 
 The Curve25519 backend is selected by `curve25519-dalek`, not by dryoc's
 `simd_backend` feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,13 +46,16 @@
 //! * [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html)
 //!   implementation for Salsa20 (used by XSalsa20-Poly1305 secretbox) on
 //!   nightly, with `features = ["simd_backend", "nightly"]`
+//! * [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html)
+//!   implementation for Poly1305 (used by one-time authentication and secret
+//!   boxes) on nightly, with `features = ["simd_backend", "nightly"]`
 //! * [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek)
 //!   (used by public/private key functions) selects its own serial or x86_64
 //!   vector backend at build time
 //! * [SHA2](https://github.com/RustCrypto/hashes/tree/master/sha2) (used by
 //!   sealed boxes) includes SIMD implementation for AVX2
 //! * [ChaCha20](https://github.com/RustCrypto/stream-ciphers/tree/master/chacha20)
-//!   (used by streaming interface) includes SIMD implementations for Neon,
+//!   (used by streaming interface) includes SIMD implementations for NEON,
 //!   AVX2, and SSE2
 //!
 //! The `simd_backend` and `nightly` features enable dryoc's portable SIMD
@@ -60,9 +63,10 @@
 //! benefit from target-specific `RUSTFLAGS`:
 //! * For AVX2 set `RUSTFLAGS=-Ctarget-cpu=haswell -Ctarget-feature=+avx2`
 //! * For SSE2 set `RUSTFLAGS=-Ctarget-feature=+sse2`
-//! * For Neon set `RUSTFLAGS=-Ctarget-feature=+neon`
-//! * For local Apple silicon benchmarks, use `RUSTFLAGS=-Ctarget-cpu=native
-//!   -Ctarget-feature=+neon`
+//! * For NEON set `RUSTFLAGS=-Ctarget-feature=+neon`
+//! * For local Apple Silicon benchmarks, use `RUSTFLAGS=-Ctarget-cpu=native`.
+//!   NEON is part of the AArch64 macOS baseline target, so adding
+//!   `-Ctarget-feature=+neon` is not expected to change native results.
 //!
 //! The Curve25519 backend is selected by `curve25519-dalek`, not by dryoc's
 //! `simd_backend` feature.
@@ -71,6 +75,9 @@
 //! implementations for all the core algos which will work across all platforms
 //! supported by LLVM, rather than relying on hand-coded assembly or intrinsics,
 //! but this is a work in progress_.
+//!
+//! See [BENCHMARKS.md](https://github.com/brndnmtthws/dryoc/blob/main/BENCHMARKS.md)
+//! for side-by-side software and SIMD benchmark results.
 //!
 //! ## APIs
 //!

--- a/src/poly1305/mod.rs
+++ b/src/poly1305/mod.rs
@@ -1,2 +1,30 @@
+#[cfg(all(feature = "simd_backend", feature = "nightly"))]
+pub(crate) mod poly1305_simd;
+
+#[cfg(any(test, not(all(feature = "simd_backend", feature = "nightly"))))]
 pub(crate) mod poly1305_soft;
+
+const BLOCK_SIZE: usize = 16;
+
+#[inline]
+fn pad_partial_block(buffer: &[u8]) -> [u8; BLOCK_SIZE] {
+    debug_assert!(buffer.len() < BLOCK_SIZE);
+
+    let mut block = [0u8; BLOCK_SIZE];
+    block[..buffer.len()].copy_from_slice(buffer);
+    block[buffer.len()] = 1;
+    block
+}
+
+#[cfg(all(test, feature = "nightly"))]
+mod bench_inputs {
+    pub(super) const BYTES_64: usize = 64;
+    pub(super) const KIB_1: usize = 1024;
+    pub(super) const KIB_16: usize = 16 * 1024;
+    pub(super) const MIB_1: usize = 1024 * 1024;
+}
+
+#[cfg(all(feature = "simd_backend", feature = "nightly"))]
+pub(crate) use poly1305_simd::*;
+#[cfg(not(all(feature = "simd_backend", feature = "nightly")))]
 pub(crate) use poly1305_soft::*;

--- a/src/poly1305/mod.rs
+++ b/src/poly1305/mod.rs
@@ -16,7 +16,7 @@ fn pad_partial_block(buffer: &[u8]) -> [u8; BLOCK_SIZE] {
     block
 }
 
-#[cfg(all(test, feature = "nightly"))]
+#[cfg(all(test, feature = "nightly", not(tarpaulin)))]
 mod bench_inputs {
     pub(super) const BYTES_64: usize = 64;
     pub(super) const KIB_1: usize = 1024;

--- a/src/poly1305/poly1305_simd.rs
+++ b/src/poly1305/poly1305_simd.rs
@@ -349,7 +349,7 @@ mod tests {
     use super::*;
     use crate::poly1305::poly1305_soft;
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     extern crate test;
 
     fn simd_mac(key: &[u8; 32], chunks: &[&[u8]]) -> [u8; BLOCK_SIZE] {
@@ -520,7 +520,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     fn bench_poly1305(b: &mut test::Bencher, len: usize) {
         use crate::rng::copy_randombytes;
 
@@ -536,25 +536,25 @@ mod tests {
         });
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn poly1305_64b_bench(b: &mut test::Bencher) {
         bench_poly1305(b, crate::poly1305::bench_inputs::BYTES_64);
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn poly1305_1k_bench(b: &mut test::Bencher) {
         bench_poly1305(b, crate::poly1305::bench_inputs::KIB_1);
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn poly1305_16k_bench(b: &mut test::Bencher) {
         bench_poly1305(b, crate::poly1305::bench_inputs::KIB_16);
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn poly1305_1m_bench(b: &mut test::Bencher) {
         bench_poly1305(b, crate::poly1305::bench_inputs::MIB_1);

--- a/src/poly1305/poly1305_simd.rs
+++ b/src/poly1305/poly1305_simd.rs
@@ -1,0 +1,562 @@
+use std::simd::Simd;
+
+use zeroize::Zeroize;
+
+use super::{BLOCK_SIZE, pad_partial_block};
+use crate::types::*;
+use crate::utils::{load_u32_le, load_u64_le};
+
+const LANES: usize = 4;
+const MASK26: u64 = (1 << 26) - 1;
+const HIBIT: u64 = 1 << 24;
+
+type Fe = [u64; 5];
+type Fe4 = [Simd<u64, LANES>; 5];
+
+#[derive(Default, Zeroize)]
+pub struct Poly1305 {
+    r: Fe,
+    r2: Fe,
+    r3: Fe,
+    r4: Fe,
+    h: Fe,
+    pad: [u64; 2],
+    buffer: Vec<u8>,
+}
+
+pub type Key = StackByteArray<32>;
+
+#[inline(always)]
+fn block_to_fe(block: &[u8], hibit: u64) -> Fe {
+    let t0 = load_u32_le(&block[0..4]) as u64;
+    let t1 = load_u32_le(&block[4..8]) as u64;
+    let t2 = load_u32_le(&block[8..12]) as u64;
+    let t3 = load_u32_le(&block[12..16]) as u64;
+
+    [
+        t0 & MASK26,
+        ((t0 >> 26) | (t1 << 6)) & MASK26,
+        ((t1 >> 20) | (t2 << 12)) & MASK26,
+        ((t2 >> 14) | (t3 << 18)) & MASK26,
+        ((t3 >> 8) & MASK26) | hibit,
+    ]
+}
+
+#[inline]
+fn key_to_r(key: &[u8]) -> Fe {
+    let mut r = [0u8; 16];
+    r.copy_from_slice(&key[..16]);
+    r[3] &= 15;
+    r[7] &= 15;
+    r[11] &= 15;
+    r[15] &= 15;
+    r[4] &= 252;
+    r[8] &= 252;
+    r[12] &= 252;
+    block_to_fe(&r, 0)
+}
+
+#[inline(always)]
+fn fe_add(lhs: Fe, rhs: Fe) -> Fe {
+    core::array::from_fn(|i| lhs[i].wrapping_add(rhs[i]))
+}
+
+#[inline]
+fn fe_carry(mut h: Fe) -> Fe {
+    let mut c = h[0] >> 26;
+    h[0] &= MASK26;
+    h[1] += c;
+    c = h[1] >> 26;
+    h[1] &= MASK26;
+    h[2] += c;
+    c = h[2] >> 26;
+    h[2] &= MASK26;
+    h[3] += c;
+    c = h[3] >> 26;
+    h[3] &= MASK26;
+    h[4] += c;
+    c = h[4] >> 26;
+    h[4] &= MASK26;
+    h[0] += c * 5;
+    c = h[0] >> 26;
+    h[0] &= MASK26;
+    h[1] += c;
+    h
+}
+
+#[inline(always)]
+fn fe_mul(lhs: Fe, rhs: Fe) -> Fe {
+    let rhs1_5 = rhs[1] * 5;
+    let rhs2_5 = rhs[2] * 5;
+    let rhs3_5 = rhs[3] * 5;
+    let rhs4_5 = rhs[4] * 5;
+
+    let d0 =
+        lhs[0] * rhs[0] + lhs[1] * rhs4_5 + lhs[2] * rhs3_5 + lhs[3] * rhs2_5 + lhs[4] * rhs1_5;
+    let mut d1 =
+        lhs[0] * rhs[1] + lhs[1] * rhs[0] + lhs[2] * rhs4_5 + lhs[3] * rhs3_5 + lhs[4] * rhs2_5;
+    let mut d2 =
+        lhs[0] * rhs[2] + lhs[1] * rhs[1] + lhs[2] * rhs[0] + lhs[3] * rhs4_5 + lhs[4] * rhs3_5;
+    let mut d3 =
+        lhs[0] * rhs[3] + lhs[1] * rhs[2] + lhs[2] * rhs[1] + lhs[3] * rhs[0] + lhs[4] * rhs4_5;
+    let mut d4 =
+        lhs[0] * rhs[4] + lhs[1] * rhs[3] + lhs[2] * rhs[2] + lhs[3] * rhs[1] + lhs[4] * rhs[0];
+
+    let mut h = [0u64; 5];
+    let mut c = d0 >> 26;
+    h[0] = d0 & MASK26;
+    d1 += c;
+    c = d1 >> 26;
+    h[1] = d1 & MASK26;
+    d2 += c;
+    c = d2 >> 26;
+    h[2] = d2 & MASK26;
+    d3 += c;
+    c = d3 >> 26;
+    h[3] = d3 & MASK26;
+    d4 += c;
+    c = d4 >> 26;
+    h[4] = d4 & MASK26;
+    h[0] += c * 5;
+    c = h[0] >> 26;
+    h[0] &= MASK26;
+    h[1] += c;
+    h
+}
+
+#[inline(always)]
+fn fe4_splat(x: Fe) -> Fe4 {
+    core::array::from_fn(|i| Simd::splat(x[i]))
+}
+
+#[inline(always)]
+fn fe4_add(lhs: Fe4, rhs: Fe4) -> Fe4 {
+    core::array::from_fn(|i| lhs[i] + rhs[i])
+}
+
+#[inline(always)]
+fn fe4_mul(lhs: Fe4, rhs: Fe4) -> Fe4 {
+    let five = Simd::splat(5);
+    let rhs1_5 = rhs[1] * five;
+    let rhs2_5 = rhs[2] * five;
+    let rhs3_5 = rhs[3] * five;
+    let rhs4_5 = rhs[4] * five;
+
+    let d0 =
+        lhs[0] * rhs[0] + lhs[1] * rhs4_5 + lhs[2] * rhs3_5 + lhs[3] * rhs2_5 + lhs[4] * rhs1_5;
+    let mut d1 =
+        lhs[0] * rhs[1] + lhs[1] * rhs[0] + lhs[2] * rhs4_5 + lhs[3] * rhs3_5 + lhs[4] * rhs2_5;
+    let mut d2 =
+        lhs[0] * rhs[2] + lhs[1] * rhs[1] + lhs[2] * rhs[0] + lhs[3] * rhs4_5 + lhs[4] * rhs3_5;
+    let mut d3 =
+        lhs[0] * rhs[3] + lhs[1] * rhs[2] + lhs[2] * rhs[1] + lhs[3] * rhs[0] + lhs[4] * rhs4_5;
+    let mut d4 =
+        lhs[0] * rhs[4] + lhs[1] * rhs[3] + lhs[2] * rhs[2] + lhs[3] * rhs[1] + lhs[4] * rhs[0];
+
+    let mask = Simd::splat(MASK26);
+    let shift = Simd::splat(26);
+    let mut h = [Simd::splat(0); 5];
+    let mut c = d0 >> shift;
+    h[0] = d0 & mask;
+    d1 += c;
+    c = d1 >> shift;
+    h[1] = d1 & mask;
+    d2 += c;
+    c = d2 >> shift;
+    h[2] = d2 & mask;
+    d3 += c;
+    c = d3 >> shift;
+    h[3] = d3 & mask;
+    d4 += c;
+    c = d4 >> shift;
+    h[4] = d4 & mask;
+    h[0] += c * five;
+    c = h[0] >> shift;
+    h[0] &= mask;
+    h[1] += c;
+    h
+}
+
+#[inline(always)]
+fn blocks_to_fe4(input: &[u8], group: usize, h: Fe) -> Fe4 {
+    let mut limbs = [[0u64; LANES]; 5];
+
+    for (lane, block) in input[group * LANES * BLOCK_SIZE..][..LANES * BLOCK_SIZE]
+        .chunks_exact(BLOCK_SIZE)
+        .enumerate()
+    {
+        let mut fe = block_to_fe(block, HIBIT);
+        if group == 0 && lane == 0 {
+            fe = fe_add(fe, h);
+        }
+
+        for i in 0..5 {
+            limbs[i][lane] = fe[i];
+        }
+    }
+
+    core::array::from_fn(|i| Simd::from(limbs[i]))
+}
+
+#[inline]
+fn sum_lanes(v: Fe4) -> Fe {
+    fe_carry(core::array::from_fn(|i| {
+        let lanes = v[i].to_array();
+        lanes[0] + lanes[1] + lanes[2] + lanes[3]
+    }))
+}
+
+impl Poly1305 {
+    pub fn new<K>(key: &K) -> Self
+    where
+        K: ByteArray<32>,
+    {
+        let key = key.as_array();
+        let r = key_to_r(&key[..16]);
+        let r2 = fe_mul(r, r);
+        let r3 = fe_mul(r2, r);
+        let r4 = fe_mul(r2, r2);
+
+        Poly1305 {
+            r,
+            r2,
+            r3,
+            r4,
+            h: [0; 5],
+            pad: [load_u64_le(&key[16..24]), load_u64_le(&key[24..32])],
+            buffer: Vec::new(),
+        }
+    }
+
+    pub fn update(&mut self, input: &[u8]) {
+        let mut m = input;
+        if !self.buffer.is_empty() {
+            let input_block_end = std::cmp::min(BLOCK_SIZE - self.buffer.len(), input.len());
+            self.buffer.extend_from_slice(&m[..input_block_end]);
+
+            if self.buffer.len() < BLOCK_SIZE {
+                return;
+            }
+
+            let mut block = [0u8; BLOCK_SIZE];
+            block.copy_from_slice(&self.buffer);
+            self.buffer.clear();
+            self.blocks(&block, false);
+
+            m = &m[input_block_end..];
+        }
+
+        let full_blocks_end = m.len() - (m.len() % BLOCK_SIZE);
+        self.blocks(&m[..full_blocks_end], false);
+
+        if full_blocks_end < m.len() {
+            self.buffer.extend_from_slice(&m[full_blocks_end..]);
+        }
+    }
+
+    fn blocks_scalar(&mut self, input: &[u8], hibit: u64) {
+        debug_assert_eq!(input.len() % BLOCK_SIZE, 0);
+
+        for m in input.chunks_exact(BLOCK_SIZE) {
+            self.h = fe_mul(fe_add(self.h, block_to_fe(m, hibit)), self.r);
+        }
+    }
+
+    fn blocks(&mut self, input: &[u8], partial: bool) {
+        if input.is_empty() {
+            return;
+        }
+
+        if partial {
+            debug_assert_eq!(input.len(), BLOCK_SIZE);
+            self.blocks_scalar(input, 0);
+            return;
+        }
+
+        let prefix_len = (input.len() / BLOCK_SIZE % LANES) * BLOCK_SIZE;
+        if prefix_len != 0 {
+            self.blocks_scalar(&input[..prefix_len], HIBIT);
+        }
+
+        let input = &input[prefix_len..];
+        if input.is_empty() {
+            return;
+        }
+
+        let group_count = input.len() / (LANES * BLOCK_SIZE);
+        let r4 = fe4_splat(self.r4);
+        let mut t = blocks_to_fe4(input, 0, self.h);
+
+        for group in 1..group_count {
+            t = fe4_add(fe4_mul(t, r4), blocks_to_fe4(input, group, [0; 5]));
+        }
+
+        let powers =
+            core::array::from_fn(|i| Simd::from([self.r4[i], self.r3[i], self.r2[i], self.r[i]]));
+
+        self.h = sum_lanes(fe4_mul(t, powers));
+    }
+
+    pub fn finalize_to_array(&mut self) -> [u8; BLOCK_SIZE] {
+        let mut mac = [0u8; 16];
+        self.finalize(&mut mac);
+        mac
+    }
+
+    pub fn finalize(&mut self, output: &mut [u8]) {
+        if !self.buffer.is_empty() {
+            self.blocks(&pad_partial_block(&self.buffer), true);
+        }
+
+        let mut h = fe_carry(self.h);
+        h = fe_carry(h);
+
+        let mut g = [0u64; 5];
+        g[0] = h[0] + 5;
+        let mut c = g[0] >> 26;
+        g[0] &= MASK26;
+        for i in 1..4 {
+            g[i] = h[i] + c;
+            c = g[i] >> 26;
+            g[i] &= MASK26;
+        }
+        g[4] = h[4].wrapping_add(c).wrapping_sub(1 << 26);
+
+        let mask = (g[4] >> 63).wrapping_sub(1);
+        g[4] &= MASK26;
+        for i in 0..5 {
+            h[i] = (h[i] & !mask) | (g[i] & mask);
+        }
+
+        let f0 = h[0] | (h[1] << 26) | (h[2] << 52);
+        let f1 = (h[2] >> 12) | (h[3] << 14) | (h[4] << 40);
+
+        let f0 = f0 as u128 + self.pad[0] as u128;
+        let f1 = f1 as u128 + self.pad[1] as u128 + (f0 >> 64);
+
+        output[0..8].copy_from_slice(&(f0 as u64).to_le_bytes());
+        output[8..16].copy_from_slice(&(f1 as u64).to_le_bytes());
+
+        self.zeroize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use rand::TryRng;
+
+    use super::*;
+    use crate::poly1305::poly1305_soft;
+
+    #[cfg(feature = "nightly")]
+    extern crate test;
+
+    fn simd_mac(key: &[u8; 32], chunks: &[&[u8]]) -> [u8; BLOCK_SIZE] {
+        let key = Key::from(key);
+        let mut mac = Poly1305::new(&key);
+        for chunk in chunks {
+            mac.update(chunk);
+        }
+        mac.finalize_to_array()
+    }
+
+    fn soft_mac(key: &[u8; 32], chunks: &[&[u8]]) -> [u8; BLOCK_SIZE] {
+        let key = poly1305_soft::Key::from(key);
+        let mut mac = poly1305_soft::Poly1305::new(&key);
+        for chunk in chunks {
+            mac.update(chunk);
+        }
+        mac.finalize_to_array()
+    }
+
+    fn chunk_message_with_pattern<'a>(message: &'a [u8], pattern: &[usize]) -> Vec<&'a [u8]> {
+        let mut chunks = Vec::new();
+        let mut offset = 0;
+        let mut pattern_index = 0;
+
+        while offset < message.len() {
+            let chunk_len = pattern[pattern_index % pattern.len()].min(message.len() - offset);
+            chunks.push(&message[offset..offset + chunk_len]);
+            offset += chunk_len;
+            pattern_index += 1;
+        }
+
+        if chunks.is_empty() {
+            chunks.push(message);
+        }
+
+        chunks
+    }
+
+    fn chunk_message_with_splits<'a>(message: &'a [u8], splits: &[usize]) -> Vec<&'a [u8]> {
+        let mut chunks = Vec::new();
+        let mut offset = 0;
+
+        for split in splits {
+            if offset == message.len() {
+                break;
+            }
+
+            let chunk_len = (*split).min(message.len() - offset);
+            chunks.push(&message[offset..offset + chunk_len]);
+            offset += chunk_len;
+        }
+
+        if offset < message.len() {
+            chunks.push(&message[offset..]);
+        }
+
+        if chunks.is_empty() {
+            chunks.push(message);
+        }
+
+        chunks
+    }
+
+    fn assert_matches_soft(key: &[u8; 32], chunks: &[&[u8]]) {
+        assert_eq!(simd_mac(key, chunks), soft_mac(key, chunks));
+    }
+
+    #[test]
+    fn test_example_vector() {
+        let key = Key::from(&[
+            0x85, 0xd6, 0xbe, 0x78, 0x57, 0x55, 0x6d, 0x33, 0x7f, 0x44, 0x52, 0xfe, 0x42, 0xd5,
+            0x06, 0xa8, 0x01, 0x03, 0x80, 0x8a, 0xfb, 0x0d, 0xb2, 0xfd, 0x4a, 0xbf, 0xf6, 0xaf,
+            0x41, 0x49, 0xf5, 0x1b,
+        ]);
+        let text = b"Cryptographic Forum Research Group";
+
+        let mut mac = Poly1305::new(&key);
+        mac.update(text);
+        let mac = mac.finalize_to_array();
+
+        assert_eq!(
+            mac,
+            [
+                0xa8, 0x06, 0x1d, 0xc1, 0x30, 0x51, 0x36, 0xc6, 0xc2, 0x2b, 0x8b, 0xaf, 0x0c, 0x01,
+                0x27, 0xa9,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_libsodium_varied_lengths_and_chunking() {
+        use rand::rngs::SysRng;
+        use sodiumoxide::crypto::onetimeauth::poly1305::{Key as SOKey, authenticate};
+
+        use crate::rng::copy_randombytes;
+
+        let key = Key::r#gen();
+        let so_key = SOKey::from_slice(&key).unwrap();
+
+        for len in 0..260 {
+            let mut data = vec![0u8; len];
+            copy_randombytes(&mut data);
+
+            let mut mac = Poly1305::new(&key);
+            for chunk in data.chunks(7) {
+                mac.update(chunk);
+            }
+            let mac = mac.finalize_to_array();
+
+            let so_mac = authenticate(&data, &so_key);
+            assert_eq!(mac, so_mac.as_ref(), "len={}", len);
+        }
+
+        for _ in 0..20 {
+            let rand_usize = (SysRng.try_next_u32().unwrap() % 4096) as usize;
+            let mut data = vec![0u8; rand_usize];
+            copy_randombytes(&mut data);
+
+            let mut mac = Poly1305::new(&key);
+            mac.update(&data);
+            let mac = mac.finalize_to_array();
+
+            let so_mac = authenticate(&data, &so_key);
+            assert_eq!(mac, so_mac.as_ref(), "len={}", rand_usize);
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        #[test]
+        fn proptest_simd_matches_soft_one_shot(
+            key in any::<[u8; 32]>(),
+            message in prop::collection::vec(any::<u8>(), 0..8192),
+        ) {
+            assert_matches_soft(&key, &[&message]);
+        }
+
+        #[test]
+        fn proptest_simd_matches_soft_fixed_chunk_patterns(
+            key in any::<[u8; 32]>(),
+            message in prop::collection::vec(any::<u8>(), 0..8192),
+        ) {
+            for pattern in [
+                &[1][..],
+                &[7],
+                &[15],
+                &[16],
+                &[17],
+                &[31],
+                &[3, 5, 8, 13, 21],
+                &[64, 1, 32, 7],
+            ] {
+                let chunks = chunk_message_with_pattern(&message, pattern);
+                assert_matches_soft(&key, &chunks);
+            }
+        }
+
+        #[test]
+        fn proptest_simd_matches_soft_random_chunking(
+            key in any::<[u8; 32]>(),
+            message in prop::collection::vec(any::<u8>(), 0..8192),
+            splits in prop::collection::vec(1usize..128, 0..256),
+        ) {
+            let chunks = chunk_message_with_splits(&message, &splits);
+            assert_matches_soft(&key, &chunks);
+        }
+    }
+
+    #[cfg(feature = "nightly")]
+    fn bench_poly1305(b: &mut test::Bencher, len: usize) {
+        use crate::rng::copy_randombytes;
+
+        let key = Key::r#gen();
+        let mut input = vec![0u8; len];
+        copy_randombytes(&mut input);
+        b.bytes = len as u64;
+
+        b.iter(|| {
+            let mut mac = Poly1305::new(test::black_box(&key));
+            mac.update(test::black_box(&input));
+            test::black_box(mac.finalize_to_array());
+        });
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn poly1305_64b_bench(b: &mut test::Bencher) {
+        bench_poly1305(b, crate::poly1305::bench_inputs::BYTES_64);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn poly1305_1k_bench(b: &mut test::Bencher) {
+        bench_poly1305(b, crate::poly1305::bench_inputs::KIB_1);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn poly1305_16k_bench(b: &mut test::Bencher) {
+        bench_poly1305(b, crate::poly1305::bench_inputs::KIB_16);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn poly1305_1m_bench(b: &mut test::Bencher) {
+        bench_poly1305(b, crate::poly1305::bench_inputs::MIB_1);
+    }
+}

--- a/src/poly1305/poly1305_soft.rs
+++ b/src/poly1305/poly1305_soft.rs
@@ -1,9 +1,8 @@
 use zeroize::Zeroize;
 
+use super::{BLOCK_SIZE, pad_partial_block};
 use crate::types::*;
 use crate::utils::load_u64_le;
-
-const BLOCK_SIZE: usize = 16;
 
 #[derive(Default, Zeroize)]
 pub struct Poly1305 {
@@ -69,12 +68,12 @@ impl Poly1305 {
                 return;
             }
 
-            // process block
-            let b = self.buffer.clone();
-            self.blocks(&b, false);
+            let mut block = [0u8; BLOCK_SIZE];
+            block.copy_from_slice(&self.buffer);
             self.buffer.clear();
+            self.blocks(&block, false);
 
-            m = &m[input_block_end..]
+            m = &m[input_block_end..];
         }
 
         // process all full blocks
@@ -106,7 +105,9 @@ impl Poly1305 {
         let s1 = r1 * (5 << 2);
         let s2 = r2 * (5 << 2);
 
-        for m in input.chunks(BLOCK_SIZE) {
+        debug_assert_eq!(input.len() % BLOCK_SIZE, 0);
+
+        for m in input.chunks_exact(BLOCK_SIZE) {
             // h += m[i]
             let t0 = load_u64_le(&m[0..8]);
             let t1 = load_u64_le(&m[8..]);
@@ -163,15 +164,7 @@ impl Poly1305 {
     pub fn finalize(&mut self, output: &mut [u8]) {
         // process any remaining block
         if !self.buffer.is_empty() {
-            self.buffer.push(1);
-            if !self.buffer.len().is_multiple_of(BLOCK_SIZE) {
-                self.buffer.resize(
-                    self.buffer.len() + (BLOCK_SIZE - self.buffer.len() % BLOCK_SIZE),
-                    0,
-                );
-            }
-
-            self.blocks(&self.buffer.clone(), true);
+            self.blocks(&pad_partial_block(&self.buffer), true);
         }
 
         // fully carry h
@@ -247,6 +240,9 @@ mod tests {
     use rand::TryRng;
 
     use super::*;
+
+    #[cfg(feature = "nightly")]
+    extern crate test;
 
     #[test]
     fn test_example_vector() {
@@ -394,5 +390,91 @@ mod tests {
 
             assert_eq!(mac, so_mac.as_ref());
         }
+    }
+
+    #[cfg(feature = "nightly")]
+    fn bench_poly1305(b: &mut test::Bencher, len: usize) {
+        use crate::rng::copy_randombytes;
+
+        let key = Key::r#gen();
+        let mut input = vec![0u8; len];
+        copy_randombytes(&mut input);
+        b.bytes = len as u64;
+
+        b.iter(|| {
+            let mut mac = Poly1305::new(test::black_box(&key));
+            mac.update(test::black_box(&input));
+            test::black_box(mac.finalize_to_array());
+        });
+    }
+
+    #[cfg(feature = "nightly")]
+    fn bench_sodiumoxide_poly1305(b: &mut test::Bencher, len: usize) {
+        use sodiumoxide::crypto::onetimeauth::poly1305::{Key as SOKey, authenticate};
+
+        use crate::rng::copy_randombytes;
+
+        sodiumoxide::init().expect("sodiumoxide init");
+
+        let key = Key::r#gen();
+        let so_key = SOKey::from_slice(&key).expect("key");
+        let mut input = vec![0u8; len];
+        copy_randombytes(&mut input);
+        b.bytes = len as u64;
+
+        b.iter(|| {
+            let _ = test::black_box(authenticate(
+                test::black_box(&input),
+                test::black_box(&so_key),
+            ));
+        });
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn poly1305_64b_bench(b: &mut test::Bencher) {
+        bench_poly1305(b, crate::poly1305::bench_inputs::BYTES_64);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn poly1305_1k_bench(b: &mut test::Bencher) {
+        bench_poly1305(b, crate::poly1305::bench_inputs::KIB_1);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn poly1305_16k_bench(b: &mut test::Bencher) {
+        bench_poly1305(b, crate::poly1305::bench_inputs::KIB_16);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn poly1305_1m_bench(b: &mut test::Bencher) {
+        bench_poly1305(b, crate::poly1305::bench_inputs::MIB_1);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn sodiumoxide_poly1305_64b_bench(b: &mut test::Bencher) {
+        bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::BYTES_64);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn sodiumoxide_poly1305_1k_bench(b: &mut test::Bencher) {
+        bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::KIB_1);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn sodiumoxide_poly1305_16k_bench(b: &mut test::Bencher) {
+        bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::KIB_16);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn sodiumoxide_poly1305_1m_bench(b: &mut test::Bencher) {
+        bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::MIB_1);
     }
 }

--- a/src/poly1305/poly1305_soft.rs
+++ b/src/poly1305/poly1305_soft.rs
@@ -241,7 +241,7 @@ mod tests {
 
     use super::*;
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     extern crate test;
 
     #[test]
@@ -392,7 +392,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     fn bench_poly1305(b: &mut test::Bencher, len: usize) {
         use crate::rng::copy_randombytes;
 
@@ -408,7 +408,7 @@ mod tests {
         });
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     fn bench_sodiumoxide_poly1305(b: &mut test::Bencher, len: usize) {
         use sodiumoxide::crypto::onetimeauth::poly1305::{Key as SOKey, authenticate};
 
@@ -430,49 +430,49 @@ mod tests {
         });
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn poly1305_64b_bench(b: &mut test::Bencher) {
         bench_poly1305(b, crate::poly1305::bench_inputs::BYTES_64);
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn poly1305_1k_bench(b: &mut test::Bencher) {
         bench_poly1305(b, crate::poly1305::bench_inputs::KIB_1);
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn poly1305_16k_bench(b: &mut test::Bencher) {
         bench_poly1305(b, crate::poly1305::bench_inputs::KIB_16);
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn poly1305_1m_bench(b: &mut test::Bencher) {
         bench_poly1305(b, crate::poly1305::bench_inputs::MIB_1);
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn sodiumoxide_poly1305_64b_bench(b: &mut test::Bencher) {
         bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::BYTES_64);
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn sodiumoxide_poly1305_1k_bench(b: &mut test::Bencher) {
         bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::KIB_1);
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn sodiumoxide_poly1305_16k_bench(b: &mut test::Bencher) {
         bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::KIB_16);
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn sodiumoxide_poly1305_1m_bench(b: &mut test::Bencher) {
         bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::MIB_1);

--- a/src/protected.rs
+++ b/src/protected.rs
@@ -1453,6 +1453,10 @@ impl<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> Zeroize
 mod tests {
     use super::*;
 
+    #[cfg_attr(
+        tarpaulin,
+        ignore = "tarpaulin can segfault while tracing mlock/mprotect tests"
+    )]
     #[test]
     fn test_lock_unlock() {
         use crate::dryocstream::Key;
@@ -1467,6 +1471,10 @@ mod tests {
         assert_eq!(unlocked_key.as_slice(), key_clone.as_slice());
     }
 
+    #[cfg_attr(
+        tarpaulin,
+        ignore = "tarpaulin can segfault while tracing mlock/mprotect tests"
+    )]
     #[test]
     fn test_protect_unprotect() {
         use crate::dryocstream::Key;
@@ -1512,6 +1520,10 @@ mod tests {
         assert_eq!(_page_round(usize::MAX, pagesize), None);
     }
 
+    #[cfg_attr(
+        tarpaulin,
+        ignore = "tarpaulin can segfault while tracing mlock/mprotect tests"
+    )]
     #[test]
     fn test_mprotect_handles_single_byte_slice() {
         let mut vec: Vec<u8, _> = Vec::new_in(PageAlignedAllocator);
@@ -1525,6 +1537,10 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(
+        tarpaulin,
+        ignore = "tarpaulin can segfault while tracing mlock/mprotect tests"
+    )]
     #[test]
     fn test_mprotect_noaccess_covers_page_boundary_tail() {
         let pagesize = *PAGESIZE;


### PR DESCRIPTION
## Summary

Adds an opt-in portable SIMD Poly1305 backend behind `simd_backend,nightly`, wires backend selection through the existing Poly1305 module, and documents the measured software/SIMD performance tradeoffs.

## User Impact

Users who enable `simd_backend,nightly` can exercise a portable SIMD Poly1305 implementation for one-time authentication and secretbox authentication. The backend remains opt-in because Apple Silicon results are mixed: small Poly1305 inputs are slower, large Poly1305 inputs are close to scalar, and secretbox benefits on larger messages from the combined SIMD Salsa20 and Poly1305 path.

## Root Cause

`dryoc` already had portable SIMD coverage for BLAKE2b and Salsa20, but Poly1305 always used the scalar implementation. Poly1305 is mostly serial in its direct RFC form, so useful SIMD requires restructuring into independent lanes and folding them back together.

## Fix

This branch adds a 4-way portable SIMD Poly1305 implementation using 5x26-bit limbs and decimated Horner evaluation with precomputed `r^2`, `r^3`, and `r^4`. It keeps the scalar backend available for default builds and test cross-checks, shares block padding helpers, adds proptest coverage against the scalar implementation, adds libsodium compatibility checks, and updates README/rustdoc/benchmark documentation.

## Validation

- `cargo test poly1305 --lib`
- `cargo test --features simd_backend poly1305 --lib`
- `cargo +nightly test --features simd_backend,nightly poly1305 --lib`
- `cargo clippy --features default -- -D warnings`
- `cargo +nightly clippy --features simd_backend,nightly -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`
- `RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features nightly blake2b_bench`
- `RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features simd_backend,nightly blake2b_bench`
- `RUSTFLAGS="-Ctarget-cpu=native" cargo +nightly bench --features nightly poly1305`
- `RUSTFLAGS="-Ctarget-cpu=native" cargo +nightly bench --features simd_backend,nightly poly1305`
- `RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features nightly crypto_secretbox_detached`
- `RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features simd_backend,nightly crypto_secretbox_detached`
