### PR TITLE
test: add wasm compatibility coverage

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,6 +15,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  wasm:
+    name: wasm32-unknown-unknown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup stable Rust toolchain with caching
+        uses: brndnmtthws/rust-action@v1
+        with:
+          toolchain: stable
+      - run: rustup target add wasm32-unknown-unknown
+      - name: Install matching wasm-bindgen test runner
+        run: |
+          WASM_BINDGEN_VERSION="$(
+            cargo tree --target wasm32-unknown-unknown --features serde,base64,wincode \
+              | sed -n 's/.*wasm-bindgen v\([0-9.]*\).*/\1/p' \
+              | head -n 1
+          )"
+          cargo install wasm-bindgen-cli --version "$WASM_BINDGEN_VERSION" --locked
+      - run: cargo test --target wasm32-unknown-unknown --features serde,base64,wincode
+        env:
+          CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
+
   build:
     strategy:
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ wasm-bindgen-test = "0.3"
 base64 = "0.22"
 hex = "0.4"
 libc = "0.2"
+num-bigint = { version = "0.4", features = ["rand"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 static_assertions = "1.1"
@@ -56,7 +57,6 @@ wincode = "0.5.3"
 
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]
 libsodium-sys = "0.2"
-num-bigint = { version = "0.4", features = ["rand"] }
 proptest = "1"
 sodiumoxide = "0.2"
 
@@ -68,7 +68,10 @@ u64_backend = []
 wincode = ["dep:wincode"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin)"] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(dryoc_native_tests)",
+  "cfg(tarpaulin)",
+] }
 
 [package.metadata.docs.rs]
 # docs.rs uses nightly, enable feature flag to get all the juicy docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,18 +39,26 @@ winapi = { version = "0.3", features = [
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.4", features = ["wasm_js"] }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [dev-dependencies]
 base64 = "0.22"
 hex = "0.4"
 libc = "0.2"
-libsodium-sys = "0.2"
-proptest = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-sodiumoxide = "0.2"
 static_assertions = "1.1"
-num-bigint = { version = "0.4", features = ["rand"] }
 wincode = "0.5.3"
+
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]
+libsodium-sys = "0.2"
+num-bigint = { version = "0.4", features = ["rand"] }
+proptest = "1"
+sodiumoxide = "0.2"
 
 [features]
 default = ["u64_backend"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+use std::env;
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(dryoc_native_tests)");
+
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    if !(target_arch == "wasm32" && target_os == "unknown") {
+        println!("cargo::rustc-cfg=dryoc_native_tests");
+    }
+}

--- a/src/argon2/mod.rs
+++ b/src/argon2/mod.rs
@@ -645,7 +645,7 @@ fn store_block(output: &mut [u8], block: &Block) {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     #[cfg(feature = "nightly")]
     extern crate test;

--- a/src/argon2/mod.rs
+++ b/src/argon2/mod.rs
@@ -746,24 +746,6 @@ mod tests {
         );
     }
 
-    #[cfg(dryoc_native_tests)]
-    unsafe extern "C" {
-        fn argon2_hash(
-            t_cost: u32,
-            m_cost: u32,
-            parallelism: u32,
-            pwd: *const u8,
-            pwdlen: usize,
-            salt: *const u8,
-            saltlen: usize,
-            hash: *mut u8,
-            hashlen: usize,
-            encoded: *mut u8,
-            encodedlen: usize,
-            type_: i32,
-        ) -> i32;
-    }
-
     #[test]
     fn test_vector_argon2id() {
         let password = [1u8; 32];
@@ -796,56 +778,6 @@ mod tests {
         );
     }
 
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_vector_argon2id_so() {
-        let password = [1u8; 32];
-        let salt = [2u8; 16];
-
-        let mut hash = [0u8; 32];
-        let mut so_hash = [0u8; 32];
-
-        super::argon2_hash(
-            3,
-            32,
-            4,
-            &password,
-            &salt,
-            None,
-            None,
-            &mut hash,
-            Argon2Type::Argon2id,
-        )
-        .expect("argon2_hash failed");
-
-        unsafe {
-            argon2_hash(
-                3,
-                32,
-                4,
-                password.as_ptr(),
-                password.len(),
-                salt.as_ptr(),
-                salt.len(),
-                so_hash.as_mut_ptr(),
-                so_hash.len(),
-                std::ptr::null_mut(),
-                0,
-                Argon2Type::Argon2id as i32,
-            );
-        }
-
-        assert_eq!(hash, so_hash);
-
-        assert_eq!(
-            hash,
-            [
-                3, 170, 185, 101, 193, 32, 1, 201, 215, 208, 210, 222, 51, 25, 44, 4, 148, 182,
-                132, 187, 20, 129, 150, 215, 60, 29, 241, 172, 175, 109, 12, 46
-            ]
-        );
-    }
-
     #[cfg(feature = "nightly")]
     #[bench]
     fn argon2id_64kib_bench(b: &mut test::Bencher) {
@@ -856,5 +788,76 @@ mod tests {
     #[bench]
     fn argon2id_1mib_bench(b: &mut test::Bencher) {
         bench_argon2id(b, 2, 1024);
+    }
+
+    #[cfg(dryoc_native_tests)]
+    mod native_tests {
+        use super::*;
+
+        unsafe extern "C" {
+            fn argon2_hash(
+                t_cost: u32,
+                m_cost: u32,
+                parallelism: u32,
+                pwd: *const u8,
+                pwdlen: usize,
+                salt: *const u8,
+                saltlen: usize,
+                hash: *mut u8,
+                hashlen: usize,
+                encoded: *mut u8,
+                encodedlen: usize,
+                type_: i32,
+            ) -> i32;
+        }
+
+        #[test]
+        fn test_vector_argon2id_so() {
+            let password = [1u8; 32];
+            let salt = [2u8; 16];
+
+            let mut hash = [0u8; 32];
+            let mut so_hash = [0u8; 32];
+
+            super::argon2_hash(
+                3,
+                32,
+                4,
+                &password,
+                &salt,
+                None,
+                None,
+                &mut hash,
+                Argon2Type::Argon2id,
+            )
+            .expect("argon2_hash failed");
+
+            unsafe {
+                argon2_hash(
+                    3,
+                    32,
+                    4,
+                    password.as_ptr(),
+                    password.len(),
+                    salt.as_ptr(),
+                    salt.len(),
+                    so_hash.as_mut_ptr(),
+                    so_hash.len(),
+                    std::ptr::null_mut(),
+                    0,
+                    Argon2Type::Argon2id as i32,
+                );
+            }
+
+            assert_eq!(hash, so_hash);
+
+            assert_eq!(
+                hash,
+                [
+                    3, 170, 185, 101, 193, 32, 1, 201, 215, 208, 210, 222, 51, 25, 44, 4, 148, 182,
+                    132, 187, 20, 129, 150, 215, 60, 29, 241, 172, 175, 109, 12, 46
+                ]
+            );
+        }
     }
 }

--- a/src/argon2/mod.rs
+++ b/src/argon2/mod.rs
@@ -645,7 +645,7 @@ fn store_block(output: &mut [u8], block: &Block) {
     }
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(test)]
 mod tests {
     #[cfg(feature = "nightly")]
     extern crate test;
@@ -746,6 +746,7 @@ mod tests {
         );
     }
 
