### PR TITLE
docs: link README unsafe note to rustdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,21 +94,6 @@ and [`wincode::SchemaRead`](https://docs.rs/wincode/latest/wincode/trait.SchemaR
 for supported Rustaceous box types, including `DryocBox` and
 `DryocSecretBox`.
 
-## Unsafe code
-
-Non-test `unsafe` code is limited to these areas:
-
-| Area | Feature gate | Why `unsafe` is required |
-|-|-|-|
-| `src/types.rs` fixed-size byte views | Always available | Converts validated byte slices and vectors into `[u8; N]` references without copying. Each cast is guarded by a length check or an exact-size wrapper invariant. |
-| `src/dryocbox.rs` and `src/dryocsecretbox.rs` wincode impls | `wincode` | Implements `unsafe` wincode schema traits for the Rustaceous box wire format. The implementations write and read initialized fields in the same order. |
-| `src/blake2b/blake2b_soft.rs` and `src/blake2b/blake2b_simd.rs` parameter blocks | Always available for the soft backend; `simd_backend,nightly` for SIMD | Views a `repr(C, packed)` BLAKE2b parameter block as bytes so the initialization vector is mixed exactly as specified. The parameter type contains only initialized byte fields. |
-| `src/protected.rs` protected memory | `nightly` | Calls OS APIs such as `mlock`, `mprotect`, `VirtualLock`, and `VirtualProtect`, implements a page-aligned guard-page allocator, and exposes exact-size byte-array views over protected heap buffers. |
-| `src/classic/salsa20_simd.rs` Salsa20 SIMD backend | `simd_backend,nightly` | Performs little-endian unaligned word XOR in 256-byte chunks and volatile zeroization of cached SIMD lanes containing derived key material. |
-
-Test-only unsafe code is used for libsodium and Argon2 compatibility checks and
-protected-memory platform probes; it is not part of the runtime crate API.
-
 ## Project status
 
 The following libsodium features are currently implemented, or awaiting
@@ -160,5 +145,6 @@ in Rust. Some optional SIMD code, including dependency-provided SIMD
 implementations and small internal helpers, may contain unsafe code. In
 particular, many SIMD implementations are considered "unsafe" due to their use
 of assembly or intrinsics, however without SIMD-based cryptography you may be
-exposed to timing attacks. See the unsafe code section above for the non-test
-unsafe inventory in this crate.
+exposed to timing attacks. See the
+[rustdoc unsafe code summary](https://docs.rs/dryoc/latest/dryoc/#unsafe-code)
+for the non-test unsafe inventory in this crate.


### PR DESCRIPTION
## Summary

Removes the duplicated unsafe-code inventory from the README and keeps the README footnote for the "mostly free of unsafe code" claim pointed at the crate rustdocs instead.

## User Impact

Readers no longer have to reconcile two copies of the unsafe-code summary. The README sends them to the canonical rustdoc section that will be published on docs.rs with the next release.

## Root Cause

The unsafe-code inventory was maintained in both `README.md` and the crate-level rustdocs, which made the README duplicate detailed security-sensitive documentation.

## Fix

Deleted the README `## Unsafe code` section and changed footnote `[^2]` to link to `https://docs.rs/dryoc/latest/dryoc/#unsafe-code`.

## Validation

Ran `cargo +nightly doc --no-deps --features nightly,serde,base64,wincode` successfully and verified the generated crate docs include the `#unsafe-code` anchor.
