### PR TITLE
ci: enforce cargo-deny advisory checks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,6 +15,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  audit:
+    name: dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup stable Rust toolchain with caching
+        uses: brndnmtthws/rust-action@v1
+        with:
+          toolchain: stable
+          cargo-packages: cargo-deny
+      - run: cargo deny --all-features check advisories
+
   wasm:
     name: wasm32-unknown-unknown
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,4 @@
+[advisories]
+ignore = [
+  { id = "RUSTSEC-2021-0137", reason = "sodiumoxide is used only as a dev-dependency for libsodium compatibility tests and is not part of dryoc's published dependency graph." },
+]


### PR DESCRIPTION
## Summary

Adds a dedicated dependency audit gate to CI using `cargo-deny` so RustSec advisory checks run on pull requests and pushes to `main`.

## User Impact

Maintainers get an explicit CI failure when a dependency introduces an unignored advisory, reducing the chance that vulnerable or yanked dependencies land unnoticed.

## Root Cause

The existing CI covered build, test, format, clippy, coverage, and publish workflows, but did not run `cargo-deny` or `cargo audit` as an enforced advisory check.

## Fix

Adds a `dependency audit` job to the build workflow that installs `cargo-deny` and runs `cargo deny --all-features check advisories`. Adds `deny.toml` with a documented ignore for the known `sodiumoxide` dev-dependency advisory used only for libsodium compatibility tests.

## Validation

Ran `cargo deny --all-features check advisories` locally and confirmed it reports `advisories ok`.
