### PR TITLE
perf: avoid detached secretbox buffer copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ in Rust. Some optional SIMD code, including dependency-provided SIMD
 implementations and small internal helpers, may contain unsafe code. In
 particular, many SIMD implementations are considered "unsafe" due to their use
 of assembly or intrinsics, however without SIMD-based cryptography you may be
-exposed to timing attacks. See the
-[rustdoc unsafe code summary](https://docs.rs/dryoc/latest/dryoc/#unsafe-code)
-for the non-test unsafe inventory in this crate.
+exposed to timing attacks. The in-crate unsafe inventory includes fixed-size
+byte views, optional wincode schema impls, BLAKE2b parameter byte views,
+protected memory, and Salsa20 SIMD unaligned in-place and buffer-to-buffer XOR.
+See the [rustdoc unsafe code summary](https://docs.rs/dryoc/latest/dryoc/#unsafe-code)
+for the full non-test unsafe inventory in this crate.

--- a/src/classic/crypto_secretbox.rs
+++ b/src/classic/crypto_secretbox.rs
@@ -67,8 +67,7 @@ pub fn crypto_secretbox_detached(
     nonce: &Nonce,
     key: &Key,
 ) {
-    ciphertext[..message.len()].copy_from_slice(message);
-    crypto_secretbox_detached_inplace(ciphertext, mac, nonce, key);
+    crypto_secretbox_detached_b2b(&mut ciphertext[..message.len()], mac, message, nonce, key);
 }
 
 /// Detached version of [`crypto_secretbox_open_easy`].
@@ -82,8 +81,7 @@ pub fn crypto_secretbox_open_detached(
     key: &Key,
 ) -> Result<(), Error> {
     let c_len = ciphertext.len();
-    message[..c_len].copy_from_slice(ciphertext);
-    crypto_secretbox_open_detached_inplace(message, mac, nonce, key)
+    crypto_secretbox_open_detached_b2b(&mut message[..c_len], mac, ciphertext, nonce, key)
 }
 
 /// Encrypts `message` with `nonce` and `key`.
@@ -263,6 +261,56 @@ mod tests {
             assert_eq!(&decrypted, &message_copy);
             assert_eq!(decrypted, so_decrypted);
         }
+    }
+
+    #[test]
+    fn test_crypto_secretbox_detached_only_touches_message_len() {
+        let key = crypto_secretbox_keygen();
+        let nonce = Nonce::generate();
+        let message = b"detached secretbox buffer prefix";
+        let mut ciphertext = vec![0xa5; message.len() + 8];
+        let mut mac = Mac::default();
+
+        crypto_secretbox_detached(&mut ciphertext, &mut mac, message, &nonce, &key);
+
+        assert_eq!(&ciphertext[message.len()..], &[0xa5; 8]);
+
+        let mut decrypted = vec![0x5a; message.len() + 8];
+        crypto_secretbox_open_detached(
+            &mut decrypted,
+            &mac,
+            &ciphertext[..message.len()],
+            &nonce,
+            &key,
+        )
+        .expect("decrypt failed");
+
+        assert_eq!(&decrypted[..message.len()], message);
+        assert_eq!(&decrypted[message.len()..], &[0x5a; 8]);
+    }
+
+    #[test]
+    fn test_crypto_secretbox_open_failure_keeps_output() {
+        let key = crypto_secretbox_keygen();
+        let nonce = Nonce::generate();
+        let message = b"authenticated plaintext";
+        let mut ciphertext = vec![0u8; message.len()];
+        let mut mac = Mac::default();
+
+        crypto_secretbox_detached(&mut ciphertext, &mut mac, message, &nonce, &key);
+        mac[0] ^= 1;
+
+        let mut decrypted = vec![0x5a; message.len()];
+        let original_decrypted = decrypted.clone();
+        assert!(
+            crypto_secretbox_open_detached(&mut decrypted, &mac, &ciphertext, &nonce, &key)
+                .is_err()
+        );
+        assert_eq!(decrypted, original_decrypted);
+
+        let mut inplace = ciphertext.clone();
+        assert!(crypto_secretbox_open_detached_inplace(&mut inplace, &mac, &nonce, &key).is_err());
+        assert_eq!(inplace, ciphertext);
     }
 
     #[cfg(feature = "nightly")]

--- a/src/classic/crypto_secretbox_impl.rs
+++ b/src/classic/crypto_secretbox_impl.rs
@@ -39,6 +39,11 @@ impl SecretBoxCipher {
     fn xor(&mut self, data: &mut [u8]) {
         self.cipher.xor_after_first_block(data, &self.first_block);
     }
+
+    fn xor_b2b(&mut self, output: &mut [u8], input: &[u8]) {
+        self.cipher
+            .xor_after_first_block_b2b(output, input, &self.first_block);
+    }
 }
 
 #[cfg(not(all(feature = "simd_backend", feature = "nightly")))]
@@ -58,6 +63,60 @@ impl SecretBoxCipher {
 
     fn xor(&mut self, data: &mut [u8]) {
         self.cipher.apply_keystream(data);
+    }
+
+    fn xor_b2b(&mut self, output: &mut [u8], input: &[u8]) {
+        self.cipher.apply_keystream_b2b(input, output);
+    }
+}
+
+pub(crate) fn crypto_secretbox_detached_b2b(
+    ciphertext: &mut [u8],
+    mac: &mut Mac,
+    message: &[u8],
+    nonce: &Nonce,
+    key: &Key,
+) {
+    debug_assert_eq!(ciphertext.len(), message.len());
+
+    let mut mac_key = Poly1305Key::new();
+    {
+        let mut cipher = SecretBoxCipher::new(nonce, key);
+        cipher.poly1305_key(&mut mac_key);
+        cipher.xor_b2b(ciphertext, message);
+    }
+
+    let mut computed_mac = Poly1305::new(&mac_key);
+    mac_key.zeroize();
+
+    computed_mac.update(ciphertext);
+    computed_mac.finalize(mac);
+}
+
+pub(crate) fn crypto_secretbox_open_detached_b2b(
+    message: &mut [u8],
+    mac: &Mac,
+    ciphertext: &[u8],
+    nonce: &Nonce,
+    key: &Key,
+) -> Result<(), Error> {
+    debug_assert_eq!(message.len(), ciphertext.len());
+
+    let mut cipher = SecretBoxCipher::new(nonce, key);
+    let mut mac_key = Poly1305Key::new();
+    cipher.poly1305_key(&mut mac_key);
+
+    let mut computed_mac = Poly1305::new(&mac_key);
+    mac_key.zeroize();
+
+    computed_mac.update(ciphertext);
+    let computed_mac = computed_mac.finalize_to_array();
+
+    if mac.ct_eq(&computed_mac).unwrap_u8() == 1 {
+        cipher.xor_b2b(message, ciphertext);
+        Ok(())
+    } else {
+        Err(dryoc_error!("decryption error (authentication failure)"))
     }
 }
 
@@ -87,22 +146,18 @@ pub(crate) fn crypto_secretbox_open_detached_inplace(
     nonce: &Nonce,
     key: &Key,
 ) -> Result<(), Error> {
-    let computed_mac = {
-        let mut cipher = SecretBoxCipher::new(nonce, key);
-        let mut mac_key = Poly1305Key::new();
-        cipher.poly1305_key(&mut mac_key);
+    let mut cipher = SecretBoxCipher::new(nonce, key);
+    let mut mac_key = Poly1305Key::new();
+    cipher.poly1305_key(&mut mac_key);
 
-        let mut computed_mac = Poly1305::new(&mac_key);
-        mac_key.zeroize();
+    let mut computed_mac = Poly1305::new(&mac_key);
+    mac_key.zeroize();
 
-        computed_mac.update(data);
-        let computed_mac = computed_mac.finalize_to_array();
-
-        cipher.xor(data);
-        computed_mac
-    };
+    computed_mac.update(data);
+    let computed_mac = computed_mac.finalize_to_array();
 
     if mac.ct_eq(&computed_mac).unwrap_u8() == 1 {
+        cipher.xor(data);
         Ok(())
     } else {
         Err(dryoc_error!("decryption error (authentication failure)"))

--- a/src/classic/salsa20_simd.rs
+++ b/src/classic/salsa20_simd.rs
@@ -146,6 +146,24 @@ fn xor_4words(data: &mut [u8], offset: usize, words: U32x4) {
     }
 }
 
+#[cfg(target_endian = "little")]
+#[inline]
+fn xor_4words_b2b(output: &mut [u8], input: &[u8], offset: usize, words: U32x4) {
+    debug_assert!(offset + 16 <= output.len());
+    debug_assert!(offset + 16 <= input.len());
+
+    // SAFETY: `offset..offset + 16` is in bounds for both buffers at all call
+    // sites in the 256-byte four-block loop. The unaligned read/write operate
+    // on initialized bytes, `u32` has no invalid bit patterns, and native word
+    // order is the required little-endian Salsa20 order on this cfg path.
+    unsafe {
+        let input_ptr = input.as_ptr().add(offset).cast::<[u32; 4]>();
+        let output_ptr = output.as_mut_ptr().add(offset).cast::<[u32; 4]>();
+        let input_words = U32x4::from(ptr::read_unaligned(input_ptr));
+        ptr::write_unaligned(output_ptr, (input_words ^ words).to_array());
+    }
+}
+
 #[cfg(not(target_endian = "little"))]
 #[inline]
 fn xor_4words(data: &mut [u8], offset: usize, words: U32x4) {
@@ -157,6 +175,20 @@ fn xor_4words(data: &mut [u8], offset: usize, words: U32x4) {
     ]);
     for (i, word) in (data_words ^ words).to_array().iter().enumerate() {
         data[offset + i * 4..offset + (i + 1) * 4].copy_from_slice(&word.to_le_bytes());
+    }
+}
+
+#[cfg(not(target_endian = "little"))]
+#[inline]
+fn xor_4words_b2b(output: &mut [u8], input: &[u8], offset: usize, words: U32x4) {
+    let input_words = U32x4::from([
+        load_u32_le(&input[offset..offset + 4]),
+        load_u32_le(&input[offset + 4..offset + 8]),
+        load_u32_le(&input[offset + 8..offset + 12]),
+        load_u32_le(&input[offset + 12..offset + 16]),
+    ]);
+    for (i, word) in (input_words ^ words).to_array().iter().enumerate() {
+        output[offset + i * 4..offset + (i + 1) * 4].copy_from_slice(&word.to_le_bytes());
     }
 }
 
@@ -196,6 +228,47 @@ fn transpose_and_xor_4words(
     );
 }
 
