### PR TITLE
perf: use soft poly1305 on aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ For example usage, refer to the
   * Blake2b (used by generic hashing, password hashing, and key derivation)
   * Argon2 block mixing (used by password hashing)
   * Salsa20 (used by XSalsa20-Poly1305 secretbox)
-  * Poly1305 (used by one-time authentication and secret boxes)
+  * Poly1305 (used by one-time authentication and secret boxes), except on
+    AArch64 where dryoc keeps the soft backend because the portable-SIMD path
+    is slower there
 * [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek) (used by public/private key functions) selects its own serial or x86_64 vector backend at build time
 * [SHA2](https://github.com/RustCrypto/hashes/tree/master/sha2) (used by sealed boxes) includes SIMD implementation for AVX2
 * [ChaCha20](https://github.com/RustCrypto/stream-ciphers/tree/master/chacha20) (used by streaming interface) includes SIMD implementations for NEON, AVX2, and SSE2
@@ -76,6 +78,10 @@ benefit from target-specific `RUSTFLAGS`:
 
 The Curve25519 backend is selected by `curve25519-dalek`, not by dryoc's
 `simd_backend` feature.
+
+Poly1305 is a special exception on AArch64: even with `simd_backend` and
+`nightly` enabled, dryoc uses the soft Poly1305 backend because profiling shows
+the portable-SIMD implementation is slower on that architecture.
 
 _Note that eventually this project will converge on portable SIMD implementations
 for all the core algos which will work across all platforms supported by LLVM,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,9 @@
 //!   * Blake2b (used by generic hashing, password hashing, and key derivation)
 //!   * Argon2 block mixing (used by password hashing)
 //!   * Salsa20 (used by XSalsa20-Poly1305 secretbox)
-//!   * Poly1305 (used by one-time authentication and secret boxes)
+//!   * Poly1305 (used by one-time authentication and secret boxes), except on
+//!     AArch64 where dryoc keeps the soft backend because the portable-SIMD path
+//!     is slower there
 //! * [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek)
 //!   (used by public/private key functions) selects its own serial or x86_64
 //!   vector backend at build time
@@ -67,6 +69,10 @@
 //!
 //! The Curve25519 backend is selected by `curve25519-dalek`, not by dryoc's
 //! `simd_backend` feature.
+//!
+//! Poly1305 is a special exception on AArch64: even with `simd_backend` and
+//! `nightly` enabled, dryoc uses the soft Poly1305 backend because profiling
+//! shows the portable-SIMD implementation is slower on that architecture.
 //!
 //! _Note that eventually this project will converge on portable SIMD
 //! implementations for all the core algos which will work across all platforms

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,8 @@
 //!   * Argon2 block mixing (used by password hashing)
 //!   * Salsa20 (used by XSalsa20-Poly1305 secretbox)
 //!   * Poly1305 (used by one-time authentication and secret boxes), except on
-//!     AArch64 where dryoc keeps the soft backend because the portable-SIMD path
-//!     is slower there
+//!     AArch64 where dryoc keeps the soft backend because the portable-SIMD
+//!     path is slower there
 //! * [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek)
 //!   (used by public/private key functions) selects its own serial or x86_64
 //!   vector backend at build time

--- a/src/poly1305/mod.rs
+++ b/src/poly1305/mod.rs
@@ -1,7 +1,15 @@
-#[cfg(all(feature = "simd_backend", feature = "nightly"))]
+#[cfg(all(
+    feature = "simd_backend",
+    feature = "nightly",
+    not(target_arch = "aarch64")
+))]
 pub(crate) mod poly1305_simd;
 
-#[cfg(any(test, not(all(feature = "simd_backend", feature = "nightly"))))]
+#[cfg(any(
+    test,
+    target_arch = "aarch64",
+    not(all(feature = "simd_backend", feature = "nightly"))
+))]
 pub(crate) mod poly1305_soft;
 
 const BLOCK_SIZE: usize = 16;
@@ -24,7 +32,16 @@ mod bench_inputs {
     pub(super) const MIB_1: usize = 1024 * 1024;
 }
 
-#[cfg(all(feature = "simd_backend", feature = "nightly"))]
+// On aarch64, the portable-SIMD Poly1305 backend is slower than the u128
+// 3-limb implementation. Keep the soft backend there even with simd_backend.
+#[cfg(all(
+    feature = "simd_backend",
+    feature = "nightly",
+    not(target_arch = "aarch64")
+))]
 pub(crate) use poly1305_simd::*;
-#[cfg(not(all(feature = "simd_backend", feature = "nightly")))]
+#[cfg(any(
+    target_arch = "aarch64",
+    not(all(feature = "simd_backend", feature = "nightly"))
+))]
 pub(crate) use poly1305_soft::*;


### PR DESCRIPTION
## Summary

Use the existing soft Poly1305 backend on AArch64 even when `simd_backend,nightly` is enabled, and document this as a deliberate architecture-specific exception.

## User Impact

Users building dryoc with the SIMD backend on AArch64 avoid selecting a slower portable-SIMD Poly1305 implementation. Other SIMD-backed internals remain enabled where supported.

## Root Cause

The portable-SIMD Poly1305 backend is not faster on AArch64. Profiling a 1 MiB one-time-auth workload showed the soft `u128` 3-limb implementation performing better than the portable-SIMD path on this host.

## Fix

Gate `poly1305_simd` out on AArch64 and export `poly1305_soft` for that architecture. README and crate-level docs now call out Poly1305 as a special AArch64 exception under `simd_backend,nightly`.

## Validation

- `cargo test --features simd_backend,nightly`
- `cargo clippy --features simd_backend,nightly -- -D warnings`
- macOS `sample` profiling against temporary release harnesses: isolated Poly1305 improved from 2979.5 MiB/s with `poly1305_simd` to 3099.3 MiB/s with `poly1305_soft` on the tested AArch64 host.
