### PR TITLE
perf: remove redundant poly1305 state stores

### DIFF
--- a/src/poly1305/poly1305_soft.rs
+++ b/src/poly1305/poly1305_soft.rs
@@ -116,18 +116,10 @@ impl Poly1305 {
             h1 = h1.wrapping_add(((t0 >> 44) | (t1 << 20)) & 0xfffffffffff);
             h2 = h2.wrapping_add(((t1 >> 24) & 0x3ffffffffff) | hibit);
 
-            self.h[0] = h0;
-            self.h[1] = h1;
-            self.h[2] = h2;
-
             // h *= r
             let d0 = mul(h0, r0) + mul(h1, s2) + mul(h2, s1);
             let mut d1 = mul(h0, r1) + mul(h1, r0) + mul(h2, s2);
             let mut d2 = mul(h0, r2) + mul(h1, r1) + mul(h2, r0);
-
-            self.h[0] = h0;
-            self.h[1] = h1;
-            self.h[2] = h2;
 
             // (partial) h %= p
             let mut c = shr(d0, 44);


### PR DESCRIPTION
## Summary

Remove redundant per-block `self.h` stores from the software Poly1305 block loop. Profiling showed Poly1305 remains a meaningful share of secretbox/box runtime after the aarch64 backend selection change, and this trims unnecessary memory traffic while keeping the accumulator in local variables until the existing end-of-loop state write.

## User Impact

Users get a faster software Poly1305 path without API, wire format, feature gate, or compatibility changes. This also helps Poly1305-backed secretbox and box operations, although those workloads are still primarily dominated by Salsa20 in the sampled profiles.

## Root Cause

The Poly1305 soft loop wrote `h0`, `h1`, and `h2` back to `self.h` twice before those fields were read again. The loop already carries the accumulator in locals, so the intermediate stores did not affect computation and only added per-block memory writes.

## Fix

Delete the two redundant `self.h[0..2]` store groups inside `Poly1305::blocks`. The final reduced accumulator store remains unchanged, preserving the existing state update point.

## Validation

- `cargo test --features simd_backend,nightly poly1305::poly1305_soft::tests`
- `cargo clippy --features simd_backend,nightly -- -D warnings`
- Earlier profiling/bench data on this branch:
  - Poly1305 1MiB bench improved from `310,819 ns` / `3373 MiB/s` to `279,015-280,571 ns` / `3737-3758 MiB/s`.
  - Poly1305 harness throughput improved from `3214.6 MiB/s` to `3415.1 MiB/s`.
  - Secretbox harness remained noisy but comparable/slightly better, with Salsa20 still the dominant sampled hotspot.
