### PR TITLE
fix: address chunks_exact clippy lints

### DIFF
--- a/src/blake2b/blake2b_simd.rs
+++ b/src/blake2b/blake2b_simd.rs
@@ -653,7 +653,7 @@ pub fn longhash(output: &mut [u8], input: &[u8]) -> Result<(), Error> {
         let end = chunk_count * HALFOUTBYTES;
         let (start, end) = output[HALFOUTBYTES..].split_at_mut(end);
 
-        for chunk in start.chunks_exact_mut(HALFOUTBYTES) {
+        for chunk in start.as_chunks_mut::<HALFOUTBYTES>().0 {
             let mut out_buffer = [0u8; OUTBYTES];
 
             hash(&mut out_buffer, &in_buffer, None)?;

--- a/src/blake2b/blake2b_soft.rs
+++ b/src/blake2b/blake2b_soft.rs
@@ -248,11 +248,11 @@ impl State {
             let t = &mut self.t;
             let f = &mut self.f;
 
-            for chunk in self.buf.chunks_exact(BLOCKBYTES) {
+            for chunk in self.buf.as_chunks::<BLOCKBYTES>().0 {
                 increment_counter(t, BLOCKBYTES);
                 compress(h, t, f, chunk);
             }
-            for chunk in input[start..end].chunks_exact(BLOCKBYTES) {
+            for chunk in input[start..end].as_chunks::<BLOCKBYTES>().0 {
                 increment_counter(t, BLOCKBYTES);
                 compress(h, t, f, chunk);
             }
@@ -382,7 +382,7 @@ pub fn longhash(output: &mut [u8], input: &[u8]) -> Result<(), Error> {
         let end = chunk_count * HALFOUTBYTES;
         let (start, end) = output[HALFOUTBYTES..].split_at_mut(end);
 
-        for chunk in start.chunks_exact_mut(HALFOUTBYTES) {
+        for chunk in start.as_chunks_mut::<HALFOUTBYTES>().0 {
             let mut out_buffer = [0u8; OUTBYTES];
 
             hash(&mut out_buffer, &in_buffer, None)?;

--- a/src/classic/crypto_pwhash.rs
+++ b/src/classic/crypto_pwhash.rs
@@ -167,7 +167,9 @@ fn base64_no_pad_encode(input: &[u8]) -> String {
 
     let mut output = String::with_capacity(input.len().div_ceil(3) * 4);
 
-    for chunk in input.chunks_exact(3) {
+    let (chunks, rem) = input.as_chunks::<3>();
+
+    for chunk in chunks {
         let n = ((chunk[0] as u32) << 16) | ((chunk[1] as u32) << 8) | chunk[2] as u32;
         output.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
         output.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
@@ -175,7 +177,6 @@ fn base64_no_pad_encode(input: &[u8]) -> String {
         output.push(ALPHABET[(n & 0x3f) as usize] as char);
     }
 
-    let rem = input.chunks_exact(3).remainder();
     if rem.len() == 1 {
         let n = (rem[0] as u32) << 16;
         output.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
@@ -209,7 +210,9 @@ fn base64_no_pad_decode(input: &str) -> Option<Vec<u8>> {
     }
 
     let mut output = Vec::with_capacity(input.len() / 4 * 3 + 2);
-    for chunk in input.chunks_exact(4) {
+    let (chunks, rem) = input.as_chunks::<4>();
+
+    for chunk in chunks {
         let n = ((decode_byte(chunk[0])? as u32) << 18)
             | ((decode_byte(chunk[1])? as u32) << 12)
             | ((decode_byte(chunk[2])? as u32) << 6)
@@ -219,7 +222,6 @@ fn base64_no_pad_decode(input: &str) -> Option<Vec<u8>> {
         output.push(n as u8);
     }
 
-    let rem = input.chunks_exact(4).remainder();
     if rem.len() == 2 {
         let second = decode_byte(rem[1])?;
         if second & 0x0f != 0 {

--- a/src/poly1305/poly1305_simd.rs
+++ b/src/poly1305/poly1305_simd.rs
@@ -181,10 +181,10 @@ fn fe4_mul(lhs: Fe4, rhs: Fe4) -> Fe4 {
 fn blocks_to_fe4(input: &[u8], group: usize, h: Fe) -> Fe4 {
     let mut limbs = [[0u64; LANES]; 5];
 
-    for (lane, block) in input[group * LANES * BLOCK_SIZE..][..LANES * BLOCK_SIZE]
-        .chunks_exact(BLOCK_SIZE)
-        .enumerate()
-    {
+    let blocks = input[group * LANES * BLOCK_SIZE..][..LANES * BLOCK_SIZE]
+        .as_chunks::<BLOCK_SIZE>()
+        .0;
+    for (lane, block) in blocks.iter().enumerate() {
         let mut fe = block_to_fe(block, HIBIT);
         if group == 0 && lane == 0 {
             fe = fe_add(fe, h);
@@ -257,7 +257,7 @@ impl Poly1305 {
     fn blocks_scalar(&mut self, input: &[u8], hibit: u64) {
         debug_assert_eq!(input.len() % BLOCK_SIZE, 0);
 
-        for m in input.chunks_exact(BLOCK_SIZE) {
+        for m in input.as_chunks::<BLOCK_SIZE>().0 {
             self.h = fe_mul(fe_add(self.h, block_to_fe(m, hibit)), self.r);
         }
     }

--- a/src/poly1305/poly1305_soft.rs
+++ b/src/poly1305/poly1305_soft.rs
@@ -107,7 +107,7 @@ impl Poly1305 {
 
         debug_assert_eq!(input.len() % BLOCK_SIZE, 0);
 
-        for m in input.chunks_exact(BLOCK_SIZE) {
+        for m in input.as_chunks::<BLOCK_SIZE>().0 {
             // h += m[i]
             let t0 = load_u64_le(&m[0..8]);
             let t1 = load_u64_le(&m[8..]);

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -40,7 +40,9 @@ pub(crate) fn siphash24(output: &mut Hash, input: &[u8], key: &Key) {
         *v2 = rotl64(*v2, 32);
     };
 
-    for chunk in input.chunks_exact(8) {
+    let (chunks, remainder) = input.as_chunks::<8>();
+
+    for chunk in chunks {
         let m = load_u64_le(chunk);
         v3 ^= m;
         round(&mut v0, &mut v1, &mut v2, &mut v3);
@@ -49,8 +51,6 @@ pub(crate) fn siphash24(output: &mut Hash, input: &[u8], key: &Key) {
     }
 
     let mut b = (input.len() as u64) << 56;
-
-    let remainder = input.chunks_exact(8).remainder();
 
     for i in (0..remainder.len()).rev() {
         b |= (remainder[i] as u64) << (i * 8);


### PR DESCRIPTION
## Summary
- Replace constant-size `chunks_exact` and `chunks_exact_mut` loops with `as_chunks`/`as_chunks_mut`.
- Preserve existing remainder handling in SipHash and password-hash base64 helpers.

This is split out from the lint failure seen in #131: https://github.com/brndnmtthws/dryoc/actions/runs/28789805628/job/85365307559?pr=131

## Verification
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy --features serde,nightly -- -D warnings`
- `cargo +nightly clippy --features simd_backend,nightly -- -D warnings`
- `cargo clippy --features default -- -D warnings`