### PR TITLE
refactor: reduce dependency surface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,8 @@ rust-version = "1.89"
 version = "0.8.1"
 
 [dependencies]
-base64 = { version = "0.22", optional = true }
-bitflags = "2.11"
 chacha20 = { version = "0.10", features = ["zeroize"] }
 curve25519-dalek = "4.1.3"
-lazy_static = "1"
 rand = { version = "0.10", default-features = false, features = ["sys_rng"] }
 salsa20 = { version = "0.11", features = ["zeroize"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
@@ -48,12 +45,12 @@ proptest = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 sodiumoxide = "0.2"
-static_assertions = "1.1"
 num-bigint = { version = "0.4", features = ["rand"] }
 wincode = "0.5.3"
 
 [features]
-default = ["u64_backend"]
+base64 = []
+default = ["base64", "u64_backend"]
 nightly = []
 simd_backend = []
 u64_backend = []

--- a/src/blake2b/blake2b_simd.rs
+++ b/src/blake2b/blake2b_simd.rs
@@ -669,7 +669,8 @@ pub fn longhash(output: &mut [u8], input: &[u8]) -> Result<(), Error> {
 mod tests {
     #[cfg(feature = "nightly")]
     extern crate test;
-    use lazy_static::lazy_static;
+    use std::sync::LazyLock;
+
     use libc::*;
     use rand::TryRng;
     use serde::{Deserialize, Serialize};
@@ -704,10 +705,9 @@ mod tests {
         out: String,
     }
 
-    lazy_static! {
-        static ref TEST_VECTORS: Vec<TestVector> =
-            serde_json::from_str(include_str!("test-vectors/blake2b-test-vectors.json")).unwrap();
-    }
+    static TEST_VECTORS: LazyLock<Vec<TestVector>> = LazyLock::new(|| {
+        serde_json::from_str(include_str!("test-vectors/blake2b-test-vectors.json")).unwrap()
+    });
 
     #[test]
     fn test_vectors() {

--- a/src/blake2b/blake2b_soft.rs
+++ b/src/blake2b/blake2b_soft.rs
@@ -398,7 +398,8 @@ pub fn longhash(output: &mut [u8], input: &[u8]) -> Result<(), Error> {
 mod tests {
     #[cfg(feature = "nightly")]
     extern crate test;
-    use lazy_static::lazy_static;
+    use std::sync::LazyLock;
+
     use libc::*;
     use serde::{Deserialize, Serialize};
 
@@ -432,10 +433,9 @@ mod tests {
         out: String,
     }
 
-    lazy_static! {
-        static ref TEST_VECTORS: Vec<TestVector> =
-            serde_json::from_str(include_str!("test-vectors/blake2b-test-vectors.json")).unwrap();
-    }
+    static TEST_VECTORS: LazyLock<Vec<TestVector>> = LazyLock::new(|| {
+        serde_json::from_str(include_str!("test-vectors/blake2b-test-vectors.json")).unwrap()
+    });
 
     #[test]
     fn test_vectors() {

--- a/src/classic/crypto_pwhash.rs
+++ b/src/classic/crypto_pwhash.rs
@@ -4,8 +4,8 @@
 //! currently only supports Argon2i and Argon2id algorithms, and does not
 //! support scrypt.
 //!
-//! To use the string-based functions, the `base64` crate feature must be
-//! enabled.
+//! String-based functions are enabled by default. They can be disabled by
+//! building without default features, and re-enabled with the `base64` feature.
 //!
 //! For details, refer to [libsodium docs](https://libsodium.gitbook.io/doc/password_hashing/default_phf).
 //!
@@ -151,17 +151,95 @@ pub fn crypto_pwhash(
 #[cfg(any(feature = "base64", all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "base64")))]
 pub(crate) fn pwhash_to_string(t_cost: u32, m_cost: u32, salt: &[u8], hash: &[u8]) -> String {
-    use base64::Engine as _;
-    use base64::engine::general_purpose;
-
     format!(
         "$argon2id$v={}$m={},t={},p=1${}${}",
         argon2::ARGON2_VERSION_NUMBER,
         m_cost,
         t_cost,
-        general_purpose::STANDARD_NO_PAD.encode(salt),
-        general_purpose::STANDARD_NO_PAD.encode(hash),
+        base64_no_pad_encode(salt),
+        base64_no_pad_encode(hash),
     )
+}
+
+#[cfg(any(feature = "base64", all(doc, not(doctest))))]
+fn base64_no_pad_encode(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    let mut output = String::with_capacity(input.len().div_ceil(3) * 4);
+
+    for chunk in input.chunks_exact(3) {
+        let n = ((chunk[0] as u32) << 16) | ((chunk[1] as u32) << 8) | chunk[2] as u32;
+        output.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+        output.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+        output.push(ALPHABET[((n >> 6) & 0x3f) as usize] as char);
+        output.push(ALPHABET[(n & 0x3f) as usize] as char);
+    }
+
+    let rem = input.chunks_exact(3).remainder();
+    if rem.len() == 1 {
+        let n = (rem[0] as u32) << 16;
+        output.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+        output.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+    } else if rem.len() == 2 {
+        let n = ((rem[0] as u32) << 16) | ((rem[1] as u32) << 8);
+        output.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+        output.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+        output.push(ALPHABET[((n >> 6) & 0x3f) as usize] as char);
+    }
+
+    output
+}
+
+#[cfg(feature = "base64")]
+fn base64_no_pad_decode(input: &str) -> Option<Vec<u8>> {
+    fn decode_byte(byte: u8) -> Option<u8> {
+        match byte {
+            b'A'..=b'Z' => Some(byte - b'A'),
+            b'a'..=b'z' => Some(byte - b'a' + 26),
+            b'0'..=b'9' => Some(byte - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+
+    let input = input.as_bytes();
+    if input.len() % 4 == 1 || input.contains(&b'=') {
+        return None;
+    }
+
+    let mut output = Vec::with_capacity(input.len() / 4 * 3 + 2);
+    for chunk in input.chunks_exact(4) {
+        let n = ((decode_byte(chunk[0])? as u32) << 18)
+            | ((decode_byte(chunk[1])? as u32) << 12)
+            | ((decode_byte(chunk[2])? as u32) << 6)
+            | decode_byte(chunk[3])? as u32;
+        output.push((n >> 16) as u8);
+        output.push((n >> 8) as u8);
+        output.push(n as u8);
+    }
+
+    let rem = input.chunks_exact(4).remainder();
+    if rem.len() == 2 {
+        let second = decode_byte(rem[1])?;
+        if second & 0x0f != 0 {
+            return None;
+        }
+        let n = ((decode_byte(rem[0])? as u32) << 18) | ((second as u32) << 12);
+        output.push((n >> 16) as u8);
+    } else if rem.len() == 3 {
+        let third = decode_byte(rem[2])?;
+        if third & 0x03 != 0 {
+            return None;
+        }
+        let n = ((decode_byte(rem[0])? as u32) << 18)
+            | ((decode_byte(rem[1])? as u32) << 12)
+            | ((third as u32) << 6);
+        output.push((n >> 16) as u8);
+        output.push((n >> 8) as u8);
+    }
+
+    Some(output)
 }
 
 pub(crate) fn convert_costs(opslimit: u64, memlimit: usize) -> (u32, u32) {
@@ -230,12 +308,7 @@ pub(crate) struct Pwhash {
 #[cfg(feature = "base64")]
 impl Pwhash {
     pub(crate) fn parse_encoded_pwhash(hashed_password: &str) -> Result<Self, Error> {
-        use base64::Engine;
         let mut pwhash = Pwhash::default();
-        let base64_engine = base64::engine::general_purpose::GeneralPurpose::new(
-            &base64::alphabet::STANDARD,
-            base64::engine::general_purpose::NO_PAD,
-        );
 
         for s in hashed_password.split('$') {
             if s.is_empty() {
@@ -269,9 +342,9 @@ impl Pwhash {
                     }
                 }
             } else if pwhash.salt.is_none() {
-                pwhash.salt = base64_engine.decode(s).ok();
+                pwhash.salt = base64_no_pad_decode(s);
             } else if pwhash.pwhash.is_none() {
-                pwhash.pwhash = base64_engine.decode(s).ok();
+                pwhash.pwhash = base64_no_pad_decode(s);
             }
         }
 
@@ -389,6 +462,28 @@ mod tests {
         .expect("so pwhash failed");
 
         assert_eq!(hash, so_hash);
+    }
+
+    #[cfg(feature = "base64")]
+    #[test]
+    fn test_base64_no_pad_matches_base64_crate() {
+        use base64::Engine as _;
+        use base64::engine::general_purpose;
+
+        for len in 0..128 {
+            let input: Vec<u8> = (0..len).map(|i| (i * 31 + len) as u8).collect();
+            let encoded = base64_no_pad_encode(&input);
+            assert_eq!(encoded, general_purpose::STANDARD_NO_PAD.encode(&input));
+            assert_eq!(
+                base64_no_pad_decode(&encoded).as_deref(),
+                Some(input.as_slice())
+            );
+        }
+
+        assert_eq!(base64_no_pad_decode("A"), None);
+        assert_eq!(base64_no_pad_decode("AA="), None);
+        assert_eq!(base64_no_pad_decode("A/"), None);
+        assert_eq!(base64_no_pad_decode("AA/"), None);
     }
 
     #[cfg(feature = "base64")]

--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -469,33 +469,31 @@ mod tests {
 
     #[test]
     fn test_sizes() {
-        use static_assertions::*;
-
         use crate::constants::*;
 
-        const_assert!(
+        const _: () = assert!(
             CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_HEADERBYTES
                 == CRYPTO_CORE_HCHACHA20_INPUTBYTES
                     + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_INONCEBYTES
         );
 
-        const_assert!(
+        const _: () = assert!(
             CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_HEADERBYTES
                 == CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES
         );
 
-        const_assert!(
+        const _: () = assert!(
             CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES
                 == CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_INONCEBYTES
                     + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_COUNTERBYTES
         );
 
-        const_assert!(
+        const _: () = assert!(
             CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_MESSAGEBYTES_MAX
                 <= CRYPTO_AEAD_CHACHA20POLY1305_IETF_MESSAGEBYTES_MAX
         );
 
-        const_assert!(
+        const _: () = assert!(
             CRYPTO_ONETIMEAUTH_POLY1305_BYTES >= CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_INONCEBYTES
         );
     }

--- a/src/dryocstream.rs
+++ b/src/dryocstream.rs
@@ -70,7 +70,6 @@
 //! * See the [protected] mod for an example using the protected memory features
 //!   with [`DryocStream`]
 
-use bitflags::bitflags;
 use zeroize::Zeroize;
 
 use crate::classic::crypto_secretstream_xchacha20poly1305::{
@@ -80,13 +79,13 @@ use crate::classic::crypto_secretstream_xchacha20poly1305::{
 };
 use crate::constants::{
     CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_HEADERBYTES,
-    CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_KEYBYTES,
-    CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_MESSAGE,
-    CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_PUSH,
-    CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_REKEY, CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES,
+    CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_KEYBYTES, CRYPTO_STREAM_CHACHA20_IETF_NONCEBYTES,
 };
 use crate::error::Error;
 pub use crate::types::*;
+
+mod tag;
+pub use tag::{Tag, TagIter, TagIterNames};
 
 /// Stream mode marker trait
 pub trait Mode {}
@@ -171,28 +170,6 @@ pub mod protected {
     /// Heap-allocated, page-aligned header for authenticated secret
     /// streams, for use with protected memory.
     pub type Header = HeapByteArray<CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_HEADERBYTES>;
-}
-
-bitflags! {
-    /// Message tag definitions
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-    pub struct Tag: u8 {
-        /// Describes a normal message in a stream.
-        const MESSAGE = CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_MESSAGE;
-        /// Indicates the message marks the end of a series of messages in a
-        /// stream, but not the end of the stream.
-        const PUSH = CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_PUSH;
-        /// Derives a new key for the stream.
-        const REKEY = CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_REKEY;
-        /// Indicates the end of the stream.
-        const FINAL = Self::PUSH.bits() | Self::REKEY.bits();
-    }
-}
-
-impl From<u8> for Tag {
-    fn from(other: u8) -> Self {
-        Self::from_bits(other).expect("Unable to parse tag")
-    }
 }
 
 /// Secret-key authenticated encrypted streams

--- a/src/dryocstream/tag.rs
+++ b/src/dryocstream/tag.rs
@@ -196,6 +196,12 @@ impl Tag {
     }
 }
 
+impl Default for Tag {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 impl fmt::Debug for Tag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Tag(")?;
@@ -404,5 +410,161 @@ impl Iterator for TagIterNames {
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Tag;
+
+    #[test]
+    fn tag_constructors_and_names_cover_known_and_unknown_bits() {
+        assert_eq!(Tag::default(), Tag::empty());
+        assert_eq!(Tag::default(), Tag::MESSAGE);
+        assert_eq!(Tag::all(), Tag::FINAL);
+
+        for bits in 0..=u8::MAX {
+            let retained = Tag::from_bits_retain(bits);
+            assert_eq!(retained.bits(), bits);
+            assert_eq!(Tag::from_bits_truncate(bits).bits(), bits & Tag::KNOWN_BITS);
+
+            let expected = if bits & !Tag::KNOWN_BITS == 0 {
+                Some(retained)
+            } else {
+                None
+            };
+            assert_eq!(Tag::from_bits(bits), expected);
+        }
+
+        assert_eq!(Tag::from(Tag::FINAL.bits()), Tag::FINAL);
+        assert_eq!(Tag::from_name("MESSAGE"), Some(Tag::MESSAGE));
+        assert_eq!(Tag::from_name("PUSH"), Some(Tag::PUSH));
+        assert_eq!(Tag::from_name("REKEY"), Some(Tag::REKEY));
+        assert_eq!(Tag::from_name("FINAL"), Some(Tag::FINAL));
+        assert_eq!(Tag::from_name("UNKNOWN"), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unable to parse tag")]
+    fn tag_from_u8_rejects_unknown_bits() {
+        let _ = Tag::from(0x80);
+    }
+
+    #[test]
+    fn tag_predicates_and_mutators_match_flag_semantics() {
+        assert!(Tag::empty().is_empty());
+        assert!(Tag::MESSAGE.is_empty());
+        assert!(!Tag::PUSH.is_empty());
+        assert!(Tag::FINAL.is_all());
+        assert!(Tag::from_bits_retain(Tag::FINAL.bits() | 0x80).is_all());
+        assert!(!Tag::PUSH.is_all());
+
+        assert!(Tag::FINAL.contains(Tag::PUSH));
+        assert!(Tag::PUSH.contains(Tag::MESSAGE));
+        assert!(!Tag::PUSH.contains(Tag::REKEY));
+        assert!(Tag::FINAL.intersects(Tag::PUSH));
+        assert!(!Tag::PUSH.intersects(Tag::REKEY));
+
+        let mut tag = Tag::empty();
+        tag.insert(Tag::PUSH);
+        assert_eq!(tag, Tag::PUSH);
+        tag.insert(Tag::REKEY);
+        assert_eq!(tag, Tag::FINAL);
+        tag.remove(Tag::PUSH);
+        assert_eq!(tag, Tag::REKEY);
+        tag.toggle(Tag::PUSH);
+        assert_eq!(tag, Tag::FINAL);
+        tag.set(Tag::REKEY, false);
+        assert_eq!(tag, Tag::PUSH);
+        tag.set(Tag::REKEY, true);
+        assert_eq!(tag, Tag::FINAL);
+        tag.clear();
+        assert_eq!(tag, Tag::empty());
+    }
+
+    #[test]
+    fn tag_set_operations_and_operators_match_flag_semantics() {
+        assert_eq!(Tag::PUSH.union(Tag::REKEY), Tag::FINAL);
+        assert_eq!(Tag::FINAL.intersection(Tag::PUSH), Tag::PUSH);
+        assert_eq!(Tag::FINAL.difference(Tag::PUSH), Tag::REKEY);
+        assert_eq!(Tag::FINAL.symmetric_difference(Tag::PUSH), Tag::REKEY);
+        assert_eq!(Tag::PUSH.complement(), Tag::REKEY);
+
+        assert_eq!(Tag::PUSH | Tag::REKEY, Tag::FINAL);
+        assert_eq!(Tag::FINAL & Tag::PUSH, Tag::PUSH);
+        assert_eq!(Tag::FINAL ^ Tag::PUSH, Tag::REKEY);
+        assert_eq!(Tag::FINAL - Tag::PUSH, Tag::REKEY);
+        assert_eq!(!Tag::PUSH, Tag::REKEY);
+
+        let mut tag = Tag::PUSH;
+        tag |= Tag::REKEY;
+        assert_eq!(tag, Tag::FINAL);
+        tag &= Tag::PUSH;
+        assert_eq!(tag, Tag::PUSH);
+        tag ^= Tag::REKEY;
+        assert_eq!(tag, Tag::FINAL);
+        tag -= Tag::PUSH;
+        assert_eq!(tag, Tag::REKEY);
+    }
+
+    #[test]
+    fn tag_iterators_skip_zero_bit_message_and_retain_unknown_bits() {
+        assert_eq!(Tag::MESSAGE.iter().collect::<Vec<_>>(), Vec::<Tag>::new());
+        assert_eq!(
+            Tag::FINAL.iter().collect::<Vec<_>>(),
+            vec![Tag::PUSH, Tag::REKEY]
+        );
+        assert_eq!(
+            Tag::FINAL.iter_names().collect::<Vec<_>>(),
+            vec![("PUSH", Tag::PUSH), ("REKEY", Tag::REKEY)]
+        );
+
+        let unknown = Tag::from_bits_retain(0x80);
+        let retained = Tag::from_bits_retain(Tag::FINAL.bits() | unknown.bits());
+
+        assert_eq!(
+            retained.iter().collect::<Vec<_>>(),
+            vec![Tag::PUSH, Tag::REKEY, unknown]
+        );
+        assert_eq!(
+            retained.iter_names().collect::<Vec<_>>(),
+            vec![("PUSH", Tag::PUSH), ("REKEY", Tag::REKEY)]
+        );
+        assert_eq!(unknown.iter().collect::<Vec<_>>(), vec![unknown]);
+        assert_eq!(unknown.iter_names().collect::<Vec<_>>(), Vec::new());
+        assert_eq!(
+            Tag::FINAL.into_iter().collect::<Vec<_>>(),
+            vec![Tag::PUSH, Tag::REKEY]
+        );
+    }
+
+    #[test]
+    fn tag_formatting_matches_bitflags_style() {
+        assert_eq!(format!("{:?}", Tag::empty()), "Tag(0x0)");
+        assert_eq!(format!("{:?}", Tag::MESSAGE), "Tag(0x0)");
+        assert_eq!(format!("{:?}", Tag::PUSH), "Tag(PUSH)");
+        assert_eq!(format!("{:?}", Tag::REKEY), "Tag(REKEY)");
+        assert_eq!(format!("{:?}", Tag::FINAL), "Tag(PUSH | REKEY)");
+
+        let retained = Tag::from_bits_retain(Tag::FINAL.bits() | 0x80);
+        assert_eq!(format!("{retained:?}"), "Tag(PUSH | REKEY | 0x80)");
+        assert_eq!(format!("{retained:b}"), format!("{:b}", retained.bits()));
+        assert_eq!(format!("{retained:o}"), format!("{:o}", retained.bits()));
+        assert_eq!(format!("{retained:x}"), format!("{:x}", retained.bits()));
+        assert_eq!(format!("{retained:X}"), format!("{:X}", retained.bits()));
+        assert_eq!(
+            format!("{retained:#04x}"),
+            format!("{:#04x}", retained.bits())
+        );
+    }
+
+    #[test]
+    fn tag_collection_traits_accumulate_flags() {
+        let mut tag = Tag::empty();
+        tag.extend([Tag::PUSH, Tag::REKEY]);
+        assert_eq!(tag, Tag::FINAL);
+
+        let tag: Tag = [Tag::PUSH, Tag::REKEY].into_iter().collect();
+        assert_eq!(tag, Tag::FINAL);
     }
 }

--- a/src/dryocstream/tag.rs
+++ b/src/dryocstream/tag.rs
@@ -1,0 +1,408 @@
+use std::fmt;
+use std::ops::{
+    BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Sub, SubAssign,
+};
+
+use crate::constants::{
+    CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_MESSAGE,
+    CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_PUSH,
+    CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_REKEY,
+};
+
+/// Message tag definitions.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Tag(u8);
+
+const TAG_ITER_FLAGS: [Tag; 2] = [Tag::PUSH, Tag::REKEY];
+const TAG_ITER_NAMES: [(&str, Tag); 2] = [("PUSH", Tag::PUSH), ("REKEY", Tag::REKEY)];
+
+impl Tag {
+    /// Indicates the end of the stream.
+    pub const FINAL: Self = Self(Self::PUSH.bits() | Self::REKEY.bits());
+    const KNOWN_BITS: u8 = Self::MESSAGE.bits() | Self::PUSH.bits() | Self::REKEY.bits();
+    /// Describes a normal message in a stream.
+    pub const MESSAGE: Self = Self(CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_MESSAGE);
+    /// Indicates the message marks the end of a series of messages in a
+    /// stream, but not the end of the stream.
+    pub const PUSH: Self = Self(CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_PUSH);
+    /// Derives a new key for the stream.
+    pub const REKEY: Self = Self(CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_TAG_REKEY);
+
+    /// Get a flags value with all bits unset.
+    #[inline]
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    /// Get a flags value with all known bits set.
+    #[inline]
+    pub const fn all() -> Self {
+        Self(Self::KNOWN_BITS)
+    }
+
+    /// Get the underlying bits value.
+    #[inline]
+    pub const fn bits(&self) -> u8 {
+        self.0
+    }
+
+    /// Convert from a bits value, returning `None` if any unknown bits are set.
+    #[inline]
+    pub const fn from_bits(bits: u8) -> Option<Self> {
+        if bits & !Self::KNOWN_BITS == 0 {
+            Some(Self(bits))
+        } else {
+            None
+        }
+    }
+
+    /// Convert from a bits value, unsetting any unknown bits.
+    #[inline]
+    pub const fn from_bits_truncate(bits: u8) -> Self {
+        Self(bits & Self::KNOWN_BITS)
+    }
+
+    /// Convert from a bits value exactly.
+    #[inline]
+    pub const fn from_bits_retain(bits: u8) -> Self {
+        Self(bits)
+    }
+
+    /// Get a flags value with the bits of a flag with the given name set.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "MESSAGE" => Some(Self::MESSAGE),
+            "PUSH" => Some(Self::PUSH),
+            "REKEY" => Some(Self::REKEY),
+            "FINAL" => Some(Self::FINAL),
+            _ => None,
+        }
+    }
+
+    /// Whether all bits in this flags value are unset.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.bits() == 0
+    }
+
+    /// Whether all known bits in this flags value are set.
+    #[inline]
+    pub const fn is_all(&self) -> bool {
+        Self::KNOWN_BITS | self.bits() == self.bits()
+    }
+
+    /// Whether any set bits in a source flags value are also set in a target
+    /// flags value.
+    #[inline]
+    pub const fn intersects(&self, other: Self) -> bool {
+        self.bits() & other.bits() != 0
+    }
+
+    /// Whether all set bits in a source flags value are also set in a target
+    /// flags value.
+    #[inline]
+    pub const fn contains(&self, other: Self) -> bool {
+        self.bits() & other.bits() == other.bits()
+    }
+
+    /// The bitwise or (`|`) of the bits in two flags values.
+    #[inline]
+    pub fn insert(&mut self, other: Self) {
+        *self = self.union(other);
+    }
+
+    /// The intersection of a source flags value with the complement of a target
+    /// flags value (`&!`).
+    #[inline]
+    pub fn remove(&mut self, other: Self) {
+        *self = self.difference(other);
+    }
+
+    /// The bitwise exclusive-or (`^`) of the bits in two flags values.
+    #[inline]
+    pub fn toggle(&mut self, other: Self) {
+        *self = self.symmetric_difference(other);
+    }
+
+    /// Call [`insert`](Self::insert) when `value` is `true` or
+    /// [`remove`](Self::remove) when `value` is `false`.
+    #[inline]
+    pub fn set(&mut self, other: Self, value: bool) {
+        if value {
+            self.insert(other);
+        } else {
+            self.remove(other);
+        }
+    }
+
+    /// Unsets all bits in the flags.
+    #[inline]
+    pub fn clear(&mut self) {
+        *self = Self::empty();
+    }
+
+    /// The bitwise and (`&`) of the bits in two flags values.
+    #[inline]
+    #[must_use]
+    pub const fn intersection(self, other: Self) -> Self {
+        Self(self.bits() & other.bits())
+    }
+
+    /// The bitwise or (`|`) of the bits in two flags values.
+    #[inline]
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.bits() | other.bits())
+    }
+
+    /// The intersection of a source flags value with the complement of a target
+    /// flags value (`&!`).
+    #[inline]
+    #[must_use]
+    pub const fn difference(self, other: Self) -> Self {
+        Self(self.bits() & !other.bits())
+    }
+
+    /// The bitwise exclusive-or (`^`) of the bits in two flags values.
+    #[inline]
+    #[must_use]
+    pub const fn symmetric_difference(self, other: Self) -> Self {
+        Self(self.bits() ^ other.bits())
+    }
+
+    /// The bitwise negation (`!`) of the bits in a flags value, truncating the
+    /// result.
+    #[inline]
+    #[must_use]
+    pub const fn complement(self) -> Self {
+        Self::from_bits_truncate(!self.bits())
+    }
+
+    /// Yield a set of contained flags values.
+    pub const fn iter(&self) -> TagIter {
+        TagIter {
+            remaining: *self,
+            index: 0,
+            yielded_unknown: false,
+        }
+    }
+
+    /// Yield a set of contained named flags values.
+    pub const fn iter_names(&self) -> TagIterNames {
+        TagIterNames {
+            remaining: *self,
+            index: 0,
+        }
+    }
+}
+
+impl fmt::Debug for Tag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Tag(")?;
+
+        let mut first = true;
+        for (name, _) in self.iter_names() {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            first = false;
+            f.write_str(name)?;
+        }
+
+        let unknown = self.bits() & !Self::KNOWN_BITS;
+        if unknown != 0 || first {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            write!(f, "0x{unknown:x}")?;
+        }
+
+        f.write_str(")")
+    }
+}
+
+impl fmt::Binary for Tag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Binary::fmt(&self.bits(), f)
+    }
+}
+
+impl fmt::Octal for Tag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Octal::fmt(&self.bits(), f)
+    }
+}
+
+impl fmt::LowerHex for Tag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.bits(), f)
+    }
+}
+
+impl fmt::UpperHex for Tag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.bits(), f)
+    }
+}
+
+impl BitOr for Tag {
+    type Output = Self;
+
+    #[inline]
+    fn bitor(self, other: Self) -> Self {
+        self.union(other)
+    }
+}
+
+impl BitOrAssign for Tag {
+    #[inline]
+    fn bitor_assign(&mut self, other: Self) {
+        self.insert(other);
+    }
+}
+
+impl BitAnd for Tag {
+    type Output = Self;
+
+    #[inline]
+    fn bitand(self, other: Self) -> Self {
+        self.intersection(other)
+    }
+}
+
+impl BitAndAssign for Tag {
+    #[inline]
+    fn bitand_assign(&mut self, other: Self) {
+        *self = self.intersection(other);
+    }
+}
+
+impl BitXor for Tag {
+    type Output = Self;
+
+    #[inline]
+    fn bitxor(self, other: Self) -> Self {
+        self.symmetric_difference(other)
+    }
+}
+
+impl BitXorAssign for Tag {
+    #[inline]
+    fn bitxor_assign(&mut self, other: Self) {
+        self.toggle(other);
+    }
+}
+
+impl Sub for Tag {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, other: Self) -> Self {
+        self.difference(other)
+    }
+}
+
+impl SubAssign for Tag {
+    #[inline]
+    fn sub_assign(&mut self, other: Self) {
+        self.remove(other);
+    }
+}
+
+impl Not for Tag {
+    type Output = Self;
+
+    #[inline]
+    fn not(self) -> Self {
+        self.complement()
+    }
+}
+
+impl Extend<Tag> for Tag {
+    fn extend<T: IntoIterator<Item = Self>>(&mut self, iter: T) {
+        for item in iter {
+            self.insert(item);
+        }
+    }
+}
+
+impl FromIterator<Tag> for Tag {
+    fn from_iter<T: IntoIterator<Item = Self>>(iter: T) -> Self {
+        let mut result = Self::empty();
+        result.extend(iter);
+        result
+    }
+}
+
+impl IntoIterator for Tag {
+    type IntoIter = TagIter;
+    type Item = Tag;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl From<u8> for Tag {
+    fn from(other: u8) -> Self {
+        Self::from_bits(other).expect("Unable to parse tag")
+    }
+}
+
+/// Iterator over contained secretstream tags.
+#[derive(Clone, Debug)]
+pub struct TagIter {
+    remaining: Tag,
+    index: usize,
+    yielded_unknown: bool,
+}
+
+impl Iterator for TagIter {
+    type Item = Tag;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.index < TAG_ITER_FLAGS.len() {
+            let flag = TAG_ITER_FLAGS[self.index];
+            self.index += 1;
+
+            if self.remaining.contains(flag) {
+                self.remaining.remove(flag);
+                return Some(flag);
+            }
+        }
+
+        let unknown = self.remaining.bits() & !Tag::KNOWN_BITS;
+        if unknown != 0 && !self.yielded_unknown {
+            self.yielded_unknown = true;
+            self.remaining.remove(Tag::from_bits_retain(unknown));
+            Some(Tag::from_bits_retain(unknown))
+        } else {
+            None
+        }
+    }
+}
+
+/// Iterator over contained named secretstream tags.
+#[derive(Clone, Debug)]
+pub struct TagIterNames {
+    remaining: Tag,
+    index: usize,
+}
+
+impl Iterator for TagIterNames {
+    type Item = (&'static str, Tag);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.index < TAG_ITER_NAMES.len() {
+            let (name, flag) = TAG_ITER_NAMES[self.index];
+            self.index += 1;
+
+            if self.remaining.contains(flag) {
+                self.remaining.remove(flag);
+                return Some((name, flag));
+            }
+        }
+
+        None
+    }
+}

--- a/src/protected.rs
+++ b/src/protected.rs
@@ -71,8 +71,8 @@
 use std::alloc::{AllocError, Allocator, Layout};
 use std::marker::PhantomData;
 use std::ptr;
+use std::sync::LazyLock;
 
-use lazy_static::lazy_static;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::error;
@@ -695,26 +695,24 @@ impl Lockable<HeapBytes> for HeapBytes {
 /// allocated region of memory.
 pub struct PageAlignedAllocator;
 
-lazy_static! {
-    static ref PAGESIZE: usize = {
-        #[cfg(unix)]
-        {
-            use libc::{_SC_PAGE_SIZE, sysconf};
-            // SAFETY: `sysconf(_SC_PAGE_SIZE)` has no pointer arguments and
-            // returns the host page size or an error sentinel.
-            unsafe { sysconf(_SC_PAGE_SIZE) as usize }
-        }
-        #[cfg(windows)]
-        {
-            use winapi::um::sysinfoapi::{GetSystemInfo, SYSTEM_INFO};
-            let mut si = SYSTEM_INFO::default();
-            // SAFETY: `si` is a valid writable `SYSTEM_INFO` out-parameter for
-            // the duration of the call.
-            unsafe { GetSystemInfo(&mut si) };
-            si.dwPageSize as usize
-        }
-    };
-}
+static PAGESIZE: LazyLock<usize> = LazyLock::new(|| {
+    #[cfg(unix)]
+    {
+        use libc::{_SC_PAGE_SIZE, sysconf};
+        // SAFETY: `sysconf(_SC_PAGE_SIZE)` has no pointer arguments and returns
+        // the host page size or an error sentinel.
+        unsafe { sysconf(_SC_PAGE_SIZE) as usize }
+    }
+    #[cfg(windows)]
+    {
+        use winapi::um::sysinfoapi::{GetSystemInfo, SYSTEM_INFO};
+        let mut si = SYSTEM_INFO::default();
+        // SAFETY: `si` is a valid writable `SYSTEM_INFO` out-parameter for the
+        // duration of the call.
+        unsafe { GetSystemInfo(&mut si) };
+        si.dwPageSize as usize
+    }
+});
 
 fn _page_round(size: usize, pagesize: usize) -> Option<usize> {
     let rem = size % pagesize;

--- a/src/protected.rs
+++ b/src/protected.rs
@@ -695,13 +695,26 @@ impl Lockable<HeapBytes> for HeapBytes {
 /// allocated region of memory.
 pub struct PageAlignedAllocator;
 
+#[cfg(unix)]
+const DEFAULT_PAGESIZE: usize = 4096;
+
+#[cfg(unix)]
+fn page_size_from_sysconf(page_size: libc::c_long) -> usize {
+    if page_size > 0 {
+        page_size as usize
+    } else {
+        DEFAULT_PAGESIZE
+    }
+}
+
 static PAGESIZE: LazyLock<usize> = LazyLock::new(|| {
     #[cfg(unix)]
     {
         use libc::{_SC_PAGE_SIZE, sysconf};
         // SAFETY: `sysconf(_SC_PAGE_SIZE)` has no pointer arguments and returns
         // the host page size or an error sentinel.
-        unsafe { sysconf(_SC_PAGE_SIZE) as usize }
+        let page_size = unsafe { sysconf(_SC_PAGE_SIZE) };
+        page_size_from_sysconf(page_size)
     }
     #[cfg(windows)]
     {
@@ -1593,6 +1606,14 @@ mod tests {
         assert_eq!(_page_round(pagesize, pagesize), Some(pagesize));
         assert_eq!(_page_round(pagesize + 1, pagesize), Some(pagesize * 2));
         assert_eq!(_page_round(usize::MAX, pagesize), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_page_size_from_sysconf_handles_error_sentinel() {
+        assert_eq!(page_size_from_sysconf(-1), DEFAULT_PAGESIZE);
+        assert_eq!(page_size_from_sysconf(0), DEFAULT_PAGESIZE);
+        assert_eq!(page_size_from_sysconf(8192), 8192);
     }
 
     #[cfg_attr(

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
-use lazy_static::__Deref;
+use std::ops::Deref;
+
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::rng::copy_randombytes;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -449,7 +449,7 @@ impl<const LENGTH: usize> std::convert::AsMut<[u8]> for StackByteArray<LENGTH> {
     }
 }
 
-impl<const LENGTH: usize> std::ops::Deref for StackByteArray<LENGTH> {
+impl<const LENGTH: usize> Deref for StackByteArray<LENGTH> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
@@ -457,7 +457,7 @@ impl<const LENGTH: usize> std::ops::Deref for StackByteArray<LENGTH> {
     }
 }
 
-impl<const LENGTH: usize> std::ops::DerefMut for StackByteArray<LENGTH> {
+impl<const LENGTH: usize> DerefMut for StackByteArray<LENGTH> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }


### PR DESCRIPTION
## Summary

Reduces dryoc's normal dependency surface by replacing small utility crates with local or standard-library implementations while preserving the relevant public behavior.

## User Impact

Default builds continue to expose password-hash string helpers, and consumers can still opt into `dryoc/base64`; the crate now pulls fewer normal third-party dependencies. `dryocstream::Tag` keeps practical bitflags-style source compatibility for constants, methods, operators, formatting, and iteration, but no longer implements external `bitflags` traits or returns external iterator types.

## Root Cause

Small utility crates were used for narrow behavior: lazy initialization, bitflag tag handling, password-hash base64 encoding, and test-only const assertions.

## Fix

Replaces `lazy_static` with `std::sync::LazyLock`, implements password-hash standard no-padding base64 locally, replaces `dryocstream::Tag`'s `bitflags` dependency with a local compatibility implementation, and uses native const assertions in tests. Keeps `base64 = []` as a compatibility feature and enables it by default.

## Validation

- `cargo check`
- `cargo check --no-default-features`
- `cargo check --features serde,wincode`
- `cargo test --features base64`
- `cargo test dryocstream --lib`
- `cargo clippy --features default -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo tree -e normal --depth 1` confirms `bitflags`, `base64`, and `lazy_static` are not normal dependencies