+#[inline]
+fn transpose_and_xor_4words_b2b(
+    output: &mut [u8],
+    input: &[u8],
+    word_offset: usize,
+    w0: U32x4,
+    w1: U32x4,
+    w2: U32x4,
+    w3: U32x4,
+) {
+    let b01_lo = simd_swizzle!(w0, w1, [0, 4, 1, 5]);
+    let b01_hi = simd_swizzle!(w0, w1, [2, 6, 3, 7]);
+    let b23_lo = simd_swizzle!(w2, w3, [0, 4, 1, 5]);
+    let b23_hi = simd_swizzle!(w2, w3, [2, 6, 3, 7]);
+
+    xor_4words_b2b(
+        output,
+        input,
+        word_offset,
+        simd_swizzle!(b01_lo, b23_lo, [0, 1, 4, 5]),
+    );
+    xor_4words_b2b(
+        output,
+        input,
+        64 + word_offset,
+        simd_swizzle!(b01_lo, b23_lo, [2, 3, 6, 7]),
+    );
+    xor_4words_b2b(
+        output,
+        input,
+        128 + word_offset,
+        simd_swizzle!(b01_hi, b23_hi, [0, 1, 4, 5]),
+    );
+    xor_4words_b2b(
+        output,
+        input,
+        192 + word_offset,
+        simd_swizzle!(b01_hi, b23_hi, [2, 3, 6, 7]),
+    );
+}
+
 fn salsa20_xor_4blocks(data: &mut [u8], input_lanes: &[U32x4; 16], counter: u64) {
     debug_assert_eq!(data.len(), 256);
 
@@ -210,6 +283,36 @@ fn salsa20_xor_4blocks(data: &mut [u8], input_lanes: &[U32x4; 16], counter: u64)
     for word_offset in (0..16).step_by(4) {
         transpose_and_xor_4words(
             data,
+            word_offset * 4,
+            state[word_offset] + orig[word_offset],
+            state[word_offset + 1] + orig[word_offset + 1],
+            state[word_offset + 2] + orig[word_offset + 2],
+            state[word_offset + 3] + orig[word_offset + 3],
+        );
+    }
+}
+
+fn salsa20_xor_4blocks_b2b(
+    output: &mut [u8],
+    input: &[u8],
+    input_lanes: &[U32x4; 16],
+    counter: u64,
+) {
+    debug_assert_eq!(output.len(), 256);
+    debug_assert_eq!(input.len(), 256);
+
+    let mut state = *input_lanes;
+    let (counter_low, counter_high) = counter_lanes(counter);
+    state[8] = counter_low;
+    state[9] = counter_high;
+
+    let orig = state;
+    salsa20_rounds(&mut state);
+
+    for word_offset in (0..16).step_by(4) {
+        transpose_and_xor_4words_b2b(
+            output,
+            input,
             word_offset * 4,
             state[word_offset] + orig[word_offset],
             state[word_offset + 1] + orig[word_offset + 1],
@@ -302,6 +405,53 @@ impl XSalsa20 {
             block.zeroize();
             counter = checked_counter_add(counter, 1);
             remaining = &mut remaining[xor_len..];
+        }
+    }
+
+    pub(crate) fn xor_after_first_block_b2b(
+        &self,
+        output: &mut [u8],
+        input: &[u8],
+        first_block: &FirstBlock,
+    ) {
+        debug_assert_eq!(output.len(), input.len());
+
+        let first_xor_len = input.len().min(32);
+        for ((out, byte), keystream) in output
+            .iter_mut()
+            .zip(input.iter())
+            .take(first_xor_len)
+            .zip(first_block.block[32..].iter())
+        {
+            *out = *byte ^ *keystream;
+        }
+
+        let mut remaining_output = &mut output[first_xor_len..];
+        let mut remaining_input = &input[first_xor_len..];
+        let mut counter = 1u64;
+        while remaining_input.len() >= 256 {
+            let (output_chunk, output_rest) = remaining_output.split_at_mut(256);
+            let (input_chunk, input_rest) = remaining_input.split_at(256);
+            salsa20_xor_4blocks_b2b(output_chunk, input_chunk, &self.input_lanes, counter);
+            counter = checked_counter_add(counter, 4);
+            remaining_output = output_rest;
+            remaining_input = input_rest;
+        }
+        while !remaining_input.is_empty() {
+            let mut block = salsa20_block(&self.input, counter);
+            let xor_len = remaining_input.len().min(64);
+            for ((out, byte), keystream) in remaining_output
+                .iter_mut()
+                .take(xor_len)
+                .zip(remaining_input.iter())
+                .zip(block.iter())
+            {
+                *out = *byte ^ *keystream;
+            }
+            block.zeroize();
+            counter = checked_counter_add(counter, 1);
+            remaining_output = &mut remaining_output[xor_len..];
+            remaining_input = &remaining_input[xor_len..];
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@
 //! | `src/dryocbox.rs` and `src/dryocsecretbox.rs` wincode impls | `wincode` | Implements `unsafe` wincode schema traits for the Rustaceous box wire format. The implementations write and read initialized fields in the same order. |
 //! | `src/blake2b/blake2b_soft.rs` and `src/blake2b/blake2b_simd.rs` parameter blocks | Always available for the soft backend; `simd_backend,nightly` for SIMD | Views a `repr(C, packed)` BLAKE2b parameter block as bytes so the initialization vector is mixed exactly as specified. The parameter type contains only initialized byte fields. |
 //! | `src/protected.rs` protected memory | `nightly` | Calls OS APIs such as `mlock`, `mprotect`, `VirtualLock`, and `VirtualProtect`, implements a page-aligned guard-page allocator, and exposes exact-size byte-array views over protected heap buffers. |
-//! | `src/classic/salsa20_simd.rs` Salsa20 SIMD backend | `simd_backend,nightly` | Performs little-endian unaligned word XOR in 256-byte chunks and volatile zeroization of cached SIMD lanes containing derived key material. |
+//! | `src/classic/salsa20_simd.rs` Salsa20 SIMD backend | `simd_backend,nightly` | Performs little-endian unaligned in-place and buffer-to-buffer word XOR in 256-byte chunks, plus volatile zeroization of cached SIMD lanes containing derived key material. |
 //!
 //! Test-only unsafe code is used for libsodium and Argon2 compatibility checks
 //! and protected-memory platform probes; it is not part of the runtime crate


### PR DESCRIPTION
## Summary

Optimize detached secretbox seal/open by avoiding full-buffer pre-copying. The public detached APIs now encrypt/decrypt buffer-to-buffer, and the SIMD XSalsa20 backend has a matching buffer-to-buffer path so detached callers do not copy the message or ciphertext before applying the stream cipher.

## User Impact

Detached `crypto_secretbox` callers get lower memory traffic and better throughput for separate input/output buffers. Oversized output buffers continue to preserve bytes past the message/ciphertext length. Detached open now also leaves the output buffer unchanged on authentication failure instead of decrypting before returning an error.

## Root Cause

`crypto_secretbox_detached` copied `message` into `ciphertext` and then encrypted in place. `crypto_secretbox_open_detached` copied `ciphertext` into `message` and then authenticated/decrypted in place. Profiling showed this extra message-sized copy as avoidable overhead in the detached API path.

## Fix

- Add buffer-to-buffer XSalsa20 XOR support to the SIMD secretbox backend.
- Add buffer-to-buffer detached seal/open helpers in the shared secretbox implementation.
- Route public detached seal/open through those helpers instead of pre-copying buffers.
- Decrypt only after authentication succeeds for both detached and in-place open.
- Update the unsafe inventory docs for the new SIMD unaligned buffer-to-buffer XOR helper.
- Add tests for output-tail preservation and authentication-failure output preservation.

## Validation

- `cargo test --features simd_backend,nightly crypto_secretbox`
- `cargo test crypto_secretbox`
- `cargo clippy --features simd_backend,nightly -- -D warnings`
- `cargo clippy --features default -- -D warnings`
- Earlier full checks on this branch:
  - `cargo test --features simd_backend,nightly`
  - `cargo test`
- Benchmarks against a temporary `origin/main` worktree:
  - 1 MiB detached secretbox: `971,055 ns` / `1079 MB/s` -> `909,850 ns` / `1152 MB/s`
  - 16 KiB detached secretbox: `15,052 ns` / `1088 MB/s` -> `14,470 ns` / `1132 MB/s`
  - 1 KiB detached secretbox: `1,265 ns` / `809 MB/s` -> `1,158 ns` / `884 MB/s`
  - 64 B detached secretbox: `266.8 ns` / `240 MB/s` -> `245.4 ns` / `261 MB/s`
- Harness runs also improved modestly:
  - seal: `1077.4 MiB/s` -> `1090.8 MiB/s`
  - open: `1076.5 MiB/s` -> `1091.8 MiB/s`
