### PR TITLE
perf: add Argon2 SIMD block mixing

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -20,18 +20,21 @@ These results were collected on:
 Commands used for the rows below:
 
 ```sh
-RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features nightly blake2b_bench
-RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features simd_backend,nightly blake2b_bench
-RUSTFLAGS="-Ctarget-cpu=native" cargo +nightly bench --features nightly poly1305
-RUSTFLAGS="-Ctarget-cpu=native" cargo +nightly bench --features simd_backend,nightly poly1305
-RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features nightly crypto_secretbox_detached
-RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=+neon" cargo +nightly bench --features simd_backend,nightly crypto_secretbox_detached
+export RUSTFLAGS="-Ctarget-cpu=native"
+
+bench_pair() {
+    cargo +nightly bench --features nightly "$1"
+    cargo +nightly bench --features simd_backend,nightly "$1"
+}
+
+bench_pair blake2b_bench
+bench_pair poly1305
+bench_pair crypto_secretbox_detached
+bench_pair argon2id_64kib_bench
+bench_pair argon2id_1mib_bench
 ```
 
-`neon` is already reported by `rustc +nightly --print cfg` on this target.
-Some commands include it explicitly along with `target-cpu=native`; adding
-`-Ctarget-feature=+neon` is not expected to change native Apple Silicon
-results.
+On Apple Silicon, `target-cpu=native` already enables NEON for this target.
 Run `cargo +nightly bench` without a benchmark-name filter to collect the full
 suite.
 
@@ -109,6 +112,20 @@ messages benefit from the Salsa20 path processing four independent counter
 blocks in parallel. Small messages are slower in this run because fixed XSalsa20
 setup plus Poly1305 SIMD overhead dominates the short payload.
 
+## Password Hashing: Argon2id
+
+Benchmark: `argon2_hash` with a fixed 32-byte password, 16-byte salt, 32-byte
+output, `t=2`, and `p=1`.
+
+| Memory cost | Software time | Software throughput | SIMD time | SIMD throughput | Relative |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 64 KiB | `74,998.33 ns/iter` | `1,747 MB/s` | `48,813.80 ns/iter` | `2,685 MB/s` | `1.54x faster` |
+| 1 MiB | `813,129.10 ns/iter` | `2,579 MB/s` | `587,006.25 ns/iter` | `3,572 MB/s` | `1.39x faster` |
+
+The portable SIMD Argon2 path vectorizes the four independent BlaMka G
+operations inside each block-mixing round. The surrounding memory indexing and
+lane scheduling remain shared with the software path.
+
 ## Benchmark Coverage
 
 Current side-by-side software/SIMD benchmark coverage:
@@ -118,6 +135,7 @@ Current side-by-side software/SIMD benchmark coverage:
 | BLAKE2b | `blake2b_soft` | `blake2b_simd` | Yes |
 | Poly1305 | `poly1305_soft` | `poly1305_simd` | Yes |
 | XSalsa20-Poly1305 secretbox | RustCrypto `salsa20` + `poly1305_soft` | portable-SIMD Salsa20 + `poly1305_simd` | Yes |
