### PR TITLE
docs: document unsafe code usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,13 @@ cargo fuzz run fuzz_target_1
   silently change them.
 - Any new `unsafe` must be small, documented by surrounding invariants, and
   covered by tests. Prefer existing unsafe wrappers and allocation helpers.
+- Put a `// SAFETY:` comment immediately before every non-test `unsafe` block,
+  `unsafe impl`, `unsafe extern`, or `unsafe fn`; explain the concrete pointer,
+  aliasing, initialization, layout, or OS-call invariant that makes it valid.
+- When adding, removing, or materially changing non-test `unsafe`, update the
+  unsafe code inventory in `src/lib.rs` and `README.md`.
+- Test-only `unsafe` should stay confined to compatibility checks or platform
+  probes, and it does not need to be listed in the unsafe inventory.
 
 ## Module Map
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ and [`wincode::SchemaRead`](https://docs.rs/wincode/latest/wincode/trait.SchemaR
 for supported Rustaceous box types, including `DryocBox` and
 `DryocSecretBox`.
 
+## Unsafe code
+
+Non-test `unsafe` code is limited to these areas:
+
+| Area | Feature gate | Why `unsafe` is required |
+|-|-|-|
+| `src/types.rs` fixed-size byte views | Always available | Converts validated byte slices and vectors into `[u8; N]` references without copying. Each cast is guarded by a length check or an exact-size wrapper invariant. |
+| `src/dryocbox.rs` and `src/dryocsecretbox.rs` wincode impls | `wincode` | Implements `unsafe` wincode schema traits for the Rustaceous box wire format. The implementations write and read initialized fields in the same order. |
+| `src/blake2b/blake2b_soft.rs` and `src/blake2b/blake2b_simd.rs` parameter blocks | Always available for the soft backend; `simd_backend,nightly` for SIMD | Views a `repr(C, packed)` BLAKE2b parameter block as bytes so the initialization vector is mixed exactly as specified. The parameter type contains only initialized byte fields. |
+| `src/protected.rs` protected memory | `nightly` | Calls OS APIs such as `mlock`, `mprotect`, `VirtualLock`, and `VirtualProtect`, implements a page-aligned guard-page allocator, and exposes exact-size byte-array views over protected heap buffers. |
+| `src/classic/salsa20_simd.rs` Salsa20 SIMD backend | `simd_backend,nightly` | Performs little-endian unaligned word XOR in 256-byte chunks and volatile zeroization of cached SIMD lanes containing derived key material. |
+
+Test-only unsafe code is used for libsodium and Argon2 compatibility checks and
+protected-memory platform probes; it is not part of the runtime crate API.
+
 ## Project status
 
 The following libsodium features are currently implemented, or awaiting
@@ -143,4 +158,5 @@ in Rust. Some optional SIMD code, including dependency-provided SIMD
 implementations and small internal helpers, may contain unsafe code. In
 particular, many SIMD implementations are considered "unsafe" due to their use
 of assembly or intrinsics, however without SIMD-based cryptography you may be
-exposed to timing attacks.
+exposed to timing attacks. See the unsafe code section above for the non-test
+unsafe inventory in this crate.

--- a/src/blake2b/blake2b_simd.rs
+++ b/src/blake2b/blake2b_simd.rs
@@ -431,6 +431,9 @@ impl State {
         let mut state = Self::default();
         state.init0();
 
+        // SAFETY: `Params` is `repr(C, packed)` and consists only of `u8`
+        // fields and byte arrays, so every byte in its object representation is
+        // initialized parameter data with alignment 1.
         let pslice = unsafe {
             std::slice::from_raw_parts(
                 (params as *const Params) as *const u8,

--- a/src/blake2b/blake2b_soft.rs
+++ b/src/blake2b/blake2b_soft.rs
@@ -146,6 +146,9 @@ impl State {
         let mut state = Self::default();
         state.init0();
 
+        // SAFETY: `Params` is `repr(C, packed)` and consists only of `u8`
+        // fields and byte arrays, so every byte in its object representation is
+        // initialized parameter data with alignment 1.
         let pslice = unsafe {
             std::slice::from_raw_parts(
                 (params as *const Params) as *const u8,

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -213,6 +213,9 @@ pub struct DryocBox<
 pub type VecBox = DryocBox<PublicKey, Mac, Vec<u8>>;
 
 #[cfg(feature = "wincode")]
+// SAFETY: The implementation writes exactly the fields used to reconstruct
+// `VecBox` below, using `wincode` schema implementations for each initialized
+// field and preserving their order.
 unsafe impl<C: wincode::config::Config> wincode::SchemaWrite<C> for VecBox {
     type Src = Self;
 
@@ -240,6 +243,8 @@ unsafe impl<C: wincode::config::Config> wincode::SchemaWrite<C> for VecBox {
 }
 
 #[cfg(feature = "wincode")]
+// SAFETY: The implementation fully initializes `dst` with a valid `VecBox`
+// after successfully reading each field in the same order as `SchemaWrite`.
 unsafe impl<'de, C: wincode::config::Config> wincode::SchemaRead<'de, C> for VecBox {
     type Dst = Self;
 

--- a/src/dryocsecretbox.rs
+++ b/src/dryocsecretbox.rs
@@ -147,6 +147,9 @@ pub struct DryocSecretBox<
 pub type VecBox = DryocSecretBox<Mac, Vec<u8>>;
 
 #[cfg(feature = "wincode")]
+// SAFETY: The implementation writes exactly the fields used to reconstruct
+// `VecBox` below, using `wincode` schema implementations for each initialized
+// field and preserving their order.
 unsafe impl<C: wincode::config::Config> wincode::SchemaWrite<C> for VecBox {
     type Src = Self;
 
@@ -168,6 +171,8 @@ unsafe impl<C: wincode::config::Config> wincode::SchemaWrite<C> for VecBox {
 }
 
 #[cfg(feature = "wincode")]
+// SAFETY: The implementation fully initializes `dst` with a valid `VecBox`
+// after successfully reading each field in the same order as `SchemaWrite`.
 unsafe impl<'de, C: wincode::config::Config> wincode::SchemaRead<'de, C> for VecBox {
     type Dst = Self;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,22 @@
 //! supported Rustaceous box types, including [`DryocBox`](dryocbox::DryocBox)
 //! and [`DryocSecretBox`](dryocsecretbox::DryocSecretBox).
 //!
+//! ## Unsafe code
+//!
+//! Non-test `unsafe` code is limited to these areas:
+//!
+//! | Area | Feature gate | Why `unsafe` is required |
+//! |-|-|-|
+//! | `src/types.rs` fixed-size byte views | Always available | Converts validated byte slices and vectors into `[u8; N]` references without copying. Each cast is guarded by a length check or an exact-size wrapper invariant. |
+//! | `src/dryocbox.rs` and `src/dryocsecretbox.rs` wincode impls | `wincode` | Implements `unsafe` wincode schema traits for the Rustaceous box wire format. The implementations write and read initialized fields in the same order. |
+//! | `src/blake2b/blake2b_soft.rs` and `src/blake2b/blake2b_simd.rs` parameter blocks | Always available for the soft backend; `simd_backend,nightly` for SIMD | Views a `repr(C, packed)` BLAKE2b parameter block as bytes so the initialization vector is mixed exactly as specified. The parameter type contains only initialized byte fields. |
+//! | `src/protected.rs` protected memory | `nightly` | Calls OS APIs such as `mlock`, `mprotect`, `VirtualLock`, and `VirtualProtect`, implements a page-aligned guard-page allocator, and exposes exact-size byte-array views over protected heap buffers. |
+//! | `src/classic/salsa20_simd.rs` Salsa20 SIMD backend | `simd_backend,nightly` | Performs little-endian unaligned word XOR in 256-byte chunks and volatile zeroization of cached SIMD lanes containing derived key material. |
+//!
+//! Test-only unsafe code is used for libsodium and Argon2 compatibility checks
+//! and protected-memory platform probes; it is not part of the runtime crate
+//! API.
+//!
 //! ## Security notes
 //!
 //! This crate has not been audited by any 3rd parties. It uses well-known
@@ -149,7 +165,8 @@
 //! implementations and small internal helpers, may contain unsafe code. In
 //! particular, many SIMD implementations are considered "unsafe" due to their
 //! use of assembly or intrinsics, however without SIMD-based cryptography you
-//! may be exposed to timing attacks.
+//! may be exposed to timing attacks. See the unsafe code section above for the
+//! non-test unsafe inventory in this crate.
 //!
 //! [^3]: The Rustaceous API is designed to protect users of this library from
 //! making mistakes, however the Classic API allows one to do as one pleases.

--- a/src/protected.rs
+++ b/src/protected.rs
@@ -267,12 +267,17 @@ fn dryoc_mlock(data: &[u8]) -> Result<(), std::io::Error> {
         {
             // tell the kernel not to include this memory in a core dump
             use libc::{MADV_DONTDUMP, madvise};
+            // SAFETY: `data` is a valid, non-empty byte slice. `madvise` may
+            // accept any address range and reports errors through its return
+            // value; this advisory call does not change Rust aliasing rules.
             unsafe {
                 madvise(data.as_ptr() as *mut c_void, data.len(), MADV_DONTDUMP);
             }
         }
 
         use libc::{c_void, mlock as c_mlock};
+        // SAFETY: `data` is a valid, non-empty byte slice. The OS only pins the
+        // mapped pages for this address range and reports failure via `ret`.
         let ret = unsafe { c_mlock(data.as_ptr() as *const c_void, data.len()) };
         match ret {
             0 => Ok(()),
@@ -284,6 +289,8 @@ fn dryoc_mlock(data: &[u8]) -> Result<(), std::io::Error> {
         use winapi::shared::minwindef::LPVOID;
         use winapi::um::memoryapi::VirtualLock;
 
+        // SAFETY: `data` is a valid, non-empty byte slice. `VirtualLock` pins
+        // the corresponding pages and reports failure through its return value.
         let res = unsafe { VirtualLock(data.as_ptr() as LPVOID, data.len()) };
         match res {
             1 => Ok(()),
@@ -303,12 +310,16 @@ fn dryoc_munlock(data: &[u8]) -> Result<(), std::io::Error> {
         {
             // undo MADV_DONTDUMP
             use libc::{MADV_DODUMP, madvise};
+            // SAFETY: `data` is a valid, non-empty byte slice. This reverses
+            // the advisory dump flag for the same address range.
             unsafe {
                 madvise(data.as_ptr() as *mut c_void, data.len(), MADV_DODUMP);
             }
         }
 
         use libc::{c_void, munlock as c_munlock};
+        // SAFETY: `data` is a valid, non-empty byte slice. The OS unpins the
+        // mapped pages for this address range and reports failure via `ret`.
         let ret = unsafe { c_munlock(data.as_ptr() as *const c_void, data.len()) };
         match ret {
             0 => Ok(()),
@@ -320,6 +331,8 @@ fn dryoc_munlock(data: &[u8]) -> Result<(), std::io::Error> {
         use winapi::shared::minwindef::LPVOID;
         use winapi::um::memoryapi::VirtualUnlock;
 
+        // SAFETY: `data` is a valid, non-empty byte slice. `VirtualUnlock`
+        // unpins the corresponding pages and reports failure via `res`.
         let res = unsafe { VirtualUnlock(data.as_ptr() as LPVOID, data.len()) };
         match res {
             1 => Ok(()),
@@ -336,6 +349,9 @@ fn dryoc_mprotect_readonly(data: &[u8]) -> Result<(), std::io::Error> {
     #[cfg(unix)]
     {
         use libc::{PROT_READ, c_void, mprotect as c_mprotect};
+        // SAFETY: Protected allocations are page-aligned and page-rounded by
+        // `PageAlignedAllocator`; callers pass slices from those allocations.
+        // `mprotect` changes page permissions and reports errors via `ret`.
         let ret = unsafe { c_mprotect(data.as_ptr() as *mut c_void, data.len(), PROT_READ) };
         match ret {
             0 => Ok(()),
@@ -350,6 +366,9 @@ fn dryoc_mprotect_readonly(data: &[u8]) -> Result<(), std::io::Error> {
 
         let mut old: DWORD = 0;
 
+        // SAFETY: Protected allocations come from `VirtualAlloc` and the slice
+        // covers committed pages. `VirtualProtect` changes page permissions and
+        // reports errors via `res`.
         let res =
             unsafe { VirtualProtect(data.as_ptr() as LPVOID, data.len(), PAGE_READONLY, &mut old) };
         match res {
@@ -367,6 +386,9 @@ fn dryoc_mprotect_readwrite(data: &[u8]) -> Result<(), std::io::Error> {
     #[cfg(unix)]
     {
         use libc::{PROT_READ, PROT_WRITE, c_void, mprotect as c_mprotect};
+        // SAFETY: Protected allocations are page-aligned and page-rounded by
+        // `PageAlignedAllocator`; callers pass slices from those allocations.
+        // `mprotect` changes page permissions and reports errors via `ret`.
         let ret = unsafe {
             c_mprotect(
                 data.as_ptr() as *mut c_void,
@@ -387,6 +409,9 @@ fn dryoc_mprotect_readwrite(data: &[u8]) -> Result<(), std::io::Error> {
 
         let mut old: DWORD = 0;
 
+        // SAFETY: Protected allocations come from `VirtualAlloc` and the slice
+        // covers committed pages. `VirtualProtect` changes page permissions and
+        // reports errors via `res`.
         let res = unsafe {
             VirtualProtect(
                 data.as_ptr() as LPVOID,
@@ -410,6 +435,9 @@ fn dryoc_mprotect_noaccess(data: &[u8]) -> Result<(), std::io::Error> {
     #[cfg(unix)]
     {
         use libc::{PROT_NONE, c_void, mprotect as c_mprotect};
+        // SAFETY: Protected allocations are page-aligned and page-rounded by
+        // `PageAlignedAllocator`; callers pass slices from those allocations.
+        // `mprotect` changes page permissions and reports errors via `ret`.
         let ret = unsafe { c_mprotect(data.as_ptr() as *mut c_void, data.len(), PROT_NONE) };
         match ret {
             0 => Ok(()),
@@ -424,6 +452,9 @@ fn dryoc_mprotect_noaccess(data: &[u8]) -> Result<(), std::io::Error> {
 
         let mut old: DWORD = 0;
 
+        // SAFETY: Protected allocations come from `VirtualAlloc` and the slice
+        // covers committed pages. `VirtualProtect` changes page permissions and
+        // reports errors via `res`.
         let res =
             unsafe { VirtualProtect(data.as_ptr() as LPVOID, data.len(), PAGE_NOACCESS, &mut old) };
         match res {
@@ -669,12 +700,16 @@ lazy_static! {
         #[cfg(unix)]
         {
             use libc::{_SC_PAGE_SIZE, sysconf};
+            // SAFETY: `sysconf(_SC_PAGE_SIZE)` has no pointer arguments and
+            // returns the host page size or an error sentinel.
             unsafe { sysconf(_SC_PAGE_SIZE) as usize }
         }
         #[cfg(windows)]
         {
             use winapi::um::sysinfoapi::{GetSystemInfo, SYSTEM_INFO};
             let mut si = SYSTEM_INFO::default();
+            // SAFETY: `si` is a valid writable `SYSTEM_INFO` out-parameter for
+            // the duration of the call.
             unsafe { GetSystemInfo(&mut si) };
             si.dwPageSize as usize
         }
@@ -690,6 +725,10 @@ fn _page_round(size: usize, pagesize: usize) -> Option<usize> {
     }
 }
 
+// SAFETY: `allocate` returns the user slice inside an owned allocation preceded
+// by one guard page. `deallocate` subtracts that same guard-page offset,
+// restores guard-page permissions, and releases the original allocation with
+// the matching platform allocator.
 unsafe impl Allocator for PageAlignedAllocator {
     #[inline]
     fn allocate(&self, layout: Layout) -> Result<ptr::NonNull<[u8]>, AllocError> {
@@ -704,6 +743,9 @@ unsafe impl Allocator for PageAlignedAllocator {
 
             // allocate full pages, in addition to an extra page at the start and
             // end which will remain locked with no access permitted.
+            // SAFETY: `out` is a valid out-parameter. `pagesize` is a power-of-
+            // two page alignment and `size` is a checked page-rounded allocation
+            // size that includes both guard pages.
             let ret = unsafe { posix_memalign(&mut out, pagesize, size) };
             if ret != 0 {
                 return Err(AllocError);
@@ -715,6 +757,9 @@ unsafe impl Allocator for PageAlignedAllocator {
         let out = {
             use winapi::um::memoryapi::VirtualAlloc;
             use winapi::um::winnt::{MEM_COMMIT, MEM_RESERVE, PAGE_READWRITE};
+            // SAFETY: `size` is a checked page-rounded allocation size that
+            // includes both guard pages. Null address lets the OS choose the
+            // base, and failure is handled by checking for null.
             let out = unsafe {
                 VirtualAlloc(
                     ptr::null_mut(),
@@ -730,6 +775,8 @@ unsafe impl Allocator for PageAlignedAllocator {
         };
 
         // lock the pages at the fore of the region
+        // SAFETY: `out` points to `size` bytes returned by the platform
+        // allocator, and the first `pagesize` bytes are within that allocation.
         let fore_protected_region =
             unsafe { std::slice::from_raw_parts_mut(out as *mut u8, pagesize) };
         dryoc_mprotect_noaccess(fore_protected_region)
@@ -738,6 +785,8 @@ unsafe impl Allocator for PageAlignedAllocator {
 
         // lock the pages at the aft of the region
         let aft_protected_region_offset = pagesize.checked_add(rounded_size).ok_or(AllocError)?;
+        // SAFETY: `aft_protected_region_offset` was bounds-checked above and
+        // leaves one full guard page within the allocated `size` bytes.
         let aft_protected_region = unsafe {
             std::slice::from_raw_parts_mut(
                 out.add(aft_protected_region_offset) as *mut u8,
@@ -748,6 +797,9 @@ unsafe impl Allocator for PageAlignedAllocator {
             .map_err(|err| eprintln!("mprotect error = {:?}, in allocator", err))
             .ok();
 
+        // SAFETY: Skipping the first guard page leaves at least `layout.size()`
+        // initialized bytes within the allocation. The returned slice is the
+        // unique user-visible allocation region.
         let slice =
             unsafe { std::slice::from_raw_parts_mut(out.add(pagesize) as *mut u8, layout.size()) };
 
@@ -755,16 +807,28 @@ unsafe impl Allocator for PageAlignedAllocator {
             .map_err(|err| eprintln!("mprotect error = {:?}, in allocator", err))
             .ok();
 
+        // SAFETY: `slice` was just built from a non-null allocation pointer and
+        // is the unique user-visible region returned by this allocator.
         unsafe { Ok(ptr::NonNull::new_unchecked(slice)) }
     }
 
+    /// # Safety
+    ///
+    /// `ptr` must be a user-region pointer previously returned by this
+    /// allocator's `allocate` method with the same `layout`.
     #[inline]
+    // SAFETY: The caller contract above is the `Allocator::deallocate` safety
+    // contract for this implementation.
     unsafe fn deallocate(&self, ptr: ptr::NonNull<u8>, layout: Layout) {
         let pagesize = *PAGESIZE;
 
+        // SAFETY: `ptr` points to the user region returned by `allocate`, which
+        // starts exactly one guard page after the original allocation base.
         let ptr = unsafe { ptr.as_ptr().offset(-(pagesize as isize)) };
 
         // unlock the fore protected region
+        // SAFETY: The original allocation starts at `ptr`, and the first
+        // `pagesize` bytes are the fore guard page.
         let fore_protected_region = unsafe { std::slice::from_raw_parts_mut(ptr, pagesize) };
         dryoc_mprotect_readwrite(fore_protected_region)
             .map_err(|err| eprintln!("mprotect error = {:?}", err))
@@ -774,6 +838,8 @@ unsafe impl Allocator for PageAlignedAllocator {
         if let Some(aft_protected_region_offset) =
             _page_round(layout.size(), pagesize).and_then(|size| pagesize.checked_add(size))
         {
+            // SAFETY: The offset mirrors `allocate` and points to the aft guard
+            // page within the original allocation.
             let aft_protected_region = unsafe {
                 std::slice::from_raw_parts_mut(ptr.add(aft_protected_region_offset), pagesize)
             };
@@ -785,6 +851,8 @@ unsafe impl Allocator for PageAlignedAllocator {
 
         #[cfg(unix)]
         {
+            // SAFETY: `ptr` is the original allocation base returned by
+            // `posix_memalign`.
             unsafe { libc::free(ptr as *mut libc::c_void) };
         }
         #[cfg(windows)]
@@ -792,6 +860,9 @@ unsafe impl Allocator for PageAlignedAllocator {
             use winapi::shared::minwindef::LPVOID;
             use winapi::um::memoryapi::VirtualFree;
             use winapi::um::winnt::MEM_RELEASE;
+            // SAFETY: `ptr` is the original allocation base returned by
+            // `VirtualAlloc`; size 0 with `MEM_RELEASE` releases the whole
+            // region.
             unsafe { VirtualFree(ptr as LPVOID, 0, MEM_RELEASE) };
         }
     }
@@ -1010,6 +1081,8 @@ impl<A: Zeroize + MutBytes, LM: traits::LockMode> MutBytes for Protected<A, trai
 impl<const LENGTH: usize> std::convert::AsRef<[u8; LENGTH]> for HeapByteArray<LENGTH> {
     fn as_ref(&self) -> &[u8; LENGTH] {
         let arr = self.0.as_ptr() as *const [u8; LENGTH];
+        // SAFETY: `HeapByteArray<LENGTH>` always allocates exactly `LENGTH`
+        // initialized bytes, and `[u8; LENGTH]` has alignment 1.
         unsafe { &*arr }
     }
 }
@@ -1017,6 +1090,8 @@ impl<const LENGTH: usize> std::convert::AsRef<[u8; LENGTH]> for HeapByteArray<LE
 impl<const LENGTH: usize> std::convert::AsMut<[u8; LENGTH]> for HeapByteArray<LENGTH> {
     fn as_mut(&mut self) -> &mut [u8; LENGTH] {
         let arr = self.0.as_mut_ptr() as *mut [u8; LENGTH];
+        // SAFETY: `HeapByteArray<LENGTH>` always allocates exactly `LENGTH`
+        // initialized bytes. `&mut self` provides exclusive access to them.
         unsafe { &mut *arr }
     }
 }
@@ -1251,8 +1326,9 @@ impl From<&[u8]> for HeapBytes {
 impl<const LENGTH: usize> ByteArray<LENGTH> for HeapByteArray<LENGTH> {
     #[inline]
     fn as_array(&self) -> &[u8; LENGTH] {
-        // this is safe for fixed-length arrays
         let ptr = self.0.as_ptr() as *const [u8; LENGTH];
+        // SAFETY: `HeapByteArray<LENGTH>` always allocates exactly `LENGTH`
+        // initialized bytes, and `[u8; LENGTH]` has alignment 1.
         unsafe { &*ptr }
     }
 }
@@ -1319,8 +1395,9 @@ impl<const LENGTH: usize> NewByteArray<LENGTH> for HeapByteArray<LENGTH> {
 
 impl<const LENGTH: usize> MutByteArray<LENGTH> for HeapByteArray<LENGTH> {
     fn as_mut_array(&mut self) -> &mut [u8; LENGTH] {
-        // this is safe for fixed-length arrays
-        let ptr = self.0.as_ptr() as *mut [u8; LENGTH];
+        let ptr = self.0.as_mut_ptr() as *mut [u8; LENGTH];
+        // SAFETY: `HeapByteArray<LENGTH>` always allocates exactly `LENGTH`
+        // initialized bytes. `&mut self` provides exclusive access to them.
         unsafe { &mut *ptr }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -153,7 +153,10 @@ impl<const LENGTH: usize> MutByteArray<LENGTH> for Vec<u8> {
             self.len(),
             LENGTH
         );
-        let arr = self.as_ptr() as *mut [u8; LENGTH];
+        let arr = self.as_mut_ptr() as *mut [u8; LENGTH];
+        // SAFETY: The assertion above guarantees the vector has at least
+        // `LENGTH` initialized bytes. `[u8; LENGTH]` has alignment 1, and the
+        // exclusive `&mut self` borrow prevents aliasing the returned prefix.
         unsafe { &mut *arr }
     }
 }
@@ -168,6 +171,9 @@ impl<const LENGTH: usize> ByteArray<LENGTH> for Vec<u8> {
             LENGTH
         );
         let arr = self.as_ptr() as *const [u8; LENGTH];
+        // SAFETY: The assertion above guarantees the vector has at least
+        // `LENGTH` initialized bytes. `[u8; LENGTH]` has alignment 1, so the
+        // first `LENGTH` bytes can be viewed as a fixed-size byte array.
         unsafe { &*arr }
     }
 }
@@ -354,6 +360,9 @@ impl<const LENGTH: usize> ByteArray<LENGTH> for &[u8] {
             LENGTH
         );
         let arr = self.as_ptr() as *const [u8; LENGTH];
+        // SAFETY: The assertion above guarantees the slice has at least
+        // `LENGTH` initialized bytes. `[u8; LENGTH]` has alignment 1, so the
+        // first `LENGTH` bytes can be viewed as a fixed-size byte array.
         unsafe { &*arr }
     }
 }
@@ -368,6 +377,9 @@ impl<const LENGTH: usize> ByteArray<LENGTH> for [u8] {
             LENGTH
         );
         let arr = self.as_ptr() as *const [u8; LENGTH];
+        // SAFETY: The assertion above guarantees the slice has at least
+        // `LENGTH` initialized bytes. `[u8; LENGTH]` has alignment 1, so the
+        // first `LENGTH` bytes can be viewed as a fixed-size byte array.
         unsafe { &*arr }
     }
 }
@@ -381,6 +393,9 @@ impl<const LENGTH: usize> MutByteArray<LENGTH> for [u8] {
             LENGTH
         );
         let arr = self.as_mut_ptr() as *mut [u8; LENGTH];
+        // SAFETY: The assertion above guarantees the slice has at least
+        // `LENGTH` initialized bytes. `[u8; LENGTH]` has alignment 1, and
+        // `&mut self` provides exclusive access to the returned prefix.
         unsafe { &mut *arr }
     }
 }
@@ -406,6 +421,8 @@ impl<const LENGTH: usize> StackByteArray<LENGTH> {
 impl<const LENGTH: usize> std::convert::AsRef<[u8; LENGTH]> for StackByteArray<LENGTH> {
     fn as_ref(&self) -> &[u8; LENGTH] {
         let arr = self.0.as_ptr() as *const [u8; LENGTH];
+        // SAFETY: `StackByteArray<LENGTH>` stores exactly `[u8; LENGTH]` in
+        // `self.0`, so this cast preserves size, alignment, and initialization.
         unsafe { &*arr }
     }
 }
@@ -413,6 +430,8 @@ impl<const LENGTH: usize> std::convert::AsRef<[u8; LENGTH]> for StackByteArray<L
 impl<const LENGTH: usize> std::convert::AsMut<[u8; LENGTH]> for StackByteArray<LENGTH> {
     fn as_mut(&mut self) -> &mut [u8; LENGTH] {
         let arr = self.0.as_mut_ptr() as *mut [u8; LENGTH];
+        // SAFETY: `StackByteArray<LENGTH>` stores exactly `[u8; LENGTH]` in
+        // `self.0`, and `&mut self` provides exclusive access to it.
         unsafe { &mut *arr }
     }
 }


### PR DESCRIPTION
## Summary

Document and justify dryoc's non-test unsafe code usage. This adds a crate-level and README unsafe inventory, adds local `SAFETY:` comments around existing non-test unsafe blocks and unsafe impls, and updates AGENTS.md with guidance for future unsafe changes.

## User Impact

Users and maintainers get a clearer view of where unsafe code exists, which feature gates expose it, and which invariants make each use acceptable. This is especially useful for security review of the protected-memory, SIMD, byte-view, and serialization surfaces.

## Root Cause

Unsafe usage was present in a few constrained areas, but the justifications were not consistently recorded next to the unsafe code and there was no central inventory in the public docs.

## Fix

The branch adds `SAFETY:` comments for non-test unsafe code, documents the unsafe inventory in `src/lib.rs` and `README.md`, clarifies that test-only unsafe is limited to compatibility checks and platform probes, and adds contributor guidance requiring future unsafe updates to keep the inventory current.

## Validation

- `cargo check`
- `cargo clippy --features default -- -D warnings`
- `cargo +nightly check --features simd_backend,nightly,wincode`
- `cargo +nightly doc --no-deps --features nightly,serde,base64,wincode`