+    #[cfg(dryoc_native_tests)]
     unsafe extern "C" {
         fn argon2_hash(
             t_cost: u32,
@@ -795,6 +796,7 @@ mod tests {
         );
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_vector_argon2id_so() {
         let password = [1u8; 32];

--- a/src/blake2b/blake2b_soft.rs
+++ b/src/blake2b/blake2b_soft.rs
@@ -399,32 +399,9 @@ mod tests {
     #[cfg(feature = "nightly")]
     extern crate test;
     use lazy_static::lazy_static;
-    #[cfg(dryoc_native_tests)]
-    use libc::*;
     use serde::{Deserialize, Serialize};
 
     use super::*;
-
-    #[cfg(dryoc_native_tests)]
-    #[repr(C)]
-    #[derive(Debug)]
-    struct B2state {
-        h: [u64; 8],
-        t: [u64; 2],
-        f: [u64; 2],
-        buf: [c_uchar; 256],
-        buflen: size_t,
-        last_node: u8,
-    }
-
-    #[cfg(dryoc_native_tests)]
-    unsafe extern "C" {
-        fn blake2b_init(S: *mut B2state, outlen: c_uchar);
-        fn blake2b_init_key(S: *mut B2state, outlen: c_uchar, key: *const u8, keylen: c_uchar);
-        fn blake2b_update(S: *mut B2state, input: *const u8, inlen: u64);
-        fn blake2b_final(S: *mut B2state, output: *mut u8, outlen: u64);
-        fn blake2b_long(pout: *mut u8, outlen: u64, input: *const u8, inlen: u64);
-    }
 
     #[derive(Debug, Serialize, Deserialize)]
     struct TestVector {
@@ -475,32 +452,97 @@ mod tests {
     }
 
     #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_b2() {
-        use crate::rng::copy_randombytes;
+    mod native_tests {
+        use libc::*;
 
-        let mut s = B2state {
-            h: [0u64; 8],
-            t: [0u64; 2],
-            f: [0u64; 2],
-            buf: [0u8; 256],
-            buflen: 0,
-            last_node: 0,
-        };
+        use super::*;
 
-        for i in 0..512 {
-            unsafe { blake2b_init(&mut s, 64) };
+        #[repr(C)]
+        #[derive(Debug)]
+        struct B2state {
+            h: [u64; 8],
+            t: [u64; 2],
+            f: [u64; 2],
+            buf: [c_uchar; 256],
+            buflen: size_t,
+            last_node: u8,
+        }
 
-            let mut state = State::init(64, None, None, None).expect("init");
+        unsafe extern "C" {
+            fn blake2b_init(S: *mut B2state, outlen: c_uchar);
+            fn blake2b_init_key(S: *mut B2state, outlen: c_uchar, key: *const u8, keylen: c_uchar);
+            fn blake2b_update(S: *mut B2state, input: *const u8, inlen: u64);
+            fn blake2b_final(S: *mut B2state, output: *mut u8, outlen: u64);
+            fn blake2b_long(pout: *mut u8, outlen: u64, input: *const u8, inlen: u64);
+        }
 
-            let mut block = vec![0u8; i];
+        #[test]
+        fn test_b2() {
+            use crate::rng::copy_randombytes;
+
+            let mut s = B2state {
+                h: [0u64; 8],
+                t: [0u64; 2],
+                f: [0u64; 2],
+                buf: [0u8; 256],
+                buflen: 0,
+                last_node: 0,
+            };
+
+            for i in 0..512 {
+                unsafe { blake2b_init(&mut s, 64) };
+
+                let mut state = State::init(64, None, None, None).expect("init");
+
+                let mut block = vec![0u8; i];
+                copy_randombytes(&mut block);
+
+                unsafe { blake2b_update(&mut s, block.as_ptr(), block.len() as u64) };
+
+                state.update(&block);
+
+                unsafe { blake2b_update(&mut s, block.as_ptr(), block.len() as u64) };
+
+                state.update(&block);
+
+                let mut output = [0u8; 64];
+                let mut so_output = [0u8; 64];
+
+                unsafe { blake2b_final(&mut s, so_output.as_mut_ptr(), so_output.len() as u64) };
+
+                state.finalize(&mut output).ok();
+
+                assert_eq!(output, so_output);
+            }
+        }
+
+        #[test]
+        fn test_b2_key() {
+            use crate::rng::copy_randombytes;
+
+            let mut s = B2state {
+                h: [0u64; 8],
+                t: [0u64; 2],
+                f: [0u64; 2],
+                buf: [0u8; 256],
+                buflen: 0,
+                last_node: 0,
+            };
+
+            let mut key = [0u8; 32];
+            copy_randombytes(&mut key);
+            let mut block = [0u8; 256];
             copy_randombytes(&mut block);
 
-            unsafe { blake2b_update(&mut s, block.as_ptr(), block.len() as u64) };
+            unsafe { blake2b_init_key(&mut s, 64, &key as *const u8, key.len() as u8) };
+
+            let mut state = State::init(64, Some(&key), None, None).expect("init");
+
+            unsafe { blake2b_update(&mut s, &block as *const u8, block.len() as u64) };
 
             state.update(&block);
 
-            unsafe { blake2b_update(&mut s, block.as_ptr(), block.len() as u64) };
+            unsafe { blake2b_update(&mut s, &block as *const u8, block.len() as u64) };
 
             state.update(&block);
 
@@ -513,101 +555,58 @@ mod tests {
 
             assert_eq!(output, so_output);
         }
-    }
 
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_b2_key() {
-        use crate::rng::copy_randombytes;
+        #[test]
+        fn test_blake2b_long() {
+            use crate::rng::copy_randombytes;
 
-        let mut s = B2state {
-            h: [0u64; 8],
-            t: [0u64; 2],
-            f: [0u64; 2],
-            buf: [0u8; 256],
-            buflen: 0,
-            last_node: 0,
-        };
+            for i in 5..320 {
+                let mut input = vec![0u8; i - 5_usize];
+                let mut output = vec![0u8; i];
+                let mut so_output = output.clone();
+                copy_randombytes(&mut input);
 
-        let mut key = [0u8; 32];
-        copy_randombytes(&mut key);
-        let mut block = [0u8; 256];
-        copy_randombytes(&mut block);
+                longhash(&mut output, &input).expect("longhash failed");
 
-        unsafe { blake2b_init_key(&mut s, 64, &key as *const u8, key.len() as u8) };
+                unsafe {
+                    blake2b_long(
+                        so_output.as_mut_ptr(),
+                        so_output.len() as u64,
+                        input.as_ptr(),
+                        input.len() as u64,
+                    )
+                };
 
-        let mut state = State::init(64, Some(&key), None, None).expect("init");
-
-        unsafe { blake2b_update(&mut s, &block as *const u8, block.len() as u64) };
-
-        state.update(&block);
-
-        unsafe { blake2b_update(&mut s, &block as *const u8, block.len() as u64) };
-
-        state.update(&block);
-
-        let mut output = [0u8; 64];
-        let mut so_output = [0u8; 64];
-
-        unsafe { blake2b_final(&mut s, so_output.as_mut_ptr(), so_output.len() as u64) };
-
-        state.finalize(&mut output).ok();
-
-        assert_eq!(output, so_output);
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_blake2b_long() {
-        use crate::rng::copy_randombytes;
-
-        for i in 5..320 {
-            let mut input = vec![0u8; i - 5_usize];
-            let mut output = vec![0u8; i];
-            let mut so_output = output.clone();
-            copy_randombytes(&mut input);
-
-            longhash(&mut output, &input).expect("longhash failed");
-
-            unsafe {
-                blake2b_long(
-                    so_output.as_mut_ptr(),
-                    so_output.len() as u64,
-                    input.as_ptr(),
-                    input.len() as u64,
-                )
-            };
-
-            assert_eq!(output, so_output);
+                assert_eq!(output, so_output);
+            }
         }
-    }
 
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_blake2b_long_rand_length() {
-        use rand::TryRng;
-        use rand::rngs::SysRng;
+        #[test]
+        fn test_blake2b_long_rand_length() {
+            use rand::TryRng;
+            use rand::rngs::SysRng;
 
-        use crate::rng::copy_randombytes;
+            use crate::rng::copy_randombytes;
 
-        for _ in 0..25 {
-            let mut input = vec![0u8; (SysRng.try_next_u32().unwrap() % 1000) as usize];
-            let mut output = vec![0u8; (SysRng.try_next_u32().unwrap() % 1000 + 64) as usize];
-            let mut so_output = output.clone();
-            copy_randombytes(&mut input);
+            for _ in 0..25 {
+                let mut input = vec![0u8; (SysRng.try_next_u32().unwrap() % 1000) as usize];
+                let mut output = vec![0u8; (SysRng.try_next_u32().unwrap() % 1000 + 64) as usize];
+                let mut so_output = output.clone();
+                copy_randombytes(&mut input);
 
-            longhash(&mut output, &input).expect("longhash failed");
+                longhash(&mut output, &input).expect("longhash failed");
 
-            unsafe {
-                blake2b_long(
-                    so_output.as_mut_ptr(),
-                    so_output.len() as u64,
-                    input.as_ptr(),
-                    input.len() as u64,
-                )
-            };
+                unsafe {
+                    blake2b_long(
+                        so_output.as_mut_ptr(),
+                        so_output.len() as u64,
+                        input.as_ptr(),
+                        input.len() as u64,
+                    )
+                };
 
-            assert_eq!(output, so_output);
+                assert_eq!(output, so_output);
+            }
         }
     }
 }

--- a/src/blake2b/blake2b_soft.rs
+++ b/src/blake2b/blake2b_soft.rs
@@ -394,16 +394,18 @@ pub fn longhash(output: &mut [u8], input: &[u8]) -> Result<(), Error> {
     }
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(test)]
 mod tests {
     #[cfg(feature = "nightly")]
     extern crate test;
     use lazy_static::lazy_static;
+    #[cfg(dryoc_native_tests)]
     use libc::*;
     use serde::{Deserialize, Serialize};
 
     use super::*;
 
+    #[cfg(dryoc_native_tests)]
     #[repr(C)]
     #[derive(Debug)]
     struct B2state {
@@ -415,6 +417,7 @@ mod tests {
         last_node: u8,
     }
 
+    #[cfg(dryoc_native_tests)]
     unsafe extern "C" {
         fn blake2b_init(S: *mut B2state, outlen: c_uchar);
         fn blake2b_init_key(S: *mut B2state, outlen: c_uchar, key: *const u8, keylen: c_uchar);
@@ -471,6 +474,7 @@ mod tests {
         });
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_b2() {
         use crate::rng::copy_randombytes;
@@ -511,6 +515,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_b2_key() {
         use crate::rng::copy_randombytes;
@@ -551,6 +556,7 @@ mod tests {
         assert_eq!(output, so_output);
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_blake2b_long() {
         use crate::rng::copy_randombytes;
@@ -576,6 +582,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_blake2b_long_rand_length() {
         use rand::TryRng;

--- a/src/blake2b/blake2b_soft.rs
+++ b/src/blake2b/blake2b_soft.rs
@@ -394,7 +394,7 @@ pub fn longhash(output: &mut [u8], input: &[u8]) -> Result<(), Error> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     #[cfg(feature = "nightly")]
     extern crate test;

--- a/src/classic/crypto_auth.rs
+++ b/src/classic/crypto_auth.rs
@@ -171,7 +171,7 @@ pub fn crypto_auth_final(state: AuthState, output: &mut [u8; CRYPTO_AUTH_BYTES])
     crypto_auth_hmacsha512256_final(state.state, output)
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use rand::TryRng;
 

--- a/src/classic/crypto_auth.rs
+++ b/src/classic/crypto_auth.rs
@@ -171,7 +171,7 @@ pub fn crypto_auth_final(state: AuthState, output: &mut [u8; CRYPTO_AUTH_BYTES])
     crypto_auth_hmacsha512256_final(state.state, output)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use rand::TryRng;
 

--- a/src/classic/crypto_box.rs
+++ b/src/classic/crypto_box.rs
@@ -463,7 +463,7 @@ pub fn crypto_box_open_easy_inplace(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use super::*;
     use crate::rng::*;

--- a/src/classic/crypto_box.rs
+++ b/src/classic/crypto_box.rs
@@ -463,11 +463,12 @@ pub fn crypto_box_open_easy_inplace(
     }
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::rng::*;
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_crypto_box_easy() {
         for i in 0..20 {
@@ -525,6 +526,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_crypto_box_easy_inplace() {
         for i in 0..20 {
@@ -624,6 +626,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_crypto_box_seed_keypair() {
         use base64::Engine as _;
@@ -647,6 +650,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_crypto_box_seal() {
         for i in 0..20 {
@@ -675,6 +679,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_crypto_box_seal_open() {
         for i in 0..20 {

--- a/src/classic/crypto_box.rs
+++ b/src/classic/crypto_box.rs
@@ -468,120 +468,6 @@ mod tests {
     use super::*;
     use crate::rng::*;
 
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_crypto_box_easy() {
-        for i in 0..20 {
-            use base64::Engine as _;
-            use base64::engine::general_purpose;
-            use sodiumoxide::crypto::box_;
-            use sodiumoxide::crypto::box_::{Nonce as SONonce, PublicKey, SecretKey};
-
-            let (sender_pk, sender_sk) = crypto_box_keypair();
-            let (recipient_pk, recipient_sk) = crypto_box_keypair();
-            let nonce = Nonce::generate();
-            let words = vec!["hello1".to_string(); i];
-            let message = words.join(" :D ");
-            let mut ciphertext = vec![0u8; message.len() + CRYPTO_BOX_MACBYTES];
-            crypto_box_easy(
-                &mut ciphertext,
-                message.as_bytes(),
-                &nonce,
-                &recipient_pk,
-                &sender_sk,
-            )
-            .expect("encrypt failed");
-
-            let so_ciphertext = box_::seal(
-                message.as_bytes(),
-                &SONonce::from_slice(&nonce).unwrap(),
-                &PublicKey::from_slice(&recipient_pk).unwrap(),
-                &SecretKey::from_slice(&sender_sk).unwrap(),
-            );
-
-            assert_eq!(
-                general_purpose::STANDARD_NO_PAD.encode(&ciphertext),
-                general_purpose::STANDARD_NO_PAD.encode(&so_ciphertext)
-            );
-
-            let mut m = vec![0u8; ciphertext.len() - CRYPTO_BOX_MACBYTES];
-            crypto_box_open_easy(
-                &mut m,
-                ciphertext.as_slice(),
-                &nonce,
-                &sender_pk,
-                &recipient_sk,
-            )
-            .expect("decrypt failed");
-            let so_m = box_::open(
-                ciphertext.as_slice(),
-                &SONonce::from_slice(&nonce).unwrap(),
-                &PublicKey::from_slice(&recipient_pk).unwrap(),
-                &SecretKey::from_slice(&sender_sk).unwrap(),
-            )
-            .unwrap();
-
-            assert_eq!(m, message.as_bytes());
-            assert_eq!(m, so_m);
-        }
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_crypto_box_easy_inplace() {
-        for i in 0..20 {
-            use base64::Engine as _;
-            use base64::engine::general_purpose;
-            use sodiumoxide::crypto::box_;
-            use sodiumoxide::crypto::box_::{Nonce as SONonce, PublicKey, SecretKey};
-
-            let (sender_pk, sender_sk) = crypto_box_keypair();
-            let (recipient_pk, recipient_sk) = crypto_box_keypair();
-            let nonce = Nonce::generate();
-            let words = vec!["hello1".to_string(); i];
-            let message: Vec<u8> = words.join(" :D ").as_bytes().to_vec();
-            let message_copy = message.clone();
-
-            let mut ciphertext = message.clone();
-            ciphertext.resize(message.len() + CRYPTO_BOX_MACBYTES, 0);
-            crypto_box_easy_inplace(&mut ciphertext, &nonce, &recipient_pk, &sender_sk)
-                .expect("encrypt failed");
-            let so_ciphertext = box_::seal(
-                message_copy.as_slice(),
-                &SONonce::from_slice(&nonce).unwrap(),
-                &PublicKey::from_slice(&recipient_pk).unwrap(),
-                &SecretKey::from_slice(&sender_sk).unwrap(),
-            );
-
-            assert_eq!(
-                general_purpose::STANDARD_NO_PAD.encode(&ciphertext),
-                general_purpose::STANDARD_NO_PAD.encode(&so_ciphertext)
-            );
-
-            let mut ciphertext_clone = ciphertext.clone();
-            crypto_box_open_easy_inplace(&mut ciphertext_clone, &nonce, &sender_pk, &recipient_sk)
-                .expect("decrypt failed");
-            ciphertext_clone.resize(message.len(), 0);
-
-            let so_m = box_::open(
-                ciphertext.as_slice(),
-                &SONonce::from_slice(&nonce).unwrap(),
-                &PublicKey::from_slice(&recipient_pk).unwrap(),
-                &SecretKey::from_slice(&sender_sk).unwrap(),
-            )
-            .expect("decrypt failed");
-
-            assert_eq!(
-                general_purpose::STANDARD_NO_PAD.encode(&ciphertext_clone),
-                general_purpose::STANDARD_NO_PAD.encode(&message_copy)
-            );
-            assert_eq!(
-                general_purpose::STANDARD_NO_PAD.encode(&so_m),
-                general_purpose::STANDARD_NO_PAD.encode(&message_copy)
-            );
-        }
-    }
-
     #[test]
     fn test_crypto_box_easy_invalid() {
         for _ in 0..20 {
@@ -627,90 +513,209 @@ mod tests {
     }
 
     #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_crypto_box_seed_keypair() {
-        use base64::Engine as _;
-        use base64::engine::general_purpose;
-        use sodiumoxide::crypto::box_::{Seed, keypair_from_seed};
+    mod native_tests {
+        use super::*;
 
-        for _ in 0..10 {
-            let seed = randombytes_buf(CRYPTO_BOX_SEEDBYTES);
+        #[test]
+        fn test_crypto_box_easy() {
+            for i in 0..20 {
+                use base64::Engine as _;
+                use base64::engine::general_purpose;
+                use sodiumoxide::crypto::box_;
+                use sodiumoxide::crypto::box_::{Nonce as SONonce, PublicKey, SecretKey};
 
-            let (pk, sk) = crypto_box_seed_keypair(&seed);
-            let (so_pk, so_sk) = keypair_from_seed(&Seed::from_slice(&seed).unwrap());
-
-            assert_eq!(
-                general_purpose::STANDARD_NO_PAD.encode(pk),
-                general_purpose::STANDARD_NO_PAD.encode(so_pk.as_ref())
-            );
-            assert_eq!(
-                general_purpose::STANDARD_NO_PAD.encode(sk),
-                general_purpose::STANDARD_NO_PAD.encode(so_sk.as_ref())
-            );
-        }
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_crypto_box_seal() {
-        for i in 0..20 {
-            use sodiumoxide::crypto::box_::{PublicKey, SecretKey};
-            use sodiumoxide::crypto::sealedbox::curve25519blake2bxsalsa20poly1305;
-
-            let (recipient_pk, recipient_sk) = crypto_box_keypair();
-            let words = vec!["hello1".to_string(); i];
-            let message = words.join(" :D ");
-            let mut ciphertext = vec![0u8; message.len() + CRYPTO_BOX_SEALBYTES];
-            crypto_box_seal(&mut ciphertext, message.as_bytes(), &recipient_pk)
+                let (sender_pk, sender_sk) = crypto_box_keypair();
+                let (recipient_pk, recipient_sk) = crypto_box_keypair();
+                let nonce = Nonce::generate();
+                let words = vec!["hello1".to_string(); i];
+                let message = words.join(" :D ");
+                let mut ciphertext = vec![0u8; message.len() + CRYPTO_BOX_MACBYTES];
+                crypto_box_easy(
+                    &mut ciphertext,
+                    message.as_bytes(),
+                    &nonce,
+                    &recipient_pk,
+                    &sender_sk,
+                )
                 .expect("encrypt failed");
 
-            let mut m = vec![0u8; ciphertext.len() - CRYPTO_BOX_SEALBYTES];
-            crypto_box_seal_open(&mut m, ciphertext.as_slice(), &recipient_pk, &recipient_sk)
+                let so_ciphertext = box_::seal(
+                    message.as_bytes(),
+                    &SONonce::from_slice(&nonce).unwrap(),
+                    &PublicKey::from_slice(&recipient_pk).unwrap(),
+                    &SecretKey::from_slice(&sender_sk).unwrap(),
+                );
+
+                assert_eq!(
+                    general_purpose::STANDARD_NO_PAD.encode(&ciphertext),
+                    general_purpose::STANDARD_NO_PAD.encode(&so_ciphertext)
+                );
+
+                let mut m = vec![0u8; ciphertext.len() - CRYPTO_BOX_MACBYTES];
+                crypto_box_open_easy(
+                    &mut m,
+                    ciphertext.as_slice(),
+                    &nonce,
+                    &sender_pk,
+                    &recipient_sk,
+                )
                 .expect("decrypt failed");
-            let so_m = curve25519blake2bxsalsa20poly1305::open(
-                ciphertext.as_slice(),
-                &PublicKey::from_slice(&recipient_pk).unwrap(),
-                &SecretKey::from_slice(&recipient_sk).unwrap(),
-            )
-            .unwrap();
+                let so_m = box_::open(
+                    ciphertext.as_slice(),
+                    &SONonce::from_slice(&nonce).unwrap(),
+                    &PublicKey::from_slice(&recipient_pk).unwrap(),
+                    &SecretKey::from_slice(&sender_sk).unwrap(),
+                )
+                .unwrap();
 
-            assert_eq!(m, message.as_bytes());
-            assert_eq!(m, so_m);
+                assert_eq!(m, message.as_bytes());
+                assert_eq!(m, so_m);
+            }
         }
-    }
 
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_crypto_box_seal_open() {
-        for i in 0..20 {
-            use sodiumoxide::crypto::box_::{PublicKey, SecretKey};
-            use sodiumoxide::crypto::sealedbox::curve25519blake2bxsalsa20poly1305;
+        #[test]
+        fn test_crypto_box_easy_inplace() {
+            for i in 0..20 {
+                use base64::Engine as _;
+                use base64::engine::general_purpose;
+                use sodiumoxide::crypto::box_;
+                use sodiumoxide::crypto::box_::{Nonce as SONonce, PublicKey, SecretKey};
 
-            let (recipient_pk, recipient_sk) = crypto_box_keypair();
-            let words = vec!["hello1".to_string(); i];
-            let message = words.join(" :D ");
-            let so_ciphertext = curve25519blake2bxsalsa20poly1305::seal(
-                message.as_bytes(),
-                &PublicKey::from_slice(&recipient_pk).unwrap(),
-            );
+                let (sender_pk, sender_sk) = crypto_box_keypair();
+                let (recipient_pk, recipient_sk) = crypto_box_keypair();
+                let nonce = Nonce::generate();
+                let words = vec!["hello1".to_string(); i];
+                let message: Vec<u8> = words.join(" :D ").as_bytes().to_vec();
+                let message_copy = message.clone();
 
-            let mut m = vec![0u8; so_ciphertext.len() - CRYPTO_BOX_SEALBYTES];
-            crypto_box_seal_open(
-                &mut m,
-                so_ciphertext.as_slice(),
-                &recipient_pk,
-                &recipient_sk,
-            )
-            .expect("decrypt failed");
-            let so_m = curve25519blake2bxsalsa20poly1305::open(
-                so_ciphertext.as_slice(),
-                &PublicKey::from_slice(&recipient_pk).unwrap(),
-                &SecretKey::from_slice(&recipient_sk).unwrap(),
-            )
-            .unwrap();
+                let mut ciphertext = message.clone();
+                ciphertext.resize(message.len() + CRYPTO_BOX_MACBYTES, 0);
+                crypto_box_easy_inplace(&mut ciphertext, &nonce, &recipient_pk, &sender_sk)
+                    .expect("encrypt failed");
+                let so_ciphertext = box_::seal(
+                    message_copy.as_slice(),
+                    &SONonce::from_slice(&nonce).unwrap(),
+                    &PublicKey::from_slice(&recipient_pk).unwrap(),
+                    &SecretKey::from_slice(&sender_sk).unwrap(),
+                );
 
-            assert_eq!(m, message.as_bytes());
-            assert_eq!(m, so_m);
+                assert_eq!(
+                    general_purpose::STANDARD_NO_PAD.encode(&ciphertext),
+                    general_purpose::STANDARD_NO_PAD.encode(&so_ciphertext)
+                );
+
+                let mut ciphertext_clone = ciphertext.clone();
+                crypto_box_open_easy_inplace(
+                    &mut ciphertext_clone,
+                    &nonce,
+                    &sender_pk,
+                    &recipient_sk,
+                )
+                .expect("decrypt failed");
+                ciphertext_clone.resize(message.len(), 0);
+
+                let so_m = box_::open(
+                    ciphertext.as_slice(),
+                    &SONonce::from_slice(&nonce).unwrap(),
+                    &PublicKey::from_slice(&recipient_pk).unwrap(),
+                    &SecretKey::from_slice(&sender_sk).unwrap(),
+                )
+                .expect("decrypt failed");
+
+                assert_eq!(
+                    general_purpose::STANDARD_NO_PAD.encode(&ciphertext_clone),
+                    general_purpose::STANDARD_NO_PAD.encode(&message_copy)
+                );
+                assert_eq!(
+                    general_purpose::STANDARD_NO_PAD.encode(&so_m),
+                    general_purpose::STANDARD_NO_PAD.encode(&message_copy)
+                );
+            }
+        }
+
+        #[test]
+        fn test_crypto_box_seed_keypair() {
+            use base64::Engine as _;
+            use base64::engine::general_purpose;
+            use sodiumoxide::crypto::box_::{Seed, keypair_from_seed};
+
+            for _ in 0..10 {
+                let seed = randombytes_buf(CRYPTO_BOX_SEEDBYTES);
+
+                let (pk, sk) = crypto_box_seed_keypair(&seed);
+                let (so_pk, so_sk) = keypair_from_seed(&Seed::from_slice(&seed).unwrap());
+
+                assert_eq!(
+                    general_purpose::STANDARD_NO_PAD.encode(pk),
+                    general_purpose::STANDARD_NO_PAD.encode(so_pk.as_ref())
+                );
+                assert_eq!(
+                    general_purpose::STANDARD_NO_PAD.encode(sk),
+                    general_purpose::STANDARD_NO_PAD.encode(so_sk.as_ref())
+                );
+            }
+        }
+
+        #[test]
+        fn test_crypto_box_seal() {
+            for i in 0..20 {
+                use sodiumoxide::crypto::box_::{PublicKey, SecretKey};
+                use sodiumoxide::crypto::sealedbox::curve25519blake2bxsalsa20poly1305;
+
+                let (recipient_pk, recipient_sk) = crypto_box_keypair();
+                let words = vec!["hello1".to_string(); i];
+                let message = words.join(" :D ");
+                let mut ciphertext = vec![0u8; message.len() + CRYPTO_BOX_SEALBYTES];
+                crypto_box_seal(&mut ciphertext, message.as_bytes(), &recipient_pk)
+                    .expect("encrypt failed");
+
+                let mut m = vec![0u8; ciphertext.len() - CRYPTO_BOX_SEALBYTES];
+                crypto_box_seal_open(&mut m, ciphertext.as_slice(), &recipient_pk, &recipient_sk)
+                    .expect("decrypt failed");
+                let so_m = curve25519blake2bxsalsa20poly1305::open(
+                    ciphertext.as_slice(),
+                    &PublicKey::from_slice(&recipient_pk).unwrap(),
+                    &SecretKey::from_slice(&recipient_sk).unwrap(),
+                )
+                .unwrap();
+
+                assert_eq!(m, message.as_bytes());
+                assert_eq!(m, so_m);
+            }
+        }
+
+        #[test]
+        fn test_crypto_box_seal_open() {
+            for i in 0..20 {
+                use sodiumoxide::crypto::box_::{PublicKey, SecretKey};
+                use sodiumoxide::crypto::sealedbox::curve25519blake2bxsalsa20poly1305;
+
+                let (recipient_pk, recipient_sk) = crypto_box_keypair();
+                let words = vec!["hello1".to_string(); i];
+                let message = words.join(" :D ");
+                let so_ciphertext = curve25519blake2bxsalsa20poly1305::seal(
+                    message.as_bytes(),
+                    &PublicKey::from_slice(&recipient_pk).unwrap(),
+                );
+
+                let mut m = vec![0u8; so_ciphertext.len() - CRYPTO_BOX_SEALBYTES];
+                crypto_box_seal_open(
+                    &mut m,
+                    so_ciphertext.as_slice(),
+                    &recipient_pk,
+                    &recipient_sk,
+                )
+                .expect("decrypt failed");
+                let so_m = curve25519blake2bxsalsa20poly1305::open(
+                    so_ciphertext.as_slice(),
+                    &PublicKey::from_slice(&recipient_pk).unwrap(),
+                    &SecretKey::from_slice(&recipient_sk).unwrap(),
+                )
+                .unwrap();
+
+                assert_eq!(m, message.as_bytes());
+                assert_eq!(m, so_m);
+            }
         }
     }
 }

--- a/src/classic/crypto_core.rs
+++ b/src/classic/crypto_core.rs
@@ -319,127 +319,6 @@ mod tests {
     use crate::classic::crypto_sign::crypto_sign_keypair;
     use crate::keypair::{KeyPair, PublicKey, SecretKey};
 
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_crypto_scalarmult_base() {
-        use base64::Engine as _;
-        use base64::engine::general_purpose;
-        for _ in 0..20 {
-            use sodiumoxide::crypto::scalarmult::curve25519::{Scalar, scalarmult_base};
-
-            let (pk, sk) = crypto_box_keypair();
-
-            let mut public_key = [0u8; CRYPTO_SCALARMULT_BYTES];
-            crypto_scalarmult_base(&mut public_key, &sk);
-
-            assert_eq!(&pk, &public_key);
-
-            let ge = scalarmult_base(&Scalar::from_slice(&sk).unwrap());
-
-            assert_eq!(
-                general_purpose::STANDARD.encode(ge.as_ref()),
-                general_purpose::STANDARD.encode(public_key)
-            );
-        }
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_crypto_scalarmult() {
-        use base64::Engine as _;
-        use base64::engine::general_purpose;
-        for _ in 0..20 {
-            use sodiumoxide::crypto::scalarmult::curve25519::{GroupElement, Scalar, scalarmult};
-
-            let (_our_pk, our_sk) = crypto_box_keypair();
-            let (their_pk, _their_sk) = crypto_box_keypair();
-
-            let mut shared_secret = [0u8; CRYPTO_SCALARMULT_BYTES];
-            crypto_scalarmult(&mut shared_secret, &our_sk, &their_pk);
-
-            let ge = scalarmult(
-                &Scalar::from_slice(&our_sk).unwrap(),
-                &GroupElement::from_slice(&their_pk).unwrap(),
-            )
-            .expect("scalarmult failed");
-
-            assert_eq!(
-                general_purpose::STANDARD.encode(ge.as_ref()),
-                general_purpose::STANDARD.encode(shared_secret)
-            );
-        }
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_crypto_core_hchacha20() {
-        use base64::Engine as _;
-        use base64::engine::general_purpose;
-        use libsodium_sys::crypto_core_hchacha20 as so_crypto_core_hchacha20;
-
-        use crate::rng::copy_randombytes;
-
-        for _ in 0..10 {
-            let mut key = [0u8; 32];
-            let mut data = [0u8; 16];
-            copy_randombytes(&mut key);
-            copy_randombytes(&mut data);
-
-            let mut out = [0u8; CRYPTO_CORE_HCHACHA20_OUTPUTBYTES];
-            crypto_core_hchacha20(&mut out, &data, &key, None);
-
-            let mut so_out = [0u8; 32];
-            unsafe {
-                let ret = so_crypto_core_hchacha20(
-                    so_out.as_mut_ptr(),
-                    data.as_ptr(),
-                    key.as_ptr(),
-                    std::ptr::null(),
-                );
-                assert_eq!(ret, 0);
-            }
-            assert_eq!(
-                general_purpose::STANDARD.encode(out),
-                general_purpose::STANDARD.encode(so_out)
-            );
-        }
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_crypto_core_hsalsa20() {
-        use base64::Engine as _;
-        use base64::engine::general_purpose;
-        use libsodium_sys::crypto_core_hsalsa20 as so_crypto_core_hsalsa20;
-
-        use crate::rng::copy_randombytes;
-
-        for _ in 0..10 {
-            let mut key = [0u8; CRYPTO_CORE_HSALSA20_KEYBYTES];
-            let mut data = [0u8; CRYPTO_CORE_HSALSA20_INPUTBYTES];
-            copy_randombytes(&mut key);
-            copy_randombytes(&mut data);
-
-            let mut out = [0u8; CRYPTO_CORE_HSALSA20_OUTPUTBYTES];
-            crypto_core_hsalsa20(&mut out, &data, &key, None);
-
-            let mut so_out = [0u8; 32];
-            unsafe {
-                let ret = so_crypto_core_hsalsa20(
-                    so_out.as_mut_ptr(),
-                    data.as_ptr(),
-                    key.as_ptr(),
-                    std::ptr::null(),
-                );
-                assert_eq!(ret, 0);
-            }
-            assert_eq!(
-                general_purpose::STANDARD.encode(out),
-                general_purpose::STANDARD.encode(so_out)
-            );
-        }
-    }
-
     #[test]
     fn test_crypto_core_ed25519_is_valid_point() {
         // Test with a known valid public key (from one of the crypto_sign test vectors)
@@ -623,5 +502,129 @@ mod tests {
         );
 
         println!("X25519 key validation: Success");
+    }
+
+    #[cfg(dryoc_native_tests)]
+    mod native_tests {
+        use super::*;
+
+        #[test]
+        fn test_crypto_scalarmult_base() {
+            use base64::Engine as _;
+            use base64::engine::general_purpose;
+            for _ in 0..20 {
+                use sodiumoxide::crypto::scalarmult::curve25519::{Scalar, scalarmult_base};
+
+                let (pk, sk) = crypto_box_keypair();
+
+                let mut public_key = [0u8; CRYPTO_SCALARMULT_BYTES];
+                crypto_scalarmult_base(&mut public_key, &sk);
+
+                assert_eq!(&pk, &public_key);
+
+                let ge = scalarmult_base(&Scalar::from_slice(&sk).unwrap());
+
+                assert_eq!(
+                    general_purpose::STANDARD.encode(ge.as_ref()),
+                    general_purpose::STANDARD.encode(public_key)
+                );
+            }
+        }
+
+        #[test]
+        fn test_crypto_scalarmult() {
+            use base64::Engine as _;
+            use base64::engine::general_purpose;
+            for _ in 0..20 {
+                use sodiumoxide::crypto::scalarmult::curve25519::{
+                    GroupElement, Scalar, scalarmult,
+                };
+
+                let (_our_pk, our_sk) = crypto_box_keypair();
+                let (their_pk, _their_sk) = crypto_box_keypair();
+
+                let mut shared_secret = [0u8; CRYPTO_SCALARMULT_BYTES];
+                crypto_scalarmult(&mut shared_secret, &our_sk, &their_pk);
+
+                let ge = scalarmult(
+                    &Scalar::from_slice(&our_sk).unwrap(),
+                    &GroupElement::from_slice(&their_pk).unwrap(),
+                )
+                .expect("scalarmult failed");
+
+                assert_eq!(
+                    general_purpose::STANDARD.encode(ge.as_ref()),
+                    general_purpose::STANDARD.encode(shared_secret)
+                );
+            }
+        }
+
+        #[test]
+        fn test_crypto_core_hchacha20() {
+            use base64::Engine as _;
+            use base64::engine::general_purpose;
+            use libsodium_sys::crypto_core_hchacha20 as so_crypto_core_hchacha20;
+
+            use crate::rng::copy_randombytes;
+
+            for _ in 0..10 {
+                let mut key = [0u8; 32];
+                let mut data = [0u8; 16];
+                copy_randombytes(&mut key);
+                copy_randombytes(&mut data);
+
+                let mut out = [0u8; CRYPTO_CORE_HCHACHA20_OUTPUTBYTES];
+                crypto_core_hchacha20(&mut out, &data, &key, None);
+
+                let mut so_out = [0u8; 32];
+                unsafe {
+                    let ret = so_crypto_core_hchacha20(
+                        so_out.as_mut_ptr(),
+                        data.as_ptr(),
+                        key.as_ptr(),
+                        std::ptr::null(),
+                    );
+                    assert_eq!(ret, 0);
+                }
+                assert_eq!(
+                    general_purpose::STANDARD.encode(out),
+                    general_purpose::STANDARD.encode(so_out)
+                );
+            }
+        }
+
+        #[test]
+        fn test_crypto_core_hsalsa20() {
+            use base64::Engine as _;
+            use base64::engine::general_purpose;
+            use libsodium_sys::crypto_core_hsalsa20 as so_crypto_core_hsalsa20;
+
+            use crate::rng::copy_randombytes;
+
+            for _ in 0..10 {
+                let mut key = [0u8; CRYPTO_CORE_HSALSA20_KEYBYTES];
+                let mut data = [0u8; CRYPTO_CORE_HSALSA20_INPUTBYTES];
+                copy_randombytes(&mut key);
+                copy_randombytes(&mut data);
+
+                let mut out = [0u8; CRYPTO_CORE_HSALSA20_OUTPUTBYTES];
+                crypto_core_hsalsa20(&mut out, &data, &key, None);
+
+                let mut so_out = [0u8; 32];
+                unsafe {
+                    let ret = so_crypto_core_hsalsa20(
+                        so_out.as_mut_ptr(),
+                        data.as_ptr(),
+                        key.as_ptr(),
+                        std::ptr::null(),
+                    );
+                    assert_eq!(ret, 0);
+                }
+                assert_eq!(
+                    general_purpose::STANDARD.encode(out),
+                    general_purpose::STANDARD.encode(so_out)
+                );
+            }
+        }
     }
 }

--- a/src/classic/crypto_core.rs
+++ b/src/classic/crypto_core.rs
@@ -312,13 +312,14 @@ pub fn crypto_core_hsalsa20(
     output[28..32].copy_from_slice(&x9.to_le_bytes());
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::classic::crypto_box::*;
     use crate::classic::crypto_sign::crypto_sign_keypair;
     use crate::keypair::{KeyPair, PublicKey, SecretKey};
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_crypto_scalarmult_base() {
         use base64::Engine as _;
@@ -342,6 +343,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_crypto_scalarmult() {
         use base64::Engine as _;
@@ -368,6 +370,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_crypto_core_hchacha20() {
         use base64::Engine as _;
@@ -402,6 +405,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_crypto_core_hsalsa20() {
         use base64::Engine as _;

--- a/src/classic/crypto_core.rs
+++ b/src/classic/crypto_core.rs
@@ -312,7 +312,7 @@ pub fn crypto_core_hsalsa20(
     output[28..32].copy_from_slice(&x9.to_le_bytes());
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use super::*;
     use crate::classic::crypto_box::*;

--- a/src/classic/crypto_generichash.rs
+++ b/src/classic/crypto_generichash.rs
@@ -121,7 +121,7 @@ pub fn crypto_generichash_keygen() -> [u8; CRYPTO_GENERICHASH_KEYBYTES] {
     key
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use rand::TryRng;
 

--- a/src/classic/crypto_generichash.rs
+++ b/src/classic/crypto_generichash.rs
@@ -121,7 +121,7 @@ pub fn crypto_generichash_keygen() -> [u8; CRYPTO_GENERICHASH_KEYBYTES] {
     key
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use rand::TryRng;
 

--- a/src/classic/crypto_hash.rs
+++ b/src/classic/crypto_hash.rs
@@ -33,7 +33,7 @@ pub fn crypto_hash_sha512_final(state: Sha512State, output: &mut Digest) {
     state.hasher.finalize_into_bytes(output)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use super::*;
 

--- a/src/classic/crypto_hash.rs
+++ b/src/classic/crypto_hash.rs
@@ -33,7 +33,7 @@ pub fn crypto_hash_sha512_final(state: Sha512State, output: &mut Digest) {
     state.hasher.finalize_into_bytes(output)
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use super::*;
 

--- a/src/classic/crypto_kdf.rs
+++ b/src/classic/crypto_kdf.rs
@@ -79,7 +79,7 @@ pub fn crypto_kdf_derive_from_key(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use super::*;
 

--- a/src/classic/crypto_kdf.rs
+++ b/src/classic/crypto_kdf.rs
@@ -79,7 +79,7 @@ pub fn crypto_kdf_derive_from_key(
     }
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use super::*;
 

--- a/src/classic/crypto_kx.rs
+++ b/src/classic/crypto_kx.rs
@@ -143,7 +143,7 @@ pub fn crypto_kx_server_session_keys(
     crypto_kx(tx, rx, client_pk, server_pk, shared_secret)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use super::*;
 

--- a/src/classic/crypto_kx.rs
+++ b/src/classic/crypto_kx.rs
@@ -143,7 +143,7 @@ pub fn crypto_kx_server_session_keys(
     crypto_kx(tx, rx, client_pk, server_pk, shared_secret)
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use super::*;
 

--- a/src/classic/crypto_onetimeauth.rs
+++ b/src/classic/crypto_onetimeauth.rs
@@ -162,7 +162,7 @@ pub fn crypto_onetimeauth_final(
     crypto_onetimeauth_poly1305_final(state.state, output)
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use super::*;
 

--- a/src/classic/crypto_onetimeauth.rs
+++ b/src/classic/crypto_onetimeauth.rs
@@ -162,7 +162,7 @@ pub fn crypto_onetimeauth_final(
     crypto_onetimeauth_poly1305_final(state.state, output)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use super::*;
 

--- a/src/classic/crypto_pwhash.rs
+++ b/src/classic/crypto_pwhash.rs
@@ -351,7 +351,7 @@ pub fn crypto_pwhash_str_needs_rehash(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use super::*;
 

--- a/src/classic/crypto_pwhash.rs
+++ b/src/classic/crypto_pwhash.rs
@@ -351,7 +351,7 @@ pub fn crypto_pwhash_str_needs_rehash(
     }
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use super::*;
 

--- a/src/classic/crypto_secretbox.rs
+++ b/src/classic/crypto_secretbox.rs
@@ -172,7 +172,7 @@ pub fn crypto_secretbox_open_easy_inplace(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     #[cfg(feature = "nightly")]
     extern crate test;

--- a/src/classic/crypto_secretbox.rs
+++ b/src/classic/crypto_secretbox.rs
@@ -172,7 +172,7 @@ pub fn crypto_secretbox_open_easy_inplace(
     }
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(all(test, dryoc_native_tests))]
 mod tests {
     #[cfg(feature = "nightly")]
     extern crate test;

--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -500,476 +500,6 @@ mod tests {
         );
     }
 
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_secretstream_basic_push() {
-        use base64::Engine as _;
-        use base64::engine::general_purpose;
-        use libsodium_sys::{
-            crypto_secretstream_xchacha20poly1305_init_pull as so_crypto_secretstream_xchacha20poly1305_init_pull,
-            crypto_secretstream_xchacha20poly1305_pull as so_crypto_secretstream_xchacha20poly1305_pull,
-            crypto_secretstream_xchacha20poly1305_push as so_crypto_secretstream_xchacha20poly1305_push,
-            crypto_secretstream_xchacha20poly1305_state,
-        };
-
-        use crate::constants::CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES;
-        use crate::dryocstream::Tag;
-
-        let mut key = Key::default();
-        crypto_secretstream_xchacha20poly1305_keygen(&mut key);
-
-        let mut push_state = State::new();
-        let mut push_header = Header::default();
-        crypto_secretstream_xchacha20poly1305_init_push(&mut push_state, &mut push_header, &key);
-        let push_state_init = push_state.clone();
-
-        let message = b"hello";
-        let mut output = vec![0u8; message.len() + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
-        let aad = b"";
-        let tag = Tag::MESSAGE.bits();
-        crypto_secretstream_xchacha20poly1305_push(
-            &mut push_state,
-            &mut output,
-            message,
-            Some(aad),
-            tag,
-        )
-        .expect("push failed");
-
-        let mut so_output = output.clone();
-        unsafe {
-            use libc::{c_uchar, c_ulonglong};
-            let mut so_state = crypto_secretstream_xchacha20poly1305_state {
-                k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
-                nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
-                _pad: [0u8; 8],
-            };
-            so_state.k.copy_from_slice(&push_state_init.k);
-            so_state.nonce.copy_from_slice(&push_state_init.nonce);
-            let mut clen_p: c_ulonglong = 0;
-            let ret = so_crypto_secretstream_xchacha20poly1305_push(
-                &mut so_state,
-                so_output.as_mut_ptr(),
-                &mut clen_p,
-                message.as_ptr(),
-                message.len() as u64,
-                aad.as_ptr(),
-                aad.len() as u64,
-                0,
-            );
-            assert_eq!(ret, 0);
-            so_output.resize(clen_p as usize, 0);
-            assert_eq!(
-                general_purpose::STANDARD.encode(&so_output),
-                general_purpose::STANDARD.encode(&output)
-            );
-            assert_eq!(
-                general_purpose::STANDARD.encode(so_state.k),
-                general_purpose::STANDARD.encode(push_state.k)
-            );
-            assert_eq!(
-                general_purpose::STANDARD.encode(so_state.nonce),
-                general_purpose::STANDARD.encode(push_state.nonce)
-            );
-
-            let mut so_state = crypto_secretstream_xchacha20poly1305_state {
-                k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
-                nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
-                _pad: [0u8; 8],
-            };
-            let mut mlen_p: c_ulonglong = 0;
-            let mut tag_p: c_uchar = 0;
-            let ret = so_crypto_secretstream_xchacha20poly1305_init_pull(
-                &mut so_state,
-                push_header.as_ptr(),
-                key.as_ptr(),
-            );
-            assert_eq!(ret, 0);
-            assert_eq!(
-                general_purpose::STANDARD.encode(so_state.k),
-                general_purpose::STANDARD.encode(push_state_init.k)
-            );
-            assert_eq!(
-                general_purpose::STANDARD.encode(so_state.nonce),
-                general_purpose::STANDARD.encode(push_state_init.nonce)
-            );
-            assert!(so_output.len() >= CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES);
-            let ret = so_crypto_secretstream_xchacha20poly1305_pull(
-                &mut so_state,
-                so_output.as_mut_ptr(),
-                &mut mlen_p,
-                &mut tag_p,
-                output.as_ptr(),
-                output.len() as u64,
-                aad.as_ptr(),
-                aad.len() as u64,
-            );
-            assert_eq!(ret, 0);
-            so_output.resize(mlen_p as usize, 0);
-        }
-        assert_eq!(
-            general_purpose::STANDARD.encode(message),
-            general_purpose::STANDARD.encode(&so_output)
-        );
-
-        let mut pull_state = State::default();
-        crypto_secretstream_xchacha20poly1305_init_pull(&mut pull_state, &push_header, &key);
-
-        assert_eq!(
-            general_purpose::STANDARD.encode(pull_state.k),
-            general_purpose::STANDARD.encode(push_state_init.k)
-        );
-        assert_eq!(
-            general_purpose::STANDARD.encode(pull_state.nonce),
-            general_purpose::STANDARD.encode(push_state_init.nonce)
-        );
-
-        let mut pull_result_message =
-            vec![0u8; output.len() - CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
-        let mut pull_result_tag = 0u8;
-        crypto_secretstream_xchacha20poly1305_pull(
-            &mut pull_state,
-            &mut pull_result_message,
-            &mut pull_result_tag,
-            &output,
-            Some(&[]),
-        )
-        .expect("pull failed");
-
-        assert_eq!(Tag::MESSAGE, Tag::from_bits(tag).expect("tag"));
-        assert_eq!(
-            general_purpose::STANDARD.encode(&pull_result_message),
-            general_purpose::STANDARD.encode(message)
-        );
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_rekey() {
-        use base64::Engine as _;
-        use base64::engine::general_purpose;
-        use libsodium_sys::{
-            crypto_secretstream_xchacha20poly1305_rekey as so_crypto_secretstream_xchacha20poly1305_rekey,
-            crypto_secretstream_xchacha20poly1305_state,
-        };
-
-        use crate::constants::CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES;
-
-        let mut key = Key::default();
-        crypto_secretstream_xchacha20poly1305_keygen(&mut key);
-
-        let mut push_state = State::default();
-        let mut push_header: Header = Header::default();
-        crypto_secretstream_xchacha20poly1305_init_push(&mut push_state, &mut push_header, &key);
-        let push_state_init = push_state.clone();
-
-        crypto_secretstream_xchacha20poly1305_rekey(&mut push_state);
-
-        let mut so_state = crypto_secretstream_xchacha20poly1305_state {
-            k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
-            nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
-            _pad: [0u8; 8],
-        };
-        so_state.k.copy_from_slice(&push_state_init.k);
-        so_state.nonce.copy_from_slice(&push_state_init.nonce);
-        unsafe {
-            so_crypto_secretstream_xchacha20poly1305_rekey(&mut so_state);
-        }
-        assert_eq!(
-            general_purpose::STANDARD.encode(so_state.k),
-            general_purpose::STANDARD.encode(push_state.k)
-        );
-        assert_eq!(
-            general_purpose::STANDARD.encode(so_state.nonce),
-            general_purpose::STANDARD.encode(push_state.nonce)
-        );
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_secretstream_lots_of_messages_push() {
-        use base64::Engine as _;
-        use base64::engine::general_purpose;
-        use libc::{c_uchar, c_ulonglong};
-        use libsodium_sys::{
-            crypto_secretstream_xchacha20poly1305_init_pull as so_crypto_secretstream_xchacha20poly1305_init_pull,
-            crypto_secretstream_xchacha20poly1305_pull as so_crypto_secretstream_xchacha20poly1305_pull,
-            crypto_secretstream_xchacha20poly1305_state,
-        };
-
-        use crate::constants::CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES;
-        use crate::dryocstream::Tag;
-
-        let mut key = Key::default();
-        crypto_secretstream_xchacha20poly1305_keygen(&mut key);
-
-        let mut push_state = State::new();
-        let mut push_header = Header::default();
-        crypto_secretstream_xchacha20poly1305_init_push(&mut push_state, &mut push_header, &key);
-        let push_state_init = push_state.clone();
-
-        let mut pull_state = State::default();
-        crypto_secretstream_xchacha20poly1305_init_pull(&mut pull_state, &push_header, &key);
-
-        assert_eq!(
-            general_purpose::STANDARD.encode(pull_state.k),
-            general_purpose::STANDARD.encode(push_state_init.k)
-        );
-        assert_eq!(
-            general_purpose::STANDARD.encode(pull_state.nonce),
-            general_purpose::STANDARD.encode(push_state_init.nonce)
-        );
-
-        let mut so_state = crypto_secretstream_xchacha20poly1305_state {
-            k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
-            nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
-            _pad: [0u8; 8],
-        };
-        so_state.k.copy_from_slice(&push_state_init.k);
-        so_state.nonce.copy_from_slice(&push_state_init.nonce);
-
-        let mut so_state = crypto_secretstream_xchacha20poly1305_state {
-            k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
-            nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
-            _pad: [0u8; 8],
-        };
-        let mut mlen_p: c_ulonglong = 0;
-        let mut tag_p: c_uchar = 0;
-        unsafe {
-            let ret = so_crypto_secretstream_xchacha20poly1305_init_pull(
-                &mut so_state,
-                push_header.as_ptr(),
-                key.as_ptr(),
-            );
-            assert_eq!(ret, 0);
-        }
-        assert_eq!(
-            general_purpose::STANDARD.encode(so_state.k),
-            general_purpose::STANDARD.encode(push_state_init.k)
-        );
-        assert_eq!(
-            general_purpose::STANDARD.encode(so_state.nonce),
-            general_purpose::STANDARD.encode(push_state_init.nonce)
-        );
-
-        for i in 0..100 {
-            let message = format!("hello {}", i);
-            let aad = format!("aad {}", i);
-            let tag = if i % 7 == 0 { Tag::REKEY } else { Tag::MESSAGE };
-
-            let mut output =
-                vec![0u8; message.len() + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
-            crypto_secretstream_xchacha20poly1305_push(
-                &mut push_state,
-                &mut output,
-                message.as_bytes(),
-                Some(aad.as_bytes()),
-                tag.bits(),
-            )
-            .expect("push failed");
-
-            let mut so_output = output.clone();
-            unsafe {
-                assert!(so_output.len() >= CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES);
-                let ret = so_crypto_secretstream_xchacha20poly1305_pull(
-                    &mut so_state,
-                    so_output.as_mut_ptr(),
-                    &mut mlen_p,
-                    &mut tag_p,
-                    output.as_ptr(),
-                    output.len() as u64,
-                    aad.as_ptr(),
-                    aad.len() as u64,
-                );
-                assert_eq!(ret, 0);
-                so_output.resize(mlen_p as usize, 0);
-            }
-            assert_eq!(
-                general_purpose::STANDARD.encode(&message),
-                general_purpose::STANDARD.encode(&so_output)
-            );
-
-            let mut pull_result_message =
-                vec![0u8; output.len() - CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
-            let mut pull_result_tag = 0u8;
-            crypto_secretstream_xchacha20poly1305_pull(
-                &mut pull_state,
-                &mut pull_result_message,
-                &mut pull_result_tag,
-                &output,
-                Some(aad.as_bytes()),
-            )
-            .expect("pull failed");
-
-            assert_eq!(tag, Tag::from_bits(pull_result_tag).expect("tag"));
-            assert_eq!(
-                general_purpose::STANDARD.encode(&pull_result_message),
-                general_purpose::STANDARD.encode(&message)
-            );
-        }
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_secretstream_basic_pull() {
-        use base64::Engine as _;
-        use base64::engine::general_purpose;
-        use libc::c_ulonglong;
-        use libsodium_sys::{
-            crypto_secretstream_xchacha20poly1305_init_push as so_crypto_secretstream_xchacha20poly1305_init_push,
-            crypto_secretstream_xchacha20poly1305_push as so_crypto_secretstream_xchacha20poly1305_push,
-            crypto_secretstream_xchacha20poly1305_state,
-        };
-
-        use crate::constants::CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES;
-
-        let mut key = Key::default();
-        crypto_secretstream_xchacha20poly1305_keygen(&mut key);
-
-        let mut so_state = crypto_secretstream_xchacha20poly1305_state {
-            k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
-            nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
-            _pad: [0u8; 8],
-        };
-        let mut so_header = Header::default();
-        unsafe {
-            so_crypto_secretstream_xchacha20poly1305_init_push(
-                &mut so_state,
-                so_header.as_mut_ptr(),
-                key.as_ptr(),
-            );
-        }
-
-        let mut pull_state = State::new();
-        crypto_secretstream_xchacha20poly1305_init_pull(&mut pull_state, &so_header, &key);
-
-        let message = b"hello";
-        let aad = b"aad";
-        let mut so_output = vec![0u8; message.len() + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
-        let mut clen_p: c_ulonglong = 0;
-
-        unsafe {
-            let ret = so_crypto_secretstream_xchacha20poly1305_push(
-                &mut so_state,
-                so_output.as_mut_ptr(),
-                &mut clen_p,
-                message.as_ptr(),
-                message.len() as u64,
-                aad.as_ptr(),
-                aad.len() as u64,
-                0,
-            );
-            assert_eq!(ret, 0);
-            so_output.resize(clen_p as usize, 0);
-        }
-
-        let mut output = vec![0u8; so_output.len()];
-        let mut tag = 0u8;
-        let mlen = crypto_secretstream_xchacha20poly1305_pull(
-            &mut pull_state,
-            &mut output,
-            &mut tag,
-            &so_output,
-            Some(aad),
-        )
-        .expect("decrypt failed");
-        output.resize(mlen, 0);
-
-        assert_eq!(
-            general_purpose::STANDARD.encode(&output),
-            general_purpose::STANDARD.encode(message)
-        );
-        assert_eq!(tag, 0);
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_secretstream_lots_of_messages_pull() {
-        use base64::Engine as _;
-        use base64::engine::general_purpose;
-        use libc::c_ulonglong;
-        use libsodium_sys::{
-            crypto_secretstream_xchacha20poly1305_init_push as so_crypto_secretstream_xchacha20poly1305_init_push,
-            crypto_secretstream_xchacha20poly1305_push as so_crypto_secretstream_xchacha20poly1305_push,
-            crypto_secretstream_xchacha20poly1305_state,
-        };
-
-        use crate::constants::CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES;
-        use crate::dryocstream::Tag;
-
-        let mut key = Key::default();
-        crypto_secretstream_xchacha20poly1305_keygen(&mut key);
-
-        let mut so_state = crypto_secretstream_xchacha20poly1305_state {
-            k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
-            nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
-            _pad: [0u8; 8],
-        };
-        let mut so_header = Header::default();
-        unsafe {
-            so_crypto_secretstream_xchacha20poly1305_init_push(
-                &mut so_state,
-                so_header.as_mut_ptr(),
-                key.as_ptr(),
-            );
-        }
-
-        let mut pull_state = State::new();
-        crypto_secretstream_xchacha20poly1305_init_pull(&mut pull_state, &so_header, &key);
-
-        for i in 0..100 {
-            let message = format!("hello {}", i);
-            let aad = format!("aad {}", i);
-            let mut so_output =
-                vec![0u8; message.len() + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
-            let mut clen_p: c_ulonglong = 0;
-
-            let tag = if i % 7 == 0 { Tag::REKEY } else { Tag::MESSAGE };
-
-            unsafe {
-                let ret = so_crypto_secretstream_xchacha20poly1305_push(
-                    &mut so_state,
-                    so_output.as_mut_ptr(),
-                    &mut clen_p,
-                    message.as_ptr(),
-                    message.len() as u64,
-                    aad.as_ptr(),
-                    aad.len() as u64,
-                    tag.bits(),
-                );
-                assert_eq!(ret, 0);
-                so_output.resize(clen_p as usize, 0);
-            }
-
-            let mut output =
-                vec![0u8; so_output.len() - CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
-            let mut outtag = 0u8;
-            crypto_secretstream_xchacha20poly1305_pull(
-                &mut pull_state,
-                &mut output,
-                &mut outtag,
-                &so_output,
-                Some(aad.as_bytes()),
-            )
-            .expect("decrypt failed");
-
-            assert_eq!(
-                general_purpose::STANDARD.encode(so_state.k),
-                general_purpose::STANDARD.encode(pull_state.k)
-            );
-            assert_eq!(
-                general_purpose::STANDARD.encode(so_state.nonce),
-                general_purpose::STANDARD.encode(pull_state.nonce)
-            );
-
-            assert_eq!(
-                general_purpose::STANDARD.encode(&output),
-                general_purpose::STANDARD.encode(&message)
-            );
-            assert_eq!(outtag, tag.bits());
-        }
-    }
-
     #[test]
     fn test_secretstream_large_aad() {
         let mut key = Key::default();
@@ -1087,5 +617,489 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[cfg(dryoc_native_tests)]
+    mod native_tests {
+        use super::*;
+
+        #[test]
+        fn test_secretstream_basic_push() {
+            use base64::Engine as _;
+            use base64::engine::general_purpose;
+            use libsodium_sys::{
+                crypto_secretstream_xchacha20poly1305_init_pull as so_crypto_secretstream_xchacha20poly1305_init_pull,
+                crypto_secretstream_xchacha20poly1305_pull as so_crypto_secretstream_xchacha20poly1305_pull,
+                crypto_secretstream_xchacha20poly1305_push as so_crypto_secretstream_xchacha20poly1305_push,
+                crypto_secretstream_xchacha20poly1305_state,
+            };
+
+            use crate::constants::CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES;
+            use crate::dryocstream::Tag;
+
+            let mut key = Key::default();
+            crypto_secretstream_xchacha20poly1305_keygen(&mut key);
+
+            let mut push_state = State::new();
+            let mut push_header = Header::default();
+            crypto_secretstream_xchacha20poly1305_init_push(
+                &mut push_state,
+                &mut push_header,
+                &key,
+            );
+            let push_state_init = push_state.clone();
+
+            let message = b"hello";
+            let mut output =
+                vec![0u8; message.len() + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
+            let aad = b"";
+            let tag = Tag::MESSAGE.bits();
+            crypto_secretstream_xchacha20poly1305_push(
+                &mut push_state,
+                &mut output,
+                message,
+                Some(aad),
+                tag,
+            )
+            .expect("push failed");
+
+            let mut so_output = output.clone();
+            unsafe {
+                use libc::{c_uchar, c_ulonglong};
+                let mut so_state = crypto_secretstream_xchacha20poly1305_state {
+                    k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
+                    nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
+                    _pad: [0u8; 8],
+                };
+                so_state.k.copy_from_slice(&push_state_init.k);
+                so_state.nonce.copy_from_slice(&push_state_init.nonce);
+                let mut clen_p: c_ulonglong = 0;
+                let ret = so_crypto_secretstream_xchacha20poly1305_push(
+                    &mut so_state,
+                    so_output.as_mut_ptr(),
+                    &mut clen_p,
+                    message.as_ptr(),
+                    message.len() as u64,
+                    aad.as_ptr(),
+                    aad.len() as u64,
+                    0,
+                );
+                assert_eq!(ret, 0);
+                so_output.resize(clen_p as usize, 0);
+                assert_eq!(
+                    general_purpose::STANDARD.encode(&so_output),
+                    general_purpose::STANDARD.encode(&output)
+                );
+                assert_eq!(
+                    general_purpose::STANDARD.encode(so_state.k),
+                    general_purpose::STANDARD.encode(push_state.k)
+                );
+                assert_eq!(
+                    general_purpose::STANDARD.encode(so_state.nonce),
+                    general_purpose::STANDARD.encode(push_state.nonce)
+                );
+
+                let mut so_state = crypto_secretstream_xchacha20poly1305_state {
+                    k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
+                    nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
+                    _pad: [0u8; 8],
+                };
+                let mut mlen_p: c_ulonglong = 0;
+                let mut tag_p: c_uchar = 0;
+                let ret = so_crypto_secretstream_xchacha20poly1305_init_pull(
+                    &mut so_state,
+                    push_header.as_ptr(),
+                    key.as_ptr(),
+                );
+                assert_eq!(ret, 0);
+                assert_eq!(
+                    general_purpose::STANDARD.encode(so_state.k),
+                    general_purpose::STANDARD.encode(push_state_init.k)
+                );
+                assert_eq!(
+                    general_purpose::STANDARD.encode(so_state.nonce),
+                    general_purpose::STANDARD.encode(push_state_init.nonce)
+                );
+                assert!(so_output.len() >= CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES);
+                let ret = so_crypto_secretstream_xchacha20poly1305_pull(
+                    &mut so_state,
+                    so_output.as_mut_ptr(),
+                    &mut mlen_p,
+                    &mut tag_p,
+                    output.as_ptr(),
+                    output.len() as u64,
+                    aad.as_ptr(),
+                    aad.len() as u64,
+                );
+                assert_eq!(ret, 0);
+                so_output.resize(mlen_p as usize, 0);
+            }
+            assert_eq!(
+                general_purpose::STANDARD.encode(message),
+                general_purpose::STANDARD.encode(&so_output)
+            );
+
+            let mut pull_state = State::default();
+            crypto_secretstream_xchacha20poly1305_init_pull(&mut pull_state, &push_header, &key);
+
+            assert_eq!(
+                general_purpose::STANDARD.encode(pull_state.k),
+                general_purpose::STANDARD.encode(push_state_init.k)
+            );
+            assert_eq!(
+                general_purpose::STANDARD.encode(pull_state.nonce),
+                general_purpose::STANDARD.encode(push_state_init.nonce)
+            );
+
+            let mut pull_result_message =
+                vec![0u8; output.len() - CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
+            let mut pull_result_tag = 0u8;
+            crypto_secretstream_xchacha20poly1305_pull(
+                &mut pull_state,
+                &mut pull_result_message,
+                &mut pull_result_tag,
+                &output,
+                Some(&[]),
+            )
+            .expect("pull failed");
+
+            assert_eq!(Tag::MESSAGE, Tag::from_bits(tag).expect("tag"));
+            assert_eq!(
+                general_purpose::STANDARD.encode(&pull_result_message),
+                general_purpose::STANDARD.encode(message)
+            );
+        }
+
+        #[test]
+        fn test_rekey() {
+            use base64::Engine as _;
+            use base64::engine::general_purpose;
+            use libsodium_sys::{
+                crypto_secretstream_xchacha20poly1305_rekey as so_crypto_secretstream_xchacha20poly1305_rekey,
+                crypto_secretstream_xchacha20poly1305_state,
+            };
+
+            use crate::constants::CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES;
+
+            let mut key = Key::default();
+            crypto_secretstream_xchacha20poly1305_keygen(&mut key);
+
+            let mut push_state = State::default();
+            let mut push_header: Header = Header::default();
+            crypto_secretstream_xchacha20poly1305_init_push(
+                &mut push_state,
+                &mut push_header,
+                &key,
+            );
+            let push_state_init = push_state.clone();
+
+            crypto_secretstream_xchacha20poly1305_rekey(&mut push_state);
+
+            let mut so_state = crypto_secretstream_xchacha20poly1305_state {
+                k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
+                nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
+                _pad: [0u8; 8],
+            };
+            so_state.k.copy_from_slice(&push_state_init.k);
+            so_state.nonce.copy_from_slice(&push_state_init.nonce);
+            unsafe {
+                so_crypto_secretstream_xchacha20poly1305_rekey(&mut so_state);
+            }
+            assert_eq!(
+                general_purpose::STANDARD.encode(so_state.k),
+                general_purpose::STANDARD.encode(push_state.k)
+            );
+            assert_eq!(
+                general_purpose::STANDARD.encode(so_state.nonce),
+                general_purpose::STANDARD.encode(push_state.nonce)
+            );
+        }
+
+        #[test]
+        fn test_secretstream_lots_of_messages_push() {
+            use base64::Engine as _;
+            use base64::engine::general_purpose;
+            use libc::{c_uchar, c_ulonglong};
+            use libsodium_sys::{
+                crypto_secretstream_xchacha20poly1305_init_pull as so_crypto_secretstream_xchacha20poly1305_init_pull,
+                crypto_secretstream_xchacha20poly1305_pull as so_crypto_secretstream_xchacha20poly1305_pull,
+                crypto_secretstream_xchacha20poly1305_state,
+            };
+
+            use crate::constants::CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES;
+            use crate::dryocstream::Tag;
+
+            let mut key = Key::default();
+            crypto_secretstream_xchacha20poly1305_keygen(&mut key);
+
+            let mut push_state = State::new();
+            let mut push_header = Header::default();
+            crypto_secretstream_xchacha20poly1305_init_push(
+                &mut push_state,
+                &mut push_header,
+                &key,
+            );
+            let push_state_init = push_state.clone();
+
+            let mut pull_state = State::default();
+            crypto_secretstream_xchacha20poly1305_init_pull(&mut pull_state, &push_header, &key);
+
+            assert_eq!(
+                general_purpose::STANDARD.encode(pull_state.k),
+                general_purpose::STANDARD.encode(push_state_init.k)
+            );
+            assert_eq!(
+                general_purpose::STANDARD.encode(pull_state.nonce),
+                general_purpose::STANDARD.encode(push_state_init.nonce)
+            );
+
+            let mut so_state = crypto_secretstream_xchacha20poly1305_state {
+                k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
+                nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
+                _pad: [0u8; 8],
+            };
+            so_state.k.copy_from_slice(&push_state_init.k);
+            so_state.nonce.copy_from_slice(&push_state_init.nonce);
+
+            let mut so_state = crypto_secretstream_xchacha20poly1305_state {
+                k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
+                nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
+                _pad: [0u8; 8],
+            };
+            let mut mlen_p: c_ulonglong = 0;
+            let mut tag_p: c_uchar = 0;
+            unsafe {
+                let ret = so_crypto_secretstream_xchacha20poly1305_init_pull(
+                    &mut so_state,
+                    push_header.as_ptr(),
+                    key.as_ptr(),
+                );
+                assert_eq!(ret, 0);
+            }
+            assert_eq!(
+                general_purpose::STANDARD.encode(so_state.k),
+                general_purpose::STANDARD.encode(push_state_init.k)
+            );
+            assert_eq!(
+                general_purpose::STANDARD.encode(so_state.nonce),
+                general_purpose::STANDARD.encode(push_state_init.nonce)
+            );
+
+            for i in 0..100 {
+                let message = format!("hello {}", i);
+                let aad = format!("aad {}", i);
+                let tag = if i % 7 == 0 { Tag::REKEY } else { Tag::MESSAGE };
+
+                let mut output =
+                    vec![0u8; message.len() + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
+                crypto_secretstream_xchacha20poly1305_push(
+                    &mut push_state,
+                    &mut output,
+                    message.as_bytes(),
+                    Some(aad.as_bytes()),
+                    tag.bits(),
+                )
+                .expect("push failed");
+
+                let mut so_output = output.clone();
+                unsafe {
+                    assert!(so_output.len() >= CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES);
+                    let ret = so_crypto_secretstream_xchacha20poly1305_pull(
+                        &mut so_state,
+                        so_output.as_mut_ptr(),
+                        &mut mlen_p,
+                        &mut tag_p,
+                        output.as_ptr(),
+                        output.len() as u64,
+                        aad.as_ptr(),
+                        aad.len() as u64,
+                    );
+                    assert_eq!(ret, 0);
+                    so_output.resize(mlen_p as usize, 0);
+                }
+                assert_eq!(
+                    general_purpose::STANDARD.encode(&message),
+                    general_purpose::STANDARD.encode(&so_output)
+                );
+
+                let mut pull_result_message =
+                    vec![0u8; output.len() - CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
+                let mut pull_result_tag = 0u8;
+                crypto_secretstream_xchacha20poly1305_pull(
+                    &mut pull_state,
+                    &mut pull_result_message,
+                    &mut pull_result_tag,
+                    &output,
+                    Some(aad.as_bytes()),
+                )
+                .expect("pull failed");
+
+                assert_eq!(tag, Tag::from_bits(pull_result_tag).expect("tag"));
+                assert_eq!(
+                    general_purpose::STANDARD.encode(&pull_result_message),
+                    general_purpose::STANDARD.encode(&message)
+                );
+            }
+        }
+
+        #[test]
+        fn test_secretstream_basic_pull() {
+            use base64::Engine as _;
+            use base64::engine::general_purpose;
+            use libc::c_ulonglong;
+            use libsodium_sys::{
+                crypto_secretstream_xchacha20poly1305_init_push as so_crypto_secretstream_xchacha20poly1305_init_push,
+                crypto_secretstream_xchacha20poly1305_push as so_crypto_secretstream_xchacha20poly1305_push,
+                crypto_secretstream_xchacha20poly1305_state,
+            };
+
+            use crate::constants::CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES;
+
+            let mut key = Key::default();
+            crypto_secretstream_xchacha20poly1305_keygen(&mut key);
+
+            let mut so_state = crypto_secretstream_xchacha20poly1305_state {
+                k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
+                nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
+                _pad: [0u8; 8],
+            };
+            let mut so_header = Header::default();
+            unsafe {
+                so_crypto_secretstream_xchacha20poly1305_init_push(
+                    &mut so_state,
+                    so_header.as_mut_ptr(),
+                    key.as_ptr(),
+                );
+            }
+
+            let mut pull_state = State::new();
+            crypto_secretstream_xchacha20poly1305_init_pull(&mut pull_state, &so_header, &key);
+
+            let message = b"hello";
+            let aad = b"aad";
+            let mut so_output =
+                vec![0u8; message.len() + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
+            let mut clen_p: c_ulonglong = 0;
+
+            unsafe {
+                let ret = so_crypto_secretstream_xchacha20poly1305_push(
+                    &mut so_state,
+                    so_output.as_mut_ptr(),
+                    &mut clen_p,
+                    message.as_ptr(),
+                    message.len() as u64,
+                    aad.as_ptr(),
+                    aad.len() as u64,
+                    0,
+                );
+                assert_eq!(ret, 0);
+                so_output.resize(clen_p as usize, 0);
+            }
+
+            let mut output = vec![0u8; so_output.len()];
+            let mut tag = 0u8;
+            let mlen = crypto_secretstream_xchacha20poly1305_pull(
+                &mut pull_state,
+                &mut output,
+                &mut tag,
+                &so_output,
+                Some(aad),
+            )
+            .expect("decrypt failed");
+            output.resize(mlen, 0);
+
+            assert_eq!(
+                general_purpose::STANDARD.encode(&output),
+                general_purpose::STANDARD.encode(message)
+            );
+            assert_eq!(tag, 0);
+        }
+
+        #[test]
+        fn test_secretstream_lots_of_messages_pull() {
+            use base64::Engine as _;
+            use base64::engine::general_purpose;
+            use libc::c_ulonglong;
+            use libsodium_sys::{
+                crypto_secretstream_xchacha20poly1305_init_push as so_crypto_secretstream_xchacha20poly1305_init_push,
+                crypto_secretstream_xchacha20poly1305_push as so_crypto_secretstream_xchacha20poly1305_push,
+                crypto_secretstream_xchacha20poly1305_state,
+            };
+
+            use crate::constants::CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES;
+            use crate::dryocstream::Tag;
+
+            let mut key = Key::default();
+            crypto_secretstream_xchacha20poly1305_keygen(&mut key);
+
+            let mut so_state = crypto_secretstream_xchacha20poly1305_state {
+                k: [0u8; CRYPTO_STREAM_CHACHA20_IETF_KEYBYTES],
+                nonce: [0u8; CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES],
+                _pad: [0u8; 8],
+            };
+            let mut so_header = Header::default();
+            unsafe {
+                so_crypto_secretstream_xchacha20poly1305_init_push(
+                    &mut so_state,
+                    so_header.as_mut_ptr(),
+                    key.as_ptr(),
+                );
+            }
+
+            let mut pull_state = State::new();
+            crypto_secretstream_xchacha20poly1305_init_pull(&mut pull_state, &so_header, &key);
+
+            for i in 0..100 {
+                let message = format!("hello {}", i);
+                let aad = format!("aad {}", i);
+                let mut so_output =
+                    vec![0u8; message.len() + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
+                let mut clen_p: c_ulonglong = 0;
+
+                let tag = if i % 7 == 0 { Tag::REKEY } else { Tag::MESSAGE };
+
+                unsafe {
+                    let ret = so_crypto_secretstream_xchacha20poly1305_push(
+                        &mut so_state,
+                        so_output.as_mut_ptr(),
+                        &mut clen_p,
+                        message.as_ptr(),
+                        message.len() as u64,
+                        aad.as_ptr(),
+                        aad.len() as u64,
+                        tag.bits(),
+                    );
+                    assert_eq!(ret, 0);
+                    so_output.resize(clen_p as usize, 0);
+                }
+
+                let mut output =
+                    vec![0u8; so_output.len() - CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES];
+                let mut outtag = 0u8;
+                crypto_secretstream_xchacha20poly1305_pull(
+                    &mut pull_state,
+                    &mut output,
+                    &mut outtag,
+                    &so_output,
+                    Some(aad.as_bytes()),
+                )
+                .expect("decrypt failed");
+
+                assert_eq!(
+                    general_purpose::STANDARD.encode(so_state.k),
+                    general_purpose::STANDARD.encode(pull_state.k)
+                );
+                assert_eq!(
+                    general_purpose::STANDARD.encode(so_state.nonce),
+                    general_purpose::STANDARD.encode(pull_state.nonce)
+                );
+
+                assert_eq!(
+                    general_purpose::STANDARD.encode(&output),
+                    general_purpose::STANDARD.encode(&message)
+                );
+                assert_eq!(outtag, tag.bits());
+            }
+        }
     }
 }

--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -462,7 +462,7 @@ pub fn crypto_secretstream_xchacha20poly1305_pull(
     Ok(mlen)
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::dryocstream::Tag;
@@ -500,6 +500,7 @@ mod tests {
         );
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_secretstream_basic_push() {
         use base64::Engine as _;
@@ -642,6 +643,7 @@ mod tests {
         );
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_rekey() {
         use base64::Engine as _;
@@ -683,6 +685,7 @@ mod tests {
         );
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_secretstream_lots_of_messages_push() {
         use base64::Engine as _;
@@ -806,6 +809,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_secretstream_basic_pull() {
         use base64::Engine as _;
@@ -878,6 +882,7 @@ mod tests {
         assert_eq!(tag, 0);
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_secretstream_lots_of_messages_pull() {
         use base64::Engine as _;

--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -543,12 +543,19 @@ mod tests {
         let mut wrong_aad = large_aad.clone();
         wrong_aad[100] = 0x43; // Change one byte
 
+        let mut wrong_aad_pull_state = State::new();
+        crypto_secretstream_xchacha20poly1305_init_pull(
+            &mut wrong_aad_pull_state,
+            &push_header,
+            &key,
+        );
+
         let mut decrypted = vec![0u8; message.len()];
         let mut tag = 0u8;
 
         assert!(
             crypto_secretstream_xchacha20poly1305_pull(
-                &mut pull_state,
+                &mut wrong_aad_pull_state,
                 &mut decrypted,
                 &mut tag,
                 &ciphertext,
@@ -602,12 +609,19 @@ mod tests {
         // Test with wrong AAD should fail
         let wrong_aad = b"xyz"; // Different 3 byte AAD
 
+        let mut wrong_aad_pull_state = State::new();
+        crypto_secretstream_xchacha20poly1305_init_pull(
+            &mut wrong_aad_pull_state,
+            &push_header,
+            &key,
+        );
+
         let mut decrypted = vec![0u8; message.len()];
         let mut tag = 0u8;
 
         assert!(
             crypto_secretstream_xchacha20poly1305_pull(
-                &mut pull_state,
+                &mut wrong_aad_pull_state,
                 &mut decrypted,
                 &mut tag,
                 &ciphertext,

--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -462,7 +462,7 @@ pub fn crypto_secretstream_xchacha20poly1305_pull(
     Ok(mlen)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use super::*;
     use crate::dryocstream::Tag;

--- a/src/classic/crypto_shorthash.rs
+++ b/src/classic/crypto_shorthash.rs
@@ -57,7 +57,7 @@ pub fn crypto_shorthash(output: &mut Hash, input: &[u8], key: &Key) {
     siphash24(output, input, key)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use rand::TryRng;
 

--- a/src/classic/crypto_shorthash.rs
+++ b/src/classic/crypto_shorthash.rs
@@ -57,7 +57,7 @@ pub fn crypto_shorthash(output: &mut Hash, input: &[u8], key: &Key) {
     siphash24(output, input, key)
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use rand::TryRng;
 

--- a/src/classic/crypto_sign.rs
+++ b/src/classic/crypto_sign.rs
@@ -197,7 +197,7 @@ pub fn crypto_sign_final_verify(
     crypto_sign_ed25519ph_final_verify(state.state, signature, public_key)
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use super::*;
 

--- a/src/classic/crypto_sign.rs
+++ b/src/classic/crypto_sign.rs
@@ -197,7 +197,7 @@ pub fn crypto_sign_final_verify(
     crypto_sign_ed25519ph_final_verify(state.state, signature, public_key)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use super::*;
 

--- a/src/classic/crypto_sign_ed25519.rs
+++ b/src/classic/crypto_sign_ed25519.rs
@@ -322,7 +322,7 @@ pub(crate) fn crypto_sign_ed25519ph_final_verify(
     res
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use base64::Engine as _;
     use base64::engine::general_purpose;

--- a/src/classic/crypto_sign_ed25519.rs
+++ b/src/classic/crypto_sign_ed25519.rs
@@ -322,7 +322,7 @@ pub(crate) fn crypto_sign_ed25519ph_final_verify(
     res
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use base64::Engine as _;
     use base64::engine::general_purpose;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,6 +6,9 @@ const fn min(a: usize, b: usize) -> usize {
 const fn max(a: usize, b: usize) -> usize {
     [a, b][(a < b) as usize]
 }
+const fn min_usize_u64(a: usize, b: u64) -> usize {
+    if (a as u64) < b { a } else { b as usize }
+}
 
 const SODIUM_SIZE_MAX: usize = min(usize::MAX, u64::MAX as usize);
 
@@ -153,7 +156,7 @@ pub const CRYPTO_PWHASH_ARGON2I_BYTES_MAX: usize = min(SODIUM_SIZE_MAX, 42949672
 pub const CRYPTO_PWHASH_ARGON2I_BYTES_MIN: usize = 16;
 pub const CRYPTO_PWHASH_ARGON2I_MEMLIMIT_INTERACTIVE: usize = 33554432;
 pub const CRYPTO_PWHASH_ARGON2I_MEMLIMIT_MAX: usize = max(
-    min(SODIUM_SIZE_MAX, 4398046510080),
+    min_usize_u64(SODIUM_SIZE_MAX, 4398046510080),
     max(
         min(SODIUM_SIZE_MAX, 2147483648),
         min(SODIUM_SIZE_MAX, 32768),
@@ -181,7 +184,7 @@ pub const CRYPTO_PWHASH_ARGON2ID_BYTES_MIN: usize = 16;
 pub const CRYPTO_PWHASH_ARGON2ID_MEMLIMIT_INTERACTIVE: usize = 67108864;
 pub const CRYPTO_PWHASH_ARGON2ID_MEMLIMIT_MIN: usize = 8192;
 pub const CRYPTO_PWHASH_ARGON2ID_MEMLIMIT_MAX: usize = max(
-    min(SODIUM_SIZE_MAX, 4398046510080),
+    min_usize_u64(SODIUM_SIZE_MAX, 4398046510080),
     max(
         min(SODIUM_SIZE_MAX, 2147483648),
         min(SODIUM_SIZE_MAX, 32768),

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -738,130 +738,6 @@ mod tests {
     use super::*;
     use crate::precalc::PrecalcSecretKey;
 
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_dryocbox_vecbox() {
-        for i in 0..20 {
-            use base64::Engine as _;
-            use base64::engine::general_purpose;
-            use sodiumoxide::crypto::box_;
-            use sodiumoxide::crypto::box_::{Nonce as SONonce, PublicKey, SecretKey};
-
-            let keypair_sender = KeyPair::generate();
-            let keypair_recipient = KeyPair::generate();
-            let keypair_sender_copy = keypair_sender.clone();
-            let keypair_recipient_copy = keypair_recipient.clone();
-            let nonce = Nonce::generate();
-            let words = vec!["hello1".to_string(); i];
-            let message = words.join(" :D ");
-            let message_copy = message.clone();
-            let dryocbox = DryocBox::encrypt_to_vecbox(
-                message.as_bytes(),
-                &nonce,
-                &keypair_recipient.public_key,
-                &keypair_sender.secret_key,
-            )
-            .unwrap();
-
-            let ciphertext = dryocbox.to_vec();
-
-            let so_ciphertext = box_::seal(
-                message_copy.as_bytes(),
-                &SONonce::from_slice(&nonce).unwrap(),
-                &PublicKey::from_slice(&keypair_recipient_copy.public_key).unwrap(),
-                &SecretKey::from_slice(&keypair_sender_copy.secret_key).unwrap(),
-            );
-
-            assert_eq!(
-                general_purpose::STANDARD.encode(&ciphertext),
-                general_purpose::STANDARD.encode(&so_ciphertext)
-            );
-
-            let keypair_sender = keypair_sender_copy.clone();
-            let keypair_recipient = keypair_recipient_copy.clone();
-
-            let m = dryocbox
-                .decrypt_to_vec(
-                    &nonce,
-                    &keypair_sender.public_key,
-                    &keypair_recipient.secret_key,
-                )
-                .expect("hmm");
-            let so_m = box_::open(
-                &ciphertext,
-                &SONonce::from_slice(&nonce).unwrap(),
-                &PublicKey::from_slice(&keypair_recipient_copy.public_key).unwrap(),
-                &SecretKey::from_slice(&keypair_sender_copy.secret_key).unwrap(),
-            )
-            .expect("HMMM");
-
-            assert_eq!(m, message_copy.as_bytes());
-            assert_eq!(m, so_m);
-        }
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_decrypt_failure() {
-        for i in 0..20 {
-            use base64::Engine as _;
-            use base64::engine::general_purpose;
-            use sodiumoxide::crypto::box_;
-            use sodiumoxide::crypto::box_::{
-                Nonce as SONonce, PublicKey as SOPublicKey, SecretKey as SOSecretKey,
-            };
-
-            let keypair_sender = KeyPair::generate();
-            let keypair_recipient = KeyPair::generate();
-            let keypair_sender_copy = keypair_sender.clone();
-            let keypair_recipient_copy = keypair_recipient.clone();
-            let nonce = Nonce::generate();
-            let words = vec!["hello1".to_string(); i];
-            let message = words.join(" :D ");
-            let message_copy = message.clone();
-            let dryocbox = DryocBox::encrypt_to_vecbox(
-                message.as_bytes(),
-                &nonce,
-                &keypair_recipient.public_key,
-                &keypair_sender.secret_key,
-            )
-            .unwrap();
-
-            let ciphertext = dryocbox.to_vec();
-
-            let so_ciphertext = box_::seal(
-                message_copy.as_bytes(),
-                &SONonce::from_slice(&nonce).unwrap(),
-                &SOPublicKey::from_slice(&keypair_recipient_copy.public_key).unwrap(),
-                &SOSecretKey::from_slice(&keypair_sender_copy.secret_key).unwrap(),
-            );
-
-            assert_eq!(
-                general_purpose::STANDARD.encode(&ciphertext),
-                general_purpose::STANDARD.encode(&so_ciphertext)
-            );
-
-            let invalid_key = KeyPair::generate();
-            let invalid_key_copy_1 = invalid_key.clone();
-            let invalid_key_copy_2 = invalid_key.clone();
-
-            DryocBox::decrypt::<Nonce, PublicKey, SecretKey, Vec<u8>>(
-                &dryocbox,
-                &nonce,
-                &invalid_key_copy_1.public_key,
-                &invalid_key_copy_2.secret_key,
-            )
-            .expect_err("hmm");
-            box_::open(
-                &ciphertext,
-                &SONonce::from_slice(&nonce).unwrap(),
-                &SOPublicKey::from_slice(&invalid_key.public_key).unwrap(),
-                &SOSecretKey::from_slice(&invalid_key.secret_key).unwrap(),
-            )
-            .expect_err("HMMM");
-        }
-    }
-
     #[test]
     fn test_decrypt_failure_empty() {
         for _ in 0..20 {
@@ -910,61 +786,6 @@ mod tests {
                 DryocBox::new_with_data_and_mac(Mac::try_from(tag).expect("mac"), data);
             assert_eq!(dryocbox.data.as_slice(), &data1_copy[CRYPTO_BOX_MACBYTES..]);
             assert_eq!(dryocbox.tag.as_array(), &data1_copy[..CRYPTO_BOX_MACBYTES]);
-        }
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_dryocbox_seal_vecbox() {
-        for i in 0..20 {
-            use sodiumoxide::crypto::box_::{PublicKey as SOPublicKey, SecretKey as SOSecretKey};
-            use sodiumoxide::crypto::sealedbox::curve25519blake2bxsalsa20poly1305;
-
-            let keypair_recipient = KeyPair::generate();
-            let words = vec!["hello1".to_string(); i];
-            let message = words.join(" :D ");
-            let message_copy = message.clone();
-            let dryocbox =
-                DryocBox::seal_to_vecbox(message.as_bytes(), &keypair_recipient.public_key)
-                    .unwrap();
-
-            let ciphertext = dryocbox.to_vec();
-
-            let m = dryocbox.unseal_to_vec(&keypair_recipient).expect("hmm");
-            let so_m = curve25519blake2bxsalsa20poly1305::open(
-                ciphertext.as_slice(),
-                &SOPublicKey::from_slice(keypair_recipient.public_key.as_slice()).unwrap(),
-                &SOSecretKey::from_slice(keypair_recipient.secret_key.as_slice()).unwrap(),
-            )
-            .unwrap();
-
-            assert_eq!(m, message_copy.as_bytes());
-            assert_eq!(m, so_m);
-        }
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_dryocbox_unseal_vecbox() {
-        for i in 0..20 {
-            use sodiumoxide::crypto::box_::PublicKey as SOPublicKey;
-            use sodiumoxide::crypto::sealedbox::curve25519blake2bxsalsa20poly1305;
-
-            let keypair_recipient = KeyPair::generate();
-            let words = vec!["hello1".to_string(); i];
-            let message = words.join(" :D ");
-
-            let ciphertext = curve25519blake2bxsalsa20poly1305::seal(
-                message.as_bytes(),
-                &SOPublicKey::from_slice(keypair_recipient.public_key.as_slice()).unwrap(),
-            );
-
-            let dryocbox =
-                DryocBox::from_sealed_bytes(&ciphertext).expect("from sealed bytes failed");
-
-            let m = dryocbox.unseal_to_vec(&keypair_recipient).expect("hmm");
-
-            assert_eq!(m, message.as_bytes());
         }
     }
 
@@ -1070,6 +891,188 @@ mod tests {
                 .expect("unable to decrypt");
 
             assert_eq!(*message, decrypted.as_slice());
+        }
+    }
+
+    #[cfg(dryoc_native_tests)]
+    mod native_tests {
+        use super::*;
+
+        #[test]
+        fn test_dryocbox_vecbox() {
+            for i in 0..20 {
+                use base64::Engine as _;
+                use base64::engine::general_purpose;
+                use sodiumoxide::crypto::box_;
+                use sodiumoxide::crypto::box_::{Nonce as SONonce, PublicKey, SecretKey};
+
+                let keypair_sender = KeyPair::generate();
+                let keypair_recipient = KeyPair::generate();
+                let keypair_sender_copy = keypair_sender.clone();
+                let keypair_recipient_copy = keypair_recipient.clone();
+                let nonce = Nonce::generate();
+                let words = vec!["hello1".to_string(); i];
+                let message = words.join(" :D ");
+                let message_copy = message.clone();
+                let dryocbox = DryocBox::encrypt_to_vecbox(
+                    message.as_bytes(),
+                    &nonce,
+                    &keypair_recipient.public_key,
+                    &keypair_sender.secret_key,
+                )
+                .unwrap();
+
+                let ciphertext = dryocbox.to_vec();
+
+                let so_ciphertext = box_::seal(
+                    message_copy.as_bytes(),
+                    &SONonce::from_slice(&nonce).unwrap(),
+                    &PublicKey::from_slice(&keypair_recipient_copy.public_key).unwrap(),
+                    &SecretKey::from_slice(&keypair_sender_copy.secret_key).unwrap(),
+                );
+
+                assert_eq!(
+                    general_purpose::STANDARD.encode(&ciphertext),
+                    general_purpose::STANDARD.encode(&so_ciphertext)
+                );
+
+                let keypair_sender = keypair_sender_copy.clone();
+                let keypair_recipient = keypair_recipient_copy.clone();
+
+                let m = dryocbox
+                    .decrypt_to_vec(
+                        &nonce,
+                        &keypair_sender.public_key,
+                        &keypair_recipient.secret_key,
+                    )
+                    .expect("hmm");
+                let so_m = box_::open(
+                    &ciphertext,
+                    &SONonce::from_slice(&nonce).unwrap(),
+                    &PublicKey::from_slice(&keypair_recipient_copy.public_key).unwrap(),
+                    &SecretKey::from_slice(&keypair_sender_copy.secret_key).unwrap(),
+                )
+                .expect("HMMM");
+
+                assert_eq!(m, message_copy.as_bytes());
+                assert_eq!(m, so_m);
+            }
+        }
+
+        #[test]
+        fn test_decrypt_failure() {
+            for i in 0..20 {
+                use base64::Engine as _;
+                use base64::engine::general_purpose;
+                use sodiumoxide::crypto::box_;
+                use sodiumoxide::crypto::box_::{
+                    Nonce as SONonce, PublicKey as SOPublicKey, SecretKey as SOSecretKey,
+                };
+
+                let keypair_sender = KeyPair::generate();
+                let keypair_recipient = KeyPair::generate();
+                let keypair_sender_copy = keypair_sender.clone();
+                let keypair_recipient_copy = keypair_recipient.clone();
+                let nonce = Nonce::generate();
+                let words = vec!["hello1".to_string(); i];
+                let message = words.join(" :D ");
+                let message_copy = message.clone();
+                let dryocbox = DryocBox::encrypt_to_vecbox(
+                    message.as_bytes(),
+                    &nonce,
+                    &keypair_recipient.public_key,
+                    &keypair_sender.secret_key,
+                )
+                .unwrap();
+
+                let ciphertext = dryocbox.to_vec();
+
+                let so_ciphertext = box_::seal(
+                    message_copy.as_bytes(),
+                    &SONonce::from_slice(&nonce).unwrap(),
+                    &SOPublicKey::from_slice(&keypair_recipient_copy.public_key).unwrap(),
+                    &SOSecretKey::from_slice(&keypair_sender_copy.secret_key).unwrap(),
+                );
+
+                assert_eq!(
+                    general_purpose::STANDARD.encode(&ciphertext),
+                    general_purpose::STANDARD.encode(&so_ciphertext)
+                );
+
+                let invalid_key = KeyPair::generate();
+                let invalid_key_copy_1 = invalid_key.clone();
+                let invalid_key_copy_2 = invalid_key.clone();
+
+                DryocBox::decrypt::<Nonce, PublicKey, SecretKey, Vec<u8>>(
+                    &dryocbox,
+                    &nonce,
+                    &invalid_key_copy_1.public_key,
+                    &invalid_key_copy_2.secret_key,
+                )
+                .expect_err("hmm");
+                box_::open(
+                    &ciphertext,
+                    &SONonce::from_slice(&nonce).unwrap(),
+                    &SOPublicKey::from_slice(&invalid_key.public_key).unwrap(),
+                    &SOSecretKey::from_slice(&invalid_key.secret_key).unwrap(),
+                )
+                .expect_err("HMMM");
+            }
+        }
+
+        #[test]
+        fn test_dryocbox_seal_vecbox() {
+            for i in 0..20 {
+                use sodiumoxide::crypto::box_::{
+                    PublicKey as SOPublicKey, SecretKey as SOSecretKey,
+                };
+                use sodiumoxide::crypto::sealedbox::curve25519blake2bxsalsa20poly1305;
+
+                let keypair_recipient = KeyPair::generate();
+                let words = vec!["hello1".to_string(); i];
+                let message = words.join(" :D ");
+                let message_copy = message.clone();
+                let dryocbox =
+                    DryocBox::seal_to_vecbox(message.as_bytes(), &keypair_recipient.public_key)
+                        .unwrap();
+
+                let ciphertext = dryocbox.to_vec();
+
+                let m = dryocbox.unseal_to_vec(&keypair_recipient).expect("hmm");
+                let so_m = curve25519blake2bxsalsa20poly1305::open(
+                    ciphertext.as_slice(),
+                    &SOPublicKey::from_slice(keypair_recipient.public_key.as_slice()).unwrap(),
+                    &SOSecretKey::from_slice(keypair_recipient.secret_key.as_slice()).unwrap(),
+                )
+                .unwrap();
+
+                assert_eq!(m, message_copy.as_bytes());
+                assert_eq!(m, so_m);
+            }
+        }
+
+        #[test]
+        fn test_dryocbox_unseal_vecbox() {
+            for i in 0..20 {
+                use sodiumoxide::crypto::box_::PublicKey as SOPublicKey;
+                use sodiumoxide::crypto::sealedbox::curve25519blake2bxsalsa20poly1305;
+
+                let keypair_recipient = KeyPair::generate();
+                let words = vec!["hello1".to_string(); i];
+                let message = words.join(" :D ");
+
+                let ciphertext = curve25519blake2bxsalsa20poly1305::seal(
+                    message.as_bytes(),
+                    &SOPublicKey::from_slice(keypair_recipient.public_key.as_slice()).unwrap(),
+                );
+
+                let dryocbox =
+                    DryocBox::from_sealed_bytes(&ciphertext).expect("from sealed bytes failed");
+
+                let m = dryocbox.unseal_to_vec(&keypair_recipient).expect("hmm");
+
+                assert_eq!(m, message.as_bytes());
+            }
         }
     }
 }

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -733,11 +733,12 @@ impl<
     }
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::precalc::PrecalcSecretKey;
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_dryocbox_vecbox() {
         for i in 0..20 {
@@ -799,6 +800,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_decrypt_failure() {
         for i in 0..20 {
@@ -911,6 +913,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_dryocbox_seal_vecbox() {
         for i in 0..20 {
@@ -940,6 +943,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_dryocbox_unseal_vecbox() {
         for i in 0..20 {

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -733,7 +733,7 @@ impl<
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use super::*;
     use crate::precalc::PrecalcSecretKey;

--- a/src/dryocsecretbox.rs
+++ b/src/dryocsecretbox.rs
@@ -397,10 +397,11 @@ impl<Mac: ByteArray<CRYPTO_SECRETBOX_MACBYTES> + Zeroize, Data: Bytes + Zeroize>
     }
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_dryocbox() {
         for i in 0..20 {
@@ -451,6 +452,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_dryocbox_vec() {
         for i in 0..20 {
@@ -538,6 +540,7 @@ mod tests {
         }
     }
 
+    #[cfg(dryoc_native_tests)]
     #[cfg(any(feature = "nightly", all(doc, not(doctest))))]
     #[cfg(feature = "nightly")]
     #[test]

--- a/src/dryocsecretbox.rs
+++ b/src/dryocsecretbox.rs
@@ -397,7 +397,7 @@ impl<Mac: ByteArray<CRYPTO_SECRETBOX_MACBYTES> + Zeroize, Data: Bytes + Zeroize>
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use super::*;
 

--- a/src/dryocsecretbox.rs
+++ b/src/dryocsecretbox.rs
@@ -401,105 +401,6 @@ impl<Mac: ByteArray<CRYPTO_SECRETBOX_MACBYTES> + Zeroize, Data: Bytes + Zeroize>
 mod tests {
     use super::*;
 
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_dryocbox() {
-        for i in 0..20 {
-            use base64::Engine as _;
-            use base64::engine::general_purpose;
-            use sodiumoxide::crypto::secretbox;
-            use sodiumoxide::crypto::secretbox::{Key as SOKey, Nonce as SONonce};
-
-            use crate::dryocsecretbox::*;
-
-            let secret_key = Key::generate();
-            let nonce = Nonce::generate();
-            let words = vec!["hello1".to_string(); i];
-            let message = words.join(" :D ").into_bytes();
-            let message_copy = message.clone();
-            let dryocsecretbox: VecBox = DryocSecretBox::encrypt(&message, &nonce, &secret_key);
-
-            let ciphertext = dryocsecretbox.clone().into_vec();
-            assert_eq!(&ciphertext, &dryocsecretbox.to_vec());
-
-            let ciphertext_copy = ciphertext.clone();
-
-            let so_ciphertext = secretbox::seal(
-                &message_copy,
-                &SONonce::from_slice(&nonce).unwrap(),
-                &SOKey::from_slice(&secret_key).unwrap(),
-            );
-            assert_eq!(
-                general_purpose::STANDARD.encode(&ciphertext),
-                general_purpose::STANDARD.encode(&so_ciphertext)
-            );
-
-            let so_decrypted = secretbox::open(
-                &ciphertext_copy,
-                &SONonce::from_slice(&nonce).unwrap(),
-                &SOKey::from_slice(&secret_key).unwrap(),
-            )
-            .expect("decrypt failed");
-
-            let m = DryocSecretBox::decrypt::<Vec<u8>, Nonce, Key>(
-                &dryocsecretbox,
-                &nonce,
-                &secret_key,
-            )
-            .expect("decrypt failed");
-            assert_eq!(m, message_copy);
-            assert_eq!(m, so_decrypted);
-        }
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_dryocbox_vec() {
-        for i in 0..20 {
-            use base64::Engine as _;
-            use base64::engine::general_purpose;
-            use sodiumoxide::crypto::secretbox;
-            use sodiumoxide::crypto::secretbox::{Key as SOKey, Nonce as SONonce};
-
-            use crate::dryocsecretbox::*;
-
-            let secret_key = Key::generate();
-            let nonce = Nonce::generate();
-            let words = vec!["hello1".to_string(); i];
-            let message = words.join(" :D ").into_bytes();
-            let message_copy = message.clone();
-            let dryocsecretbox = DryocSecretBox::encrypt_to_vecbox(&message, &nonce, &secret_key);
-
-            let ciphertext = dryocsecretbox.clone().into_vec();
-            assert_eq!(&ciphertext, &dryocsecretbox.to_vec());
-
-            let ciphertext_copy = ciphertext.clone();
-
-            let so_ciphertext = secretbox::seal(
-                &message_copy,
-                &SONonce::from_slice(&nonce).unwrap(),
-                &SOKey::from_slice(&secret_key).unwrap(),
-            );
-            assert_eq!(
-                general_purpose::STANDARD.encode(&ciphertext),
-                general_purpose::STANDARD.encode(&so_ciphertext)
-            );
-
-            let so_decrypted = secretbox::open(
-                &ciphertext_copy,
-                &SONonce::from_slice(&nonce).unwrap(),
-                &SOKey::from_slice(&secret_key).unwrap(),
-            )
-            .expect("decrypt failed");
-
-            let m = dryocsecretbox
-                .decrypt_to_vec(&nonce, &secret_key)
-                .expect("decrypt failed");
-            assert_eq!(m, message_copy);
-            assert_eq!(m, so_decrypted);
-        }
-    }
-
     #[test]
     fn test_copy() {
         for _ in 0..20 {
@@ -541,54 +442,154 @@ mod tests {
     }
 
     #[cfg(dryoc_native_tests)]
-    #[cfg(any(feature = "nightly", all(doc, not(doctest))))]
-    #[cfg(feature = "nightly")]
-    #[test]
-    fn test_dryocbox_locked() {
-        for i in 0..20 {
-            use base64::Engine as _;
-            use base64::engine::general_purpose;
-            use sodiumoxide::crypto::secretbox;
-            use sodiumoxide::crypto::secretbox::{Key as SOKey, Nonce as SONonce};
+    mod native_tests {
+        #[test]
+        fn test_dryocbox() {
+            for i in 0..20 {
+                use base64::Engine as _;
+                use base64::engine::general_purpose;
+                use sodiumoxide::crypto::secretbox;
+                use sodiumoxide::crypto::secretbox::{Key as SOKey, Nonce as SONonce};
 
-            use crate::dryocsecretbox::*;
-            use crate::protected::*;
+                use crate::dryocsecretbox::*;
 
-            let secret_key = protected::Key::gen_locked().expect("gen failed");
-            let nonce = protected::Nonce::gen_locked().expect("gen failed");
-            let words = vec!["hello1".to_string(); i];
-            let message = words.join(" :D ");
-            let message_copy = message.clone();
-            let dryocsecretbox: protected::LockedBox =
-                DryocSecretBox::encrypt(message.as_bytes(), &nonce, &secret_key);
+                let secret_key = Key::generate();
+                let nonce = Nonce::generate();
+                let words = vec!["hello1".to_string(); i];
+                let message = words.join(" :D ").into_bytes();
+                let message_copy = message.clone();
+                let dryocsecretbox: VecBox = DryocSecretBox::encrypt(&message, &nonce, &secret_key);
 
-            let ciphertext = dryocsecretbox.to_vec();
+                let ciphertext = dryocsecretbox.clone().into_vec();
+                assert_eq!(&ciphertext, &dryocsecretbox.to_vec());
 
-            let ciphertext_copy = ciphertext.clone();
+                let ciphertext_copy = ciphertext.clone();
 
-            let so_ciphertext = secretbox::seal(
-                message_copy.as_bytes(),
-                &SONonce::from_slice(nonce.as_slice()).unwrap(),
-                &SOKey::from_slice(secret_key.as_slice()).unwrap(),
-            );
-            assert_eq!(
-                general_purpose::STANDARD.encode(&ciphertext),
-                general_purpose::STANDARD.encode(&so_ciphertext)
-            );
+                let so_ciphertext = secretbox::seal(
+                    &message_copy,
+                    &SONonce::from_slice(&nonce).unwrap(),
+                    &SOKey::from_slice(&secret_key).unwrap(),
+                );
+                assert_eq!(
+                    general_purpose::STANDARD.encode(&ciphertext),
+                    general_purpose::STANDARD.encode(&so_ciphertext)
+                );
 
-            let so_decrypted = secretbox::open(
-                &ciphertext_copy,
-                &SONonce::from_slice(nonce.as_slice()).unwrap(),
-                &SOKey::from_slice(secret_key.as_slice()).unwrap(),
-            )
-            .expect("decrypt failed");
-
-            let m: LockedBytes = dryocsecretbox
-                .decrypt(&nonce, &secret_key)
+                let so_decrypted = secretbox::open(
+                    &ciphertext_copy,
+                    &SONonce::from_slice(&nonce).unwrap(),
+                    &SOKey::from_slice(&secret_key).unwrap(),
+                )
                 .expect("decrypt failed");
 
-            assert_eq!(m.as_slice(), message_copy.as_bytes());
-            assert_eq!(m.as_slice(), so_decrypted);
+                let m = DryocSecretBox::decrypt::<Vec<u8>, Nonce, Key>(
+                    &dryocsecretbox,
+                    &nonce,
+                    &secret_key,
+                )
+                .expect("decrypt failed");
+                assert_eq!(m, message_copy);
+                assert_eq!(m, so_decrypted);
+            }
+        }
+
+        #[test]
+        fn test_dryocbox_vec() {
+            for i in 0..20 {
+                use base64::Engine as _;
+                use base64::engine::general_purpose;
+                use sodiumoxide::crypto::secretbox;
+                use sodiumoxide::crypto::secretbox::{Key as SOKey, Nonce as SONonce};
+
+                use crate::dryocsecretbox::*;
+
+                let secret_key = Key::generate();
+                let nonce = Nonce::generate();
+                let words = vec!["hello1".to_string(); i];
+                let message = words.join(" :D ").into_bytes();
+                let message_copy = message.clone();
+                let dryocsecretbox =
+                    DryocSecretBox::encrypt_to_vecbox(&message, &nonce, &secret_key);
+
+                let ciphertext = dryocsecretbox.clone().into_vec();
+                assert_eq!(&ciphertext, &dryocsecretbox.to_vec());
+
+                let ciphertext_copy = ciphertext.clone();
+
+                let so_ciphertext = secretbox::seal(
+                    &message_copy,
+                    &SONonce::from_slice(&nonce).unwrap(),
+                    &SOKey::from_slice(&secret_key).unwrap(),
+                );
+                assert_eq!(
+                    general_purpose::STANDARD.encode(&ciphertext),
+                    general_purpose::STANDARD.encode(&so_ciphertext)
+                );
+
+                let so_decrypted = secretbox::open(
+                    &ciphertext_copy,
+                    &SONonce::from_slice(&nonce).unwrap(),
+                    &SOKey::from_slice(&secret_key).unwrap(),
+                )
+                .expect("decrypt failed");
+
+                let m = dryocsecretbox
+                    .decrypt_to_vec(&nonce, &secret_key)
+                    .expect("decrypt failed");
+                assert_eq!(m, message_copy);
+                assert_eq!(m, so_decrypted);
+            }
+        }
+
+        #[cfg(any(feature = "nightly", all(doc, not(doctest))))]
+        #[cfg(feature = "nightly")]
+        #[test]
+        fn test_dryocbox_locked() {
+            for i in 0..20 {
+                use base64::Engine as _;
+                use base64::engine::general_purpose;
+                use sodiumoxide::crypto::secretbox;
+                use sodiumoxide::crypto::secretbox::{Key as SOKey, Nonce as SONonce};
+
+                use crate::dryocsecretbox::*;
+                use crate::protected::*;
+
+                let secret_key = protected::Key::gen_locked().expect("gen failed");
+                let nonce = protected::Nonce::gen_locked().expect("gen failed");
+                let words = vec!["hello1".to_string(); i];
+                let message = words.join(" :D ");
+                let message_copy = message.clone();
+                let dryocsecretbox: protected::LockedBox =
+                    DryocSecretBox::encrypt(message.as_bytes(), &nonce, &secret_key);
+
+                let ciphertext = dryocsecretbox.to_vec();
+
+                let ciphertext_copy = ciphertext.clone();
+
+                let so_ciphertext = secretbox::seal(
+                    message_copy.as_bytes(),
+                    &SONonce::from_slice(nonce.as_slice()).unwrap(),
+                    &SOKey::from_slice(secret_key.as_slice()).unwrap(),
+                );
+                assert_eq!(
+                    general_purpose::STANDARD.encode(&ciphertext),
+                    general_purpose::STANDARD.encode(&so_ciphertext)
+                );
+
+                let so_decrypted = secretbox::open(
+                    &ciphertext_copy,
+                    &SONonce::from_slice(nonce.as_slice()).unwrap(),
+                    &SOKey::from_slice(secret_key.as_slice()).unwrap(),
+                )
+                .expect("decrypt failed");
+
+                let m: LockedBytes = dryocsecretbox
+                    .decrypt(&nonce, &secret_key)
+                    .expect("decrypt failed");
+
+                assert_eq!(m.as_slice(), message_copy.as_bytes());
+                assert_eq!(m.as_slice(), so_decrypted);
+            }
         }
     }
 }

--- a/src/dryocstream.rs
+++ b/src/dryocstream.rs
@@ -349,7 +349,7 @@ impl DryocStream<Pull> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use super::*;
 

--- a/src/dryocstream.rs
+++ b/src/dryocstream.rs
@@ -349,7 +349,7 @@ impl DryocStream<Pull> {
     }
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use super::*;
 

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -399,7 +399,7 @@ impl<
     }
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(test)]
 mod tests {
 
     use super::*;
@@ -434,6 +434,7 @@ mod tests {
         assert!(all_eq(&keypair.secret_key, 0));
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_gen_keypair() {
         use sodiumoxide::crypto::scalarmult::curve25519::{Scalar, scalarmult_base};

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -399,7 +399,7 @@ impl<
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
 
     use super::*;

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -434,28 +434,6 @@ mod tests {
         assert!(all_eq(&keypair.secret_key, 0));
     }
 
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_gen_keypair() {
-        use sodiumoxide::crypto::scalarmult::curve25519::{Scalar, scalarmult_base};
-
-        use crate::classic::crypto_core::crypto_scalarmult_base;
-
-        let keypair = KeyPair::<
-            StackByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
-            StackByteArray<CRYPTO_BOX_SECRETKEYBYTES>,
-        >::generate();
-
-        let mut public_key = [0u8; CRYPTO_BOX_PUBLICKEYBYTES];
-        crypto_scalarmult_base(&mut public_key, keypair.secret_key.as_array());
-
-        assert_eq!(keypair.public_key.as_array(), &public_key);
-
-        let ge = scalarmult_base(&Scalar::from_slice(&keypair.secret_key).unwrap());
-
-        assert_eq!(ge.as_ref(), public_key);
-    }
-
     #[test]
     fn test_from_secret_key() {
         let keypair_1 = KeyPair::<
@@ -605,5 +583,31 @@ mod tests {
             !KeyPair::<PublicKey, SecretKey>::is_valid_ed25519_key(&identity_pk),
             "Identity element (small order point) should be invalid even with relaxed validation"
         );
+    }
+
+    #[cfg(dryoc_native_tests)]
+    mod native_tests {
+        use super::*;
+
+        #[test]
+        fn test_gen_keypair() {
+            use sodiumoxide::crypto::scalarmult::curve25519::{Scalar, scalarmult_base};
+
+            use crate::classic::crypto_core::crypto_scalarmult_base;
+
+            let keypair = KeyPair::<
+                StackByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
+                StackByteArray<CRYPTO_BOX_SECRETKEYBYTES>,
+            >::generate();
+
+            let mut public_key = [0u8; CRYPTO_BOX_PUBLICKEYBYTES];
+            crypto_scalarmult_base(&mut public_key, keypair.secret_key.as_array());
+
+            assert_eq!(keypair.public_key.as_array(), &public_key);
+
+            let ge = scalarmult_base(&Scalar::from_slice(&keypair.secret_key).unwrap());
+
+            assert_eq!(ge.as_ref(), public_key);
+        }
     }
 }

--- a/src/poly1305/poly1305_soft.rs
+++ b/src/poly1305/poly1305_soft.rs
@@ -235,7 +235,7 @@ impl Poly1305 {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use rand::TryRng;
 

--- a/src/poly1305/poly1305_soft.rs
+++ b/src/poly1305/poly1305_soft.rs
@@ -235,10 +235,8 @@ impl Poly1305 {
     }
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(test)]
 mod tests {
-    use rand::TryRng;
-
     use super::*;
 
     #[cfg(all(feature = "nightly", not(tarpaulin)))]
@@ -258,10 +256,14 @@ mod tests {
         mac.update(text);
         let mac = mac.finalize_to_array();
 
-        use sodiumoxide::crypto::onetimeauth::poly1305::{Key as SOKey, authenticate};
-        let so_key = SOKey::from_slice(&key).expect("key");
-        let so_mac = authenticate(text, &so_key);
-        assert_eq!(mac, so_mac.as_ref());
+        #[cfg(dryoc_native_tests)]
+        {
+            use sodiumoxide::crypto::onetimeauth::poly1305::{Key as SOKey, authenticate};
+
+            let so_key = SOKey::from_slice(&key).expect("key");
+            let so_mac = authenticate(text, &so_key);
+            assert_eq!(mac, so_mac.as_ref());
+        }
         assert_eq!(
             mac,
             [
@@ -366,8 +368,10 @@ mod tests {
         );
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_libsodium() {
+        use rand::TryRng;
         use rand::rngs::SysRng;
         use sodiumoxide::crypto::onetimeauth::poly1305::{Key as SOKey, authenticate};
 
@@ -408,6 +412,7 @@ mod tests {
         });
     }
 
+    #[cfg(dryoc_native_tests)]
     #[cfg(all(feature = "nightly", not(tarpaulin)))]
     fn bench_sodiumoxide_poly1305(b: &mut test::Bencher, len: usize) {
         use sodiumoxide::crypto::onetimeauth::poly1305::{Key as SOKey, authenticate};
@@ -454,24 +459,28 @@ mod tests {
         bench_poly1305(b, crate::poly1305::bench_inputs::MIB_1);
     }
 
+    #[cfg(dryoc_native_tests)]
     #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn sodiumoxide_poly1305_64b_bench(b: &mut test::Bencher) {
         bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::BYTES_64);
     }
 
+    #[cfg(dryoc_native_tests)]
     #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn sodiumoxide_poly1305_1k_bench(b: &mut test::Bencher) {
         bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::KIB_1);
     }
 
+    #[cfg(dryoc_native_tests)]
     #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn sodiumoxide_poly1305_16k_bench(b: &mut test::Bencher) {
         bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::KIB_16);
     }
 
+    #[cfg(dryoc_native_tests)]
     #[cfg(all(feature = "nightly", not(tarpaulin)))]
     #[bench]
     fn sodiumoxide_poly1305_1m_bench(b: &mut test::Bencher) {

--- a/src/poly1305/poly1305_soft.rs
+++ b/src/poly1305/poly1305_soft.rs
@@ -256,14 +256,6 @@ mod tests {
         mac.update(text);
         let mac = mac.finalize_to_array();
 
-        #[cfg(dryoc_native_tests)]
-        {
-            use sodiumoxide::crypto::onetimeauth::poly1305::{Key as SOKey, authenticate};
-
-            let so_key = SOKey::from_slice(&key).expect("key");
-            let so_mac = authenticate(text, &so_key);
-            assert_eq!(mac, so_mac.as_ref());
-        }
         assert_eq!(
             mac,
             [
@@ -368,34 +360,6 @@ mod tests {
         );
     }
 
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_libsodium() {
-        use rand::TryRng;
-        use rand::rngs::SysRng;
-        use sodiumoxide::crypto::onetimeauth::poly1305::{Key as SOKey, authenticate};
-
-        use crate::rng::copy_randombytes;
-
-        let key = Key::generate();
-
-        let so_key = SOKey::from_slice(&key).unwrap();
-
-        for _ in 0..20 {
-            let rand_usize = (SysRng.try_next_u32().unwrap() % 1000) as usize;
-            let mut data = vec![0u8; rand_usize];
-            copy_randombytes(&mut data);
-
-            let mut mac = Poly1305::new(&key);
-            mac.update(&data);
-            let mac = mac.finalize_to_array();
-
-            let so_mac = authenticate(&data, &so_key);
-
-            assert_eq!(mac, so_mac.as_ref());
-        }
-    }
-
     #[cfg(all(feature = "nightly", not(tarpaulin)))]
     fn bench_poly1305(b: &mut test::Bencher, len: usize) {
         use crate::rng::copy_randombytes;
@@ -409,29 +373,6 @@ mod tests {
             let mut mac = Poly1305::new(test::black_box(&key));
             mac.update(test::black_box(&input));
             test::black_box(mac.finalize_to_array());
-        });
-    }
-
-    #[cfg(dryoc_native_tests)]
-    #[cfg(all(feature = "nightly", not(tarpaulin)))]
-    fn bench_sodiumoxide_poly1305(b: &mut test::Bencher, len: usize) {
-        use sodiumoxide::crypto::onetimeauth::poly1305::{Key as SOKey, authenticate};
-
-        use crate::rng::copy_randombytes;
-
-        sodiumoxide::init().expect("sodiumoxide init");
-
-        let key = Key::r#gen();
-        let so_key = SOKey::from_slice(&key).expect("key");
-        let mut input = vec![0u8; len];
-        copy_randombytes(&mut input);
-        b.bytes = len as u64;
-
-        b.iter(|| {
-            let _ = test::black_box(authenticate(
-                test::black_box(&input),
-                test::black_box(&so_key),
-            ));
         });
     }
 
@@ -460,30 +401,80 @@ mod tests {
     }
 
     #[cfg(dryoc_native_tests)]
-    #[cfg(all(feature = "nightly", not(tarpaulin)))]
-    #[bench]
-    fn sodiumoxide_poly1305_64b_bench(b: &mut test::Bencher) {
-        bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::BYTES_64);
-    }
+    mod native_tests {
+        use super::*;
 
-    #[cfg(dryoc_native_tests)]
-    #[cfg(all(feature = "nightly", not(tarpaulin)))]
-    #[bench]
-    fn sodiumoxide_poly1305_1k_bench(b: &mut test::Bencher) {
-        bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::KIB_1);
-    }
+        #[test]
+        fn test_libsodium() {
+            use rand::TryRng;
+            use rand::rngs::SysRng;
+            use sodiumoxide::crypto::onetimeauth::poly1305::{Key as SOKey, authenticate};
 
-    #[cfg(dryoc_native_tests)]
-    #[cfg(all(feature = "nightly", not(tarpaulin)))]
-    #[bench]
-    fn sodiumoxide_poly1305_16k_bench(b: &mut test::Bencher) {
-        bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::KIB_16);
-    }
+            use crate::rng::copy_randombytes;
 
-    #[cfg(dryoc_native_tests)]
-    #[cfg(all(feature = "nightly", not(tarpaulin)))]
-    #[bench]
-    fn sodiumoxide_poly1305_1m_bench(b: &mut test::Bencher) {
-        bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::MIB_1);
+            let key = Key::generate();
+
+            let so_key = SOKey::from_slice(&key).unwrap();
+
+            for _ in 0..20 {
+                let rand_usize = (SysRng.try_next_u32().unwrap() % 1000) as usize;
+                let mut data = vec![0u8; rand_usize];
+                copy_randombytes(&mut data);
+
+                let mut mac = Poly1305::new(&key);
+                mac.update(&data);
+                let mac = mac.finalize_to_array();
+
+                let so_mac = authenticate(&data, &so_key);
+
+                assert_eq!(mac, so_mac.as_ref());
+            }
+        }
+
+        #[cfg(all(feature = "nightly", not(tarpaulin)))]
+        fn bench_sodiumoxide_poly1305(b: &mut test::Bencher, len: usize) {
+            use sodiumoxide::crypto::onetimeauth::poly1305::{Key as SOKey, authenticate};
+
+            use crate::rng::copy_randombytes;
+
+            sodiumoxide::init().expect("sodiumoxide init");
+
+            let key = Key::r#gen();
+            let so_key = SOKey::from_slice(&key).expect("key");
+            let mut input = vec![0u8; len];
+            copy_randombytes(&mut input);
+            b.bytes = len as u64;
+
+            b.iter(|| {
+                let _ = test::black_box(authenticate(
+                    test::black_box(&input),
+                    test::black_box(&so_key),
+                ));
+            });
+        }
+
+        #[cfg(all(feature = "nightly", not(tarpaulin)))]
+        #[bench]
+        fn sodiumoxide_poly1305_64b_bench(b: &mut test::Bencher) {
+            bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::BYTES_64);
+        }
+
+        #[cfg(all(feature = "nightly", not(tarpaulin)))]
+        #[bench]
+        fn sodiumoxide_poly1305_1k_bench(b: &mut test::Bencher) {
+            bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::KIB_1);
+        }
+
+        #[cfg(all(feature = "nightly", not(tarpaulin)))]
+        #[bench]
+        fn sodiumoxide_poly1305_16k_bench(b: &mut test::Bencher) {
+            bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::KIB_16);
+        }
+
+        #[cfg(all(feature = "nightly", not(tarpaulin)))]
+        #[bench]
+        fn sodiumoxide_poly1305_1m_bench(b: &mut test::Bencher) {
+            bench_sodiumoxide_poly1305(b, crate::poly1305::bench_inputs::MIB_1);
+        }
     }
 }

--- a/src/poly1305/u130.rs
+++ b/src/poly1305/u130.rs
@@ -350,7 +350,7 @@ impl DerefMut for U130<Unreduced> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use num_bigint::BigUint;
 

--- a/src/poly1305/u130.rs
+++ b/src/poly1305/u130.rs
@@ -350,7 +350,7 @@ impl DerefMut for U130<Unreduced> {
     }
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(test)]
 mod tests {
     use num_bigint::BigUint;
 

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -94,7 +94,7 @@ impl Default for Sha512 {
     }
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use super::*;
 

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -94,7 +94,7 @@ impl Default for Sha512 {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use super::*;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -118,30 +118,6 @@ mod tests {
         assert_eq!([1, 0, 0], a);
     }
 
-    #[cfg(dryoc_native_tests)]
-    #[test]
-    fn test_sodium_increment() {
-        use libsodium_sys::sodium_increment as so_sodium_increment;
-        use rand::TryRng;
-        use rand::rngs::SysRng;
-
-        use crate::rng::copy_randombytes;
-
-        for _ in 0..20 {
-            let rand_usize = (SysRng.try_next_u32().unwrap() % 1000) as usize;
-            let mut data = vec![0u8; rand_usize];
-            copy_randombytes(&mut data);
-
-            let mut data_copy = data.clone();
-
-            sodium_increment(&mut data);
-
-            unsafe { so_sodium_increment(data_copy.as_mut_ptr(), data_copy.len()) };
-
-            assert_eq!(data, data_copy);
-        }
-    }
-
     #[test]
     fn test_pad16() {
         assert_eq!(pad16(0), 0);
@@ -152,5 +128,33 @@ mod tests {
         assert_eq!(pad16(17), 15);
         assert_eq!(pad16(32), 0);
         assert_eq!(pad16(33), 15);
+    }
+
+    #[cfg(dryoc_native_tests)]
+    mod native_tests {
+        use super::*;
+
+        #[test]
+        fn test_sodium_increment() {
+            use libsodium_sys::sodium_increment as so_sodium_increment;
+            use rand::TryRng;
+            use rand::rngs::SysRng;
+
+            use crate::rng::copy_randombytes;
+
+            for _ in 0..20 {
+                let rand_usize = (SysRng.try_next_u32().unwrap() % 1000) as usize;
+                let mut data = vec![0u8; rand_usize];
+                copy_randombytes(&mut data);
+
+                let mut data_copy = data.clone();
+
+                sodium_increment(&mut data);
+
+                unsafe { so_sodium_increment(data_copy.as_mut_ptr(), data_copy.len()) };
+
+                assert_eq!(data, data_copy);
+            }
+        }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -55,10 +55,8 @@ pub(crate) fn pad16(n: usize) -> usize {
     (0x10 - (n % 16)) & 0xf
 }
 
-#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+#[cfg(test)]
 mod tests {
-    use rand::TryRng;
-
     use super::*;
 
     #[test]
@@ -120,9 +118,11 @@ mod tests {
         assert_eq!([1, 0, 0], a);
     }
 
+    #[cfg(dryoc_native_tests)]
     #[test]
     fn test_sodium_increment() {
         use libsodium_sys::sodium_increment as so_sodium_increment;
+        use rand::TryRng;
         use rand::rngs::SysRng;
 
         use crate::rng::copy_randombytes;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -55,7 +55,7 @@ pub(crate) fn pad16(n: usize) -> usize {
     (0x10 - (n % 16)) & 0xf
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
     use rand::TryRng;
 

--- a/tests/wasm_tests.rs
+++ b/tests/wasm_tests.rs
@@ -1,0 +1,85 @@
+#![cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+
+use dryoc::classic::crypto_generichash::crypto_generichash;
+use dryoc::dryocbox::{DryocBox, KeyPair, NewByteArray, Nonce};
+use dryoc::dryocsecretbox::{DryocSecretBox, Key};
+use dryoc::precalc::PrecalcSecretKey;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+#[wasm_bindgen_test]
+fn dryocbox_roundtrip() {
+    let sender_keypair = KeyPair::generate();
+    let recipient_keypair = KeyPair::generate();
+    let nonce = Nonce::generate();
+    let message = b"wasm dryocbox";
+
+    let dryocbox = DryocBox::encrypt_to_vecbox(
+        message,
+        &nonce,
+        &recipient_keypair.public_key,
+        &sender_keypair.secret_key,
+    )
+    .expect("unable to encrypt");
+
+    let decrypted = dryocbox
+        .decrypt_to_vec(
+            &nonce,
+            &sender_keypair.public_key,
+            &recipient_keypair.secret_key,
+        )
+        .expect("unable to decrypt");
+
+    assert_eq!(message, decrypted.as_slice());
+}
+
+#[wasm_bindgen_test]
+fn dryocbox_precalc_roundtrip() {
+    let sender_keypair = KeyPair::generate();
+    let recipient_keypair = KeyPair::generate();
+    let nonce = Nonce::generate();
+    let message = b"wasm dryocbox precalc";
+    let shared_key =
+        PrecalcSecretKey::precalculate(&recipient_keypair.public_key, &sender_keypair.secret_key);
+
+    let dryocbox =
+        DryocBox::precalc_encrypt_to_vecbox(message, &nonce, &shared_key).expect("encrypt failed");
+    let decrypted = dryocbox
+        .decrypt_to_vec(
+            &nonce,
+            &sender_keypair.public_key,
+            &recipient_keypair.secret_key,
+        )
+        .expect("decrypt failed");
+
+    assert_eq!(message, decrypted.as_slice());
+}
+
+#[wasm_bindgen_test]
+fn dryocsecretbox_roundtrip() {
+    let secret_key = Key::generate();
+    let nonce = dryoc::dryocsecretbox::Nonce::generate();
+    let message = b"wasm dryocsecretbox";
+
+    let dryocsecretbox: dryoc::dryocsecretbox::VecBox =
+        DryocSecretBox::encrypt(message, &nonce, &secret_key);
+    let decrypted: Vec<u8> = dryocsecretbox
+        .decrypt(&nonce, &secret_key)
+        .expect("unable to decrypt");
+
+    assert_eq!(message, decrypted.as_slice());
+}
+
+#[wasm_bindgen_test]
+fn generichash_known_answer() {
+    let mut hash = [0u8; 32];
+    crypto_generichash(&mut hash, b"abc", None).expect("hash failed");
+
+    assert_eq!(
+        &hash,
+        &[
+            0xbd, 0xdd, 0x81, 0x3c, 0x63, 0x42, 0x39, 0x72, 0x31, 0x71, 0xef, 0x3f, 0xee, 0x98,
+            0x57, 0x9b, 0x94, 0x96, 0x4e, 0x3b, 0xb1, 0xcb, 0x3e, 0x42, 0x72, 0x62, 0xc8, 0xc0,
+            0x68, 0xd5, 0x23, 0x19,
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

Adds wasm32-unknown-unknown compatibility coverage for dryoc and wires that coverage into CI. The crate now configures wasm-compatible randomness, skips native-only compatibility test modules on wasm, and adds wasm-bindgen tests for core Rustaceous encryption and hashing paths.

## User Impact

Users targeting wasm can catch regressions in CI before release. The default wasm test command now builds and runs instead of failing on native-only dev dependencies or 32-bit constant overflows.

## Root Cause

The crate depended on OS randomness without enabling the wasm JS entropy backend, used a 64-bit-sized Argon2 memory limit literal in `usize` constants, and compiled native/libsodium-heavy test modules for wasm targets where those dependencies cannot link.

## Fix

Adds target-specific wasm `getrandom` and `wasm-bindgen-test` setup, moves native-only test dependencies behind a non-wasm target cfg, gates native compatibility test modules off for wasm32-unknown-unknown, fixes the Argon2 memory limit constants for 32-bit pointer targets, and adds a GitHub Actions wasm job with a matching wasm-bindgen test runner.

## Validation

- `CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test --target wasm32-unknown-unknown --features serde,base64,wincode`
- `cargo test`
- `cargo clippy --features default -- -D warnings`
- `cargo +nightly fmt --all -- --check`