+| Argon2id password hashing | scalar Argon2 block mixer | portable-SIMD Argon2 block mixer | Yes |
 
 Algorithms without side-by-side benchmark coverage should get their own section
 when a second implementation is added or when performance work begins.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ For example usage, refer to the
 * Protected memory handling (`mprotect()` + `mlock()`, along with Windows equivalents)
 * [Serde](https://serde.rs/) support (with `features = ["serde"]`)
 * [wincode](https://crates.io/crates/wincode) support for direct binary serialization of Rustaceous box types (with `features = ["wincode"]`)
-* [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html) implementation for Blake2b (used by generic hashing, password hashing, and key derivation) on nightly, with `features = ["simd_backend", "nightly"]`
-* [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html) implementation for Salsa20 (used by XSalsa20-Poly1305 secretbox) on nightly, with `features = ["simd_backend", "nightly"]`
-* [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html) implementation for Poly1305 (used by one-time authentication and secret boxes) on nightly, with `features = ["simd_backend", "nightly"]`
+* [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html) implementations on nightly, with `features = ["simd_backend", "nightly"]`:
+  * Blake2b (used by generic hashing, password hashing, and key derivation)
+  * Argon2 block mixing (used by password hashing)
+  * Salsa20 (used by XSalsa20-Poly1305 secretbox)
+  * Poly1305 (used by one-time authentication and secret boxes)
 * [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek) (used by public/private key functions) selects its own serial or x86_64 vector backend at build time
 * [SHA2](https://github.com/RustCrypto/hashes/tree/master/sha2) (used by sealed boxes) includes SIMD implementation for AVX2
 * [ChaCha20](https://github.com/RustCrypto/stream-ciphers/tree/master/chacha20) (used by streaming interface) includes SIMD implementations for NEON, AVX2, and SSE2

--- a/src/argon2/argon2_simd.rs
+++ b/src/argon2/argon2_simd.rs
@@ -1,0 +1,82 @@
+use std::simd::{Simd, simd_swizzle};
+
+use super::{Block, finalize_block, prepare_block};
+
+#[inline]
+pub(super) fn fill_block(
+    prev_block: &Block,
+    ref_block: &Block,
+    next_block: Option<&Block>,
+) -> Block {
+    let (mut block_r, block_tmp) = prepare_block(prev_block, ref_block, next_block);
+    apply_block_rounds!(&mut block_r, blake2_round_nomsg_simd);
+    finalize_block(block_tmp, &block_r)
+}
+
+#[inline(always)]
+fn rotr64x4<const N: u64>(v: Simd<u64, 4>) -> Simd<u64, 4> {
+    (v >> Simd::splat(N)) | (v << Simd::splat(64 - N))
+}
+
+#[inline(always)]
+fn fblamka_x4(x: Simd<u64, 4>, y: Simd<u64, 4>) -> Simd<u64, 4> {
+    let m = Simd::splat(0xFFFFFFFFu64);
+    let xy = (x & m) * (y & m);
+    x + y + xy + xy
+}
+
+#[inline(always)]
+fn g_simd(a: &mut Simd<u64, 4>, b: &mut Simd<u64, 4>, c: &mut Simd<u64, 4>, d: &mut Simd<u64, 4>) {
+    *a = fblamka_x4(*a, *b);
+    *d = rotr64x4::<32>(*d ^ *a);
+    *c = fblamka_x4(*c, *d);
+    *b = rotr64x4::<24>(*b ^ *c);
+    *a = fblamka_x4(*a, *b);
+    *d = rotr64x4::<16>(*d ^ *a);
+    *c = fblamka_x4(*c, *d);
+    *b = rotr64x4::<63>(*b ^ *c);
+}
+
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+fn blake2_round_nomsg_simd(
+    block: &mut Block,
+    v0: usize,
+    v1: usize,
+    v2: usize,
+    v3: usize,
+    v4: usize,
+    v5: usize,
+    v6: usize,
+    v7: usize,
+    v8: usize,
+    v9: usize,
+    v10: usize,
+    v11: usize,
+    v12: usize,
+    v13: usize,
+    v14: usize,
+    v15: usize,
+) {
+    let mut a = Simd::from_array([block.v[v0], block.v[v1], block.v[v2], block.v[v3]]);
+    let mut b = Simd::from_array([block.v[v4], block.v[v5], block.v[v6], block.v[v7]]);
+    let mut c = Simd::from_array([block.v[v8], block.v[v9], block.v[v10], block.v[v11]]);
+    let mut d = Simd::from_array([block.v[v12], block.v[v13], block.v[v14], block.v[v15]]);
+
+    g_simd(&mut a, &mut b, &mut c, &mut d);
+
+    b = simd_swizzle!(b, [1, 2, 3, 0]);
+    c = simd_swizzle!(c, [2, 3, 0, 1]);
+    d = simd_swizzle!(d, [3, 0, 1, 2]);
+
+    g_simd(&mut a, &mut b, &mut c, &mut d);
+
+    b = simd_swizzle!(b, [3, 0, 1, 2]);
+    c = simd_swizzle!(c, [2, 3, 0, 1]);
+    d = simd_swizzle!(d, [1, 2, 3, 0]);
+
+    [block.v[v0], block.v[v1], block.v[v2], block.v[v3]] = a.to_array();
+    [block.v[v4], block.v[v5], block.v[v6], block.v[v7]] = b.to_array();
+    [block.v[v8], block.v[v9], block.v[v10], block.v[v11]] = c.to_array();
+    [block.v[v12], block.v[v13], block.v[v14], block.v[v15]] = d.to_array();
+}

--- a/src/argon2/argon2_soft.rs
+++ b/src/argon2/argon2_soft.rs
@@ -1,0 +1,62 @@
+use super::{Block, finalize_block, prepare_block};
+use crate::utils::rotr64;
+
+#[inline]
+pub(super) fn fill_block(
+    prev_block: &Block,
+    ref_block: &Block,
+    next_block: Option<&Block>,
+) -> Block {
+    let (mut block_r, block_tmp) = prepare_block(prev_block, ref_block, next_block);
+    apply_block_rounds!(&mut block_r, blake2_round_nomsg);
+    finalize_block(block_tmp, &block_r)
+}
+
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn blake2_round_nomsg(
+    block: &mut Block,
+    v0: usize,
+    v1: usize,
+    v2: usize,
+    v3: usize,
+    v4: usize,
+    v5: usize,
+    v6: usize,
+    v7: usize,
+    v8: usize,
+    v9: usize,
+    v10: usize,
+    v11: usize,
+    v12: usize,
+    v13: usize,
+    v14: usize,
+    v15: usize,
+) {
+    let g = |block: &mut Block, a, b, c, d| {
+        block.v[a] = fblamka(block.v[a], block.v[b]);
+        block.v[d] = rotr64(block.v[d] ^ block.v[a], 32);
+        block.v[c] = fblamka(block.v[c], block.v[d]);
+        block.v[b] = rotr64(block.v[b] ^ block.v[c], 24);
+        block.v[a] = fblamka(block.v[a], block.v[b]);
+        block.v[d] = rotr64(block.v[d] ^ block.v[a], 16);
+        block.v[c] = fblamka(block.v[c], block.v[d]);
+        block.v[b] = rotr64(block.v[b] ^ block.v[c], 63);
+    };
+
+    g(block, v0, v4, v8, v12);
+    g(block, v1, v5, v9, v13);
+    g(block, v2, v6, v10, v14);
+    g(block, v3, v7, v11, v15);
+    g(block, v0, v5, v10, v15);
+    g(block, v1, v6, v11, v12);
+    g(block, v2, v7, v8, v13);
+    g(block, v3, v4, v9, v14);
+}
+
+#[inline]
+fn fblamka(x: u64, y: u64) -> u64 {
+    let m = 0xFFFFFFFFu64;
+    let xy = (x & m) * (y & m);
+    x.wrapping_add(y).wrapping_add(2u64.wrapping_mul(xy))
+}

--- a/src/argon2/mod.rs
+++ b/src/argon2/mod.rs
@@ -2,7 +2,7 @@ use zeroize::Zeroize;
 
 use crate::blake2b;
 use crate::error::Error;
-use crate::utils::{load_u64_le, rotr64};
+use crate::utils::load_u64_le;
 
 // Version of the algorithm
 pub(crate) const ARGON2_VERSION_NUMBER: u32 = 0x13;
@@ -69,6 +69,7 @@ pub(crate) enum Argon2Type {
 }
 
 #[derive(Clone)]
+#[repr(align(64))]
 struct Block {
     v: [u64; ARGON2_QWORDS_IN_BLOCK],
 }
@@ -81,6 +82,64 @@ impl Default for Block {
         }
     }
 }
+
+macro_rules! apply_block_rounds {
+    ($block:expr, $round:ident) => {{
+        for i in 0..8 {
+            $round(
+                $block,
+                16 * i,
+                16 * i + 1,
+                16 * i + 2,
+                16 * i + 3,
+                16 * i + 4,
+                16 * i + 5,
+                16 * i + 6,
+                16 * i + 7,
+                16 * i + 8,
+                16 * i + 9,
+                16 * i + 10,
+                16 * i + 11,
+                16 * i + 12,
+                16 * i + 13,
+                16 * i + 14,
+                16 * i + 15,
+            );
+        }
+
+        for i in 0..8 {
+            $round(
+                $block,
+                2 * i,
+                2 * i + 1,
+                2 * i + 16,
+                2 * i + 17,
+                2 * i + 32,
+                2 * i + 33,
+                2 * i + 48,
+                2 * i + 49,
+                2 * i + 64,
+                2 * i + 65,
+                2 * i + 80,
+                2 * i + 81,
+                2 * i + 96,
+                2 * i + 97,
+                2 * i + 112,
+                2 * i + 113,
+            );
+        }
+    }};
+}
+
+#[cfg(all(feature = "simd_backend", feature = "nightly"))]
+mod argon2_simd;
+#[cfg(any(test, not(all(feature = "simd_backend", feature = "nightly"))))]
+mod argon2_soft;
+
+#[cfg(all(feature = "simd_backend", feature = "nightly"))]
+use argon2_simd::fill_block;
+#[cfg(not(all(feature = "simd_backend", feature = "nightly")))]
+use argon2_soft::fill_block;
 
 #[derive(Default)]
 struct BlockRegion {
@@ -398,12 +457,19 @@ fn fill_segment(instance: &mut Argon2Instance, position: &mut Argon2Position) {
             ref_lane == position.lane as u64,
         );
 
-        let prev_block = &instance.region.memory[prev_offset as usize];
-        let ref_block = &instance.region.memory
-            [(instance.lane_length as u64 * ref_lane + ref_index as u64) as usize];
-        let mut next_block = instance.region.memory[curr_offset as usize].clone();
+        let next_block = {
+            let memory = &instance.region.memory;
+            let prev_block = &memory[prev_offset as usize];
+            let ref_block =
+                &memory[(instance.lane_length as u64 * ref_lane + ref_index as u64) as usize];
+            let curr_block = if position.pass == 0 {
+                None
+            } else {
+                Some(&memory[curr_offset as usize])
+            };
 
-        fill_block(prev_block, ref_block, &mut next_block, position.pass != 0);
+            fill_block(prev_block, ref_block, curr_block)
+        };
 
         instance.region.memory[curr_offset as usize] = next_block;
         prev_offset += 1;
@@ -476,7 +542,6 @@ fn generate_addresses(instance: &mut Argon2Instance, position: &Argon2Position) 
     let mut input_block = Block::default();
     let zero_block = Block::default();
     let mut address_block = Block::default();
-    let mut tmp_block = Block::default();
 
     input_block.v[0] = position.pass as u64;
     input_block.v[1] = position.lane as u64;
@@ -488,10 +553,8 @@ fn generate_addresses(instance: &mut Argon2Instance, position: &Argon2Position) 
     for i in 0..instance.segment_length {
         if i.is_multiple_of(ARGON2_ADDRESSES_IN_BLOCK) {
             input_block.v[6] += 1;
-            tmp_block.v.fill(0);
-            address_block.v.fill(0);
-            fill_block(&zero_block, &input_block, &mut tmp_block, true);
-            fill_block(&zero_block, &tmp_block, &mut address_block, true);
+            let tmp_block = fill_block(&zero_block, &input_block, None);
+            address_block = fill_block(&zero_block, &tmp_block, None);
         }
 
         instance.pseudo_rands[i as usize] =
@@ -500,112 +563,26 @@ fn generate_addresses(instance: &mut Argon2Instance, position: &Argon2Position) 
 }
 
 #[inline]
-fn fill_block(prev_block: &Block, ref_block: &Block, next_block: &mut Block, with_xor: bool) {
-    let mut block_r = Block::default();
-    let mut block_tmp = Block::default();
-
-    copy_block(&mut block_r, ref_block);
+fn prepare_block(
+    prev_block: &Block,
+    ref_block: &Block,
+    next_block: Option<&Block>,
+) -> (Block, Block) {
+    let mut block_r = ref_block.clone();
     xor_block(&mut block_r, prev_block);
-    copy_block(&mut block_tmp, &block_r);
-    if with_xor {
+
+    let mut block_tmp = block_r.clone();
+    if let Some(next_block) = next_block {
         xor_block(&mut block_tmp, next_block);
     }
 
-    for i in 0..8 {
-        blake2_round_nomsg(
-            &mut block_r,
-            16 * i,
-            16 * i + 1,
-            16 * i + 2,
-            16 * i + 3,
-            16 * i + 4,
-            16 * i + 5,
-            16 * i + 6,
-            16 * i + 7,
-            16 * i + 8,
-            16 * i + 9,
-            16 * i + 10,
-            16 * i + 11,
-            16 * i + 12,
-            16 * i + 13,
-            16 * i + 14,
-            16 * i + 15,
-        );
-    }
-
-    for i in 0..8 {
-        blake2_round_nomsg(
-            &mut block_r,
-            2 * i,
-            2 * i + 1,
-            2 * i + 16,
-            2 * i + 17,
-            2 * i + 32,
-            2 * i + 33,
-            2 * i + 48,
-            2 * i + 49,
-            2 * i + 64,
-            2 * i + 65,
-            2 * i + 80,
-            2 * i + 81,
-            2 * i + 96,
-            2 * i + 97,
-            2 * i + 112,
-            2 * i + 113,
-        );
-    }
-
-    copy_block(next_block, &block_tmp);
-    xor_block(next_block, &block_r);
+    (block_r, block_tmp)
 }
 
 #[inline]
-#[allow(clippy::too_many_arguments)]
-fn blake2_round_nomsg(
-    block: &mut Block,
-    v0: usize,
-    v1: usize,
-    v2: usize,
-    v3: usize,
-    v4: usize,
-    v5: usize,
-    v6: usize,
-    v7: usize,
-    v8: usize,
-    v9: usize,
-    v10: usize,
-    v11: usize,
-    v12: usize,
-    v13: usize,
-    v14: usize,
-    v15: usize,
-) {
-    let g = |block: &mut Block, a, b, c, d| {
-        block.v[a] = fblamka(block.v[a], block.v[b]);
-        block.v[d] = rotr64(block.v[d] ^ block.v[a], 32);
-        block.v[c] = fblamka(block.v[c], block.v[d]);
-        block.v[b] = rotr64(block.v[b] ^ block.v[c], 24);
-        block.v[a] = fblamka(block.v[a], block.v[b]);
-        block.v[d] = rotr64(block.v[d] ^ block.v[a], 16);
-        block.v[c] = fblamka(block.v[c], block.v[d]);
-        block.v[b] = rotr64(block.v[b] ^ block.v[c], 63);
-    };
-
-    g(block, v0, v4, v8, v12);
-    g(block, v1, v5, v9, v13);
-    g(block, v2, v6, v10, v14);
-    g(block, v3, v7, v11, v15);
-    g(block, v0, v5, v10, v15);
-    g(block, v1, v6, v11, v12);
-    g(block, v2, v7, v8, v13);
-    g(block, v3, v4, v9, v14);
-}
-
-#[inline]
-fn fblamka(x: u64, y: u64) -> u64 {
-    let m = 0xFFFFFFFFu64;
-    let xy = (x & m) * (y & m);
-    x.wrapping_add(y).wrapping_add(2u64.wrapping_mul(xy))
+fn finalize_block(mut block_tmp: Block, block_r: &Block) -> Block {
+    xor_block(&mut block_tmp, block_r);
+    block_tmp
 }
 
 fn copy_block(dst: &mut Block, src: &Block) {
@@ -670,7 +647,72 @@ fn store_block(output: &mut [u8], block: &Block) {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "nightly")]
+    extern crate test;
+
     use super::*;
+
+    #[cfg(feature = "nightly")]
+    fn bench_argon2id(b: &mut test::Bencher, t_cost: u32, m_cost: u32) {
+        let password = [1u8; 32];
+        let salt = [2u8; 16];
+        let mut hash = [0u8; 32];
+
+        b.bytes = t_cost as u64 * m_cost as u64 * 1024;
+        b.iter(|| {
+            super::argon2_hash(
+                test::black_box(t_cost),
+                test::black_box(m_cost),
+                1,
+                test::black_box(&password),
+                test::black_box(&salt),
+                None,
+                None,
+                test::black_box(&mut hash),
+                Argon2Type::Argon2id,
+            )
+            .expect("argon2_hash failed");
+            test::black_box(&hash);
+        });
+    }
+
+    #[cfg(all(feature = "simd_backend", feature = "nightly"))]
+    fn test_block(seed: u64) -> Block {
+        let mut block = Block::default();
+        for (i, word) in block.v.iter_mut().enumerate() {
+            let i = i as u64;
+            *word = seed
+                .wrapping_add(i.wrapping_mul(0x9e37_79b9_7f4a_7c15))
+                .rotate_left((i % 64) as u32);
+        }
+        block
+    }
+
+    #[cfg(all(feature = "simd_backend", feature = "nightly"))]
+    #[test]
+    fn test_fill_block_simd_matches_soft() {
+        let cases = [
+            (Block::default(), Block::default(), None),
+            (test_block(0), test_block(1), None),
+            (
+                test_block(0x0123_4567_89ab_cdef),
+                test_block(0xfedc_ba98_7654_3210),
+                None,
+            ),
+            (
+                test_block(0x1111_2222_3333_4444),
+                test_block(0x5555_6666_7777_8888),
+                Some(test_block(0x9999_aaaa_bbbb_cccc)),
+            ),
+        ];
+
+        for (prev_block, ref_block, next_block) in cases {
+            let soft = argon2_soft::fill_block(&prev_block, &ref_block, next_block.as_ref());
+            let simd = argon2_simd::fill_block(&prev_block, &ref_block, next_block.as_ref());
+
+            assert_eq!(soft.v, simd.v);
+        }
+    }
 
     #[test]
     fn test_vector_argon2i() {
@@ -800,5 +842,17 @@ mod tests {
                 132, 187, 20, 129, 150, 215, 60, 29, 241, 172, 175, 109, 12, 46
             ]
         );
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn argon2id_64kib_bench(b: &mut test::Bencher) {
+        bench_argon2id(b, 2, 64);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn argon2id_1mib_bench(b: &mut test::Bencher) {
+        bench_argon2id(b, 2, 1024);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,14 +41,11 @@
 //! * [wincode](https://crates.io/crates/wincode) support for direct binary
 //!   serialization of Rustaceous box types (with `features = ["wincode"]`)
 //! * [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html)
-//!   implementation for Blake2b (used by generic hashing, password hashing, and
-//!   key derivation) on nightly, with `features = ["simd_backend", "nightly"]`
-//! * [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html)
-//!   implementation for Salsa20 (used by XSalsa20-Poly1305 secretbox) on
-//!   nightly, with `features = ["simd_backend", "nightly"]`
-//! * [_Portable_ SIMD](https://doc.rust-lang.org/std/simd/index.html)
-//!   implementation for Poly1305 (used by one-time authentication and secret
-//!   boxes) on nightly, with `features = ["simd_backend", "nightly"]`
+//!   implementations on nightly, with `features = ["simd_backend", "nightly"]`:
+//!   * Blake2b (used by generic hashing, password hashing, and key derivation)
+//!   * Argon2 block mixing (used by password hashing)
+//!   * Salsa20 (used by XSalsa20-Poly1305 secretbox)
+//!   * Poly1305 (used by one-time authentication and secret boxes)
 //! * [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek)
 //!   (used by public/private key functions) selects its own serial or x86_64
 //!   vector backend at build time

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -45,6 +45,7 @@ pub(crate) fn load_u32_le(bytes: &[u8]) -> u32 {
 }
 
 #[inline]
+#[cfg_attr(all(feature = "simd_backend", feature = "nightly"), allow(dead_code))]
 pub(crate) fn rotr64(x: u64, b: u32) -> u64 {
     x.rotate_right(b)
 }


### PR DESCRIPTION
## Summary

Adds a portable SIMD Argon2 block-mixing backend behind `simd_backend,nightly`, keeps the scalar backend as the default path, and splits Argon2 backend code into soft/SIMD modules to match the existing backend layout.

## User Impact

Password hashing can use the SIMD backend on nightly builds that opt into `simd_backend`, improving Argon2id throughput while preserving the default software implementation and existing public API behavior.

## Root Cause

Argon2 block mixing previously only used the scalar BlaMka round implementation, even though the round contains independent operations that can be evaluated in SIMD lanes. The Argon2 implementation was also monolithic, unlike the crate's other SIMD-backed primitives.

## Fix

- Move Argon2 into `src/argon2/mod.rs` with shared scheduling, block preparation, and finalization logic.
- Add `argon2_soft` and `argon2_simd` backend modules selected by feature gates.
- Add a SIMD equivalence test that compares soft and SIMD block-mixing output directly.
- Document the Argon2 SIMD backend and add benchmark coverage/results.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo test`
- `cargo +nightly test --features simd_backend,nightly`
- `cargo clippy --features default -- -D warnings`
- `cargo +nightly clippy --features simd_backend,nightly -- -D warnings`
- `git diff --check HEAD`
