### PR TITLE
feat(sign): add Ed25519 key extraction helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ implementation. This list has been reviewed against
 * [x] [Key exchange](https://docs.rs/dryoc/latest/dryoc/kx/index.html) (`crypto_kx_*`) [libsodium link](https://doc.libsodium.org/key_exchange)
 * [x] [Public-key signatures](https://docs.rs/dryoc/latest/dryoc/sign/index.html) (`crypto_sign_*`) [libsodium link](https://doc.libsodium.org/public-key_cryptography/public-key_signatures)
 * [x] [Ed25519 to Curve25519](https://docs.rs/dryoc/latest/dryoc/classic/crypto_sign_ed25519/index.html) (`crypto_sign_ed25519_*`) [libsodium link](https://doc.libsodium.org/advanced/ed25519-curve25519)
+* [x] [Signature secret-key extraction helpers](https://docs.rs/dryoc/latest/dryoc/classic/crypto_sign_ed25519/index.html) (`crypto_sign_ed25519_sk_to_seed`, `crypto_sign_ed25519_sk_to_pk`) [libsodium link](https://doc.libsodium.org/public-key_cryptography/public-key_signatures)
 * [x] [SHA-2 hashing](https://docs.rs/dryoc/latest/dryoc/classic/crypto_hash/index.html) (`crypto_hash_sha256_*`, `crypto_hash_sha512_*`) [libsodium link](https://doc.libsodium.org/hashing/sha-2)
 * [x] [Short-input hashing](https://docs.rs/dryoc/latest/dryoc/classic/crypto_shorthash/index.html) (`crypto_shorthash`) [libsodium link](https://doc.libsodium.org/hashing/short-input_hashing)
 * [x] [Password hashing](https://docs.rs/dryoc/latest/dryoc/pwhash/index.html) (`crypto_pwhash_*`) [libsodium link](https://doc.libsodium.org/password_hashing/default_phf)
@@ -141,7 +142,6 @@ crates:
 * [ ] SHA-3 hash variants (`crypto_hash_sha3256_*`, `crypto_hash_sha3512_*`)
 * [ ] Extendable-output functions (`crypto_xof_shake*`, `crypto_xof_turboshake*`), added in libsodium 1.0.21
 * [ ] [Key encapsulation](https://github.com/jedisct1/libsodium/releases/tag/1.0.22-RELEASE) (`crypto_kem_*`, `crypto_kem_mlkem768_*`, `crypto_kem_xwing_*`), added in libsodium 1.0.22
-* [ ] Signature secret-key extraction helpers (`crypto_sign_ed25519_sk_to_seed`, `crypto_sign_ed25519_sk_to_pk`)
 * [ ] Deterministic random data for reproducible tests (`randombytes_buf_deterministic`)
 * [ ] Short-input hash variants beyond SipHash-2-4 with 64-bit output (`crypto_shorthash_siphashx24_*`)
 * [ ] [IP address encryption](https://doc.libsodium.org/secret-key_cryptography/ip_address_encryption) (`crypto_ipcrypt_*`, `sodium_ip2bin`, `sodium_bin2ip`), added in libsodium 1.0.21

--- a/src/classic/crypto_sign.rs
+++ b/src/classic/crypto_sign.rs
@@ -54,7 +54,9 @@
 //! ```
 
 use super::crypto_sign_ed25519::*;
-pub use super::crypto_sign_ed25519::{PublicKey, SecretKey};
+pub use super::crypto_sign_ed25519::{
+    PublicKey, SecretKey, crypto_sign_ed25519_sk_to_pk, crypto_sign_ed25519_sk_to_seed,
+};
 use crate::constants::CRYPTO_SIGN_BYTES;
 use crate::error::Error;
 

--- a/src/classic/crypto_sign_ed25519.rs
+++ b/src/classic/crypto_sign_ed25519.rs
@@ -1,12 +1,33 @@
-//! # Ed25519 to Curve25519 conversion
+//! # Ed25519 signing helpers
 //!
-//! This module implements libsodium's Ed25519 to Curve25519 conversion
-//! functions. You can use these functions when you want to sign messages with
-//! the same keys used to encrypt messages (i.e., using a public-key box).
+//! This module implements libsodium's Ed25519 helper functions, including
+//! Ed25519 to Curve25519 conversion and secret-key extraction. You can use the
+//! conversion functions when you want to sign messages with the same keys used
+//! to encrypt messages (i.e., using a public-key box).
 //!
 //! Generally speaking, you should avoid signing and encrypting with the same
 //! keypair. Additionally, an encrypted box doesn't need to be separately signed
 //! as it already includes a message authentication code.
+//!
+//! ## Classic API example
+//!
+//! ```
+//! use dryoc::classic::crypto_sign::{
+//!     crypto_sign_ed25519_sk_to_pk, crypto_sign_ed25519_sk_to_seed, crypto_sign_seed_keypair,
+//! };
+//! use dryoc::constants::{CRYPTO_SIGN_PUBLICKEYBYTES, CRYPTO_SIGN_SEEDBYTES};
+//!
+//! let seed = [7u8; CRYPTO_SIGN_SEEDBYTES];
+//! let (public_key, secret_key) = crypto_sign_seed_keypair(&seed);
+//!
+//! let mut extracted_seed = [0u8; CRYPTO_SIGN_SEEDBYTES];
+//! let mut extracted_public_key = [0u8; CRYPTO_SIGN_PUBLICKEYBYTES];
+//! crypto_sign_ed25519_sk_to_seed(&mut extracted_seed, &secret_key);
+//! crypto_sign_ed25519_sk_to_pk(&mut extracted_public_key, &secret_key);
+//!
+//! assert_eq!(extracted_seed, seed);
+//! assert_eq!(extracted_public_key, public_key);
+//! ```
 
 use curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
 use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
@@ -126,6 +147,26 @@ pub fn crypto_sign_ed25519_sk_to_curve25519(
     let mut scalar = clamp_hash(hash);
     x25519_secret_key.copy_from_slice(&scalar);
     scalar.zeroize()
+}
+
+/// Extracts the Ed25519 seed from `secret_key`, placing the result into `seed`.
+///
+/// Compatible with libsodium's `crypto_sign_ed25519_sk_to_seed`.
+pub fn crypto_sign_ed25519_sk_to_seed(
+    seed: &mut [u8; CRYPTO_SIGN_ED25519_SEEDBYTES],
+    secret_key: &SecretKey,
+) {
+    seed.copy_from_slice(&secret_key[..CRYPTO_SIGN_ED25519_SEEDBYTES]);
+}
+
+/// Extracts the Ed25519 public key from `secret_key`, placing the result into
+/// `public_key`.
+///
+/// Compatible with libsodium's `crypto_sign_ed25519_sk_to_pk`.
+pub fn crypto_sign_ed25519_sk_to_pk(public_key: &mut PublicKey, secret_key: &SecretKey) {
+    public_key.copy_from_slice(
+        &secret_key[CRYPTO_SIGN_ED25519_SEEDBYTES..CRYPTO_SIGN_ED25519_SECRETKEYBYTES],
+    );
 }
 
 pub(crate) fn crypto_sign_ed25519(
@@ -384,6 +425,34 @@ mod tests {
                 general_purpose::STANDARD.encode(xsk),
                 general_purpose::STANDARD.encode(so_xsk)
             );
+        }
+    }
+
+    #[test]
+    fn test_secret_key_extraction() {
+        use libsodium_sys::{
+            crypto_sign_ed25519_sk_to_pk as so_crypto_sign_ed25519_sk_to_pk,
+            crypto_sign_ed25519_sk_to_seed as so_crypto_sign_ed25519_sk_to_seed,
+        };
+
+        for _ in 0..10 {
+            let (pk, sk) = crypto_sign_ed25519_keypair();
+            let mut seed = [0u8; CRYPTO_SIGN_ED25519_SEEDBYTES];
+            let mut extracted_pk = [0u8; CRYPTO_SIGN_ED25519_PUBLICKEYBYTES];
+            crypto_sign_ed25519_sk_to_seed(&mut seed, &sk);
+            crypto_sign_ed25519_sk_to_pk(&mut extracted_pk, &sk);
+
+            let mut so_seed = [0u8; CRYPTO_SIGN_ED25519_SEEDBYTES];
+            let mut so_pk = [0u8; CRYPTO_SIGN_ED25519_PUBLICKEYBYTES];
+
+            unsafe {
+                so_crypto_sign_ed25519_sk_to_seed(so_seed.as_mut_ptr(), sk.as_ptr());
+                so_crypto_sign_ed25519_sk_to_pk(so_pk.as_mut_ptr(), sk.as_ptr());
+            }
+
+            assert_eq!(seed, so_seed);
+            assert_eq!(extracted_pk, pk);
+            assert_eq!(extracted_pk, so_pk);
         }
     }
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -27,6 +27,11 @@
 //! separate. While it's possible to convert Ed25519 keys to X25519 keys (or
 //! derive them from the same seed), one is cautioned against doing so.
 //!
+//! Signing secret keys include both the seed and public key. Use
+//! [`secret_key_to_seed`], [`secret_key_to_public_key`],
+//! [`SigningKeyPair::to_seed`], or [`SigningKeyPair::to_public_key`] to extract
+//! those parts when interoperating with libsodium-style key storage.
+//!
 //! ## Rustaceous API example, single-part
 //!
 //! ```
@@ -43,6 +48,21 @@
 //! signed_message
 //!     .verify(&keypair.public_key)
 //!     .expect("verification failed");
+//! ```
+//!
+//! ## Extracting key material
+//!
+//! ```
+//! use dryoc::sign::*;
+//!
+//! let seed = Seed::from([7u8; dryoc::constants::CRYPTO_SIGN_SEEDBYTES]);
+//! let keypair = SigningKeyPair::<PublicKey, SecretKey>::from_seed(&seed);
+//!
+//! let extracted_seed: Seed = keypair.to_seed();
+//! let extracted_public_key: PublicKey = keypair.to_public_key();
+//!
+//! assert_eq!(extracted_seed, seed);
+//! assert_eq!(extracted_public_key, keypair.public_key);
 //! ```
 //!
 //! ## Incremental (multi-part) interface
@@ -79,7 +99,8 @@ use subtle::ConstantTimeEq;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::classic::crypto_sign::{
-    SignerState, crypto_sign_detached, crypto_sign_final_create, crypto_sign_final_verify,
+    SignerState, crypto_sign_detached, crypto_sign_ed25519_sk_to_pk,
+    crypto_sign_ed25519_sk_to_seed, crypto_sign_final_create, crypto_sign_final_verify,
     crypto_sign_init, crypto_sign_keypair_inplace, crypto_sign_seed_keypair_inplace,
     crypto_sign_update, crypto_sign_verify_detached,
 };
@@ -94,10 +115,36 @@ use crate::types::*;
 pub type PublicKey = StackByteArray<CRYPTO_SIGN_PUBLICKEYBYTES>;
 /// Stack-allocated secret key for message signing.
 pub type SecretKey = StackByteArray<CRYPTO_SIGN_SECRETKEYBYTES>;
+/// Stack-allocated seed for message signing.
+pub type Seed = StackByteArray<CRYPTO_SIGN_SEEDBYTES>;
 /// Stack-allocated signature for message signing.
 pub type Signature = StackByteArray<CRYPTO_SIGN_BYTES>;
 /// Heap-allocated message for message signing.
 pub type Message = Vec<u8>;
+
+/// Extracts the Ed25519 seed from a signing secret key.
+pub fn secret_key_to_seed<
+    SeedOut: NewByteArray<CRYPTO_SIGN_SEEDBYTES>,
+    SigningSecretKey: ByteArray<CRYPTO_SIGN_SECRETKEYBYTES>,
+>(
+    secret_key: &SigningSecretKey,
+) -> SeedOut {
+    let mut seed = SeedOut::new_byte_array();
+    crypto_sign_ed25519_sk_to_seed(seed.as_mut_array(), secret_key.as_array());
+    seed
+}
+
+/// Extracts the Ed25519 public key from a signing secret key.
+pub fn secret_key_to_public_key<
+    PublicKeyOut: NewByteArray<CRYPTO_SIGN_PUBLICKEYBYTES>,
+    SigningSecretKey: ByteArray<CRYPTO_SIGN_SECRETKEYBYTES>,
+>(
+    secret_key: &SigningSecretKey,
+) -> PublicKeyOut {
+    let mut public_key = PublicKeyOut::new_byte_array();
+    crypto_sign_ed25519_sk_to_pk(public_key.as_mut_array(), secret_key.as_array());
+    public_key
+}
 
 #[cfg_attr(
     feature = "serde",
@@ -176,6 +223,24 @@ impl<
     }
 }
 
+impl<
+    PublicKey: ByteArray<CRYPTO_SIGN_PUBLICKEYBYTES> + Zeroize,
+    SecretKey: ByteArray<CRYPTO_SIGN_SECRETKEYBYTES> + Zeroize,
+> SigningKeyPair<PublicKey, SecretKey>
+{
+    /// Extracts the Ed25519 seed from this keypair's secret key.
+    pub fn to_seed<SeedOut: NewByteArray<CRYPTO_SIGN_SEEDBYTES>>(&self) -> SeedOut {
+        secret_key_to_seed(&self.secret_key)
+    }
+
+    /// Extracts the Ed25519 public key embedded in this keypair's secret key.
+    pub fn to_public_key<PublicKeyOut: NewByteArray<CRYPTO_SIGN_PUBLICKEYBYTES>>(
+        &self,
+    ) -> PublicKeyOut {
+        secret_key_to_public_key(&self.secret_key)
+    }
+}
+
 impl
     SigningKeyPair<
         StackByteArray<CRYPTO_SIGN_PUBLICKEYBYTES>,
@@ -251,6 +316,9 @@ pub mod protected {
     /// Heap-allocated, page-aligned secret-key for signed messages,
     /// for use with protected memory.
     pub type SecretKey = HeapByteArray<CRYPTO_SIGN_SECRETKEYBYTES>;
+    /// Heap-allocated, page-aligned seed for signed messages,
+    /// for use with protected memory.
+    pub type Seed = HeapByteArray<CRYPTO_SIGN_SEEDBYTES>;
     /// Heap-allocated, page-aligned signature for signed messages,
     /// for use with protected memory.
     pub type Signature = HeapByteArray<CRYPTO_SIGN_BYTES>;
@@ -573,5 +641,24 @@ mod tests {
         signed_message
             .verify(&keypair.public_key)
             .expect("verification failed");
+    }
+
+    #[test]
+    fn test_secret_key_extraction() {
+        let seed = Seed::generate();
+        let keypair = SigningKeyPair::<PublicKey, SecretKey>::from_seed(&seed);
+
+        let extracted_seed: Seed = keypair.to_seed();
+        let extracted_public_key: PublicKey = keypair.to_public_key();
+        assert_eq!(extracted_seed, seed);
+        assert_eq!(extracted_public_key, keypair.public_key);
+
+        let extracted_seed_vec: Vec<u8> = secret_key_to_seed(&keypair.secret_key);
+        let extracted_public_key_vec: Vec<u8> = secret_key_to_public_key(&keypair.secret_key);
+        assert_eq!(extracted_seed_vec.as_slice(), seed.as_slice());
+        assert_eq!(
+            extracted_public_key_vec.as_slice(),
+            keypair.public_key.as_slice()
+        );
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -125,6 +125,43 @@ fn test_rustaceous_hmac_and_hkdf_public_api() {
     assert_eq!(okm512.len(), 96);
 }
 
+#[test]
+fn test_signing_key_extraction_public_api() {
+    use dryoc::classic::crypto_sign::{
+        crypto_sign_ed25519_sk_to_pk, crypto_sign_ed25519_sk_to_seed, crypto_sign_seed_keypair,
+    };
+    use dryoc::sign::{
+        PublicKey, SecretKey, Seed, SigningKeyPair, secret_key_to_public_key, secret_key_to_seed,
+    };
+    use dryoc::types::*;
+
+    let seed = [7u8; dryoc::constants::CRYPTO_SIGN_SEEDBYTES];
+    let (classic_public_key, classic_secret_key) = crypto_sign_seed_keypair(&seed);
+    let mut classic_extracted_seed = [0u8; dryoc::constants::CRYPTO_SIGN_SEEDBYTES];
+    let mut classic_extracted_public_key = [0u8; dryoc::constants::CRYPTO_SIGN_PUBLICKEYBYTES];
+    crypto_sign_ed25519_sk_to_seed(&mut classic_extracted_seed, &classic_secret_key);
+    crypto_sign_ed25519_sk_to_pk(&mut classic_extracted_public_key, &classic_secret_key);
+    assert_eq!(classic_extracted_seed, seed);
+    assert_eq!(classic_extracted_public_key, classic_public_key);
+
+    let signing_keypair = SigningKeyPair::<PublicKey, SecretKey>::from_seed(&seed);
+    let rustaceous_seed: Seed = signing_keypair.to_seed();
+    let rustaceous_public_key: PublicKey = signing_keypair.to_public_key();
+    assert_eq!(rustaceous_seed.as_slice(), seed);
+    assert_eq!(
+        rustaceous_public_key.as_slice(),
+        signing_keypair.public_key.as_slice()
+    );
+
+    let rustaceous_seed_vec: Vec<u8> = secret_key_to_seed(&signing_keypair.secret_key);
+    let rustaceous_public_key_vec: Vec<u8> = secret_key_to_public_key(&signing_keypair.secret_key);
+    assert_eq!(rustaceous_seed_vec.as_slice(), seed.as_slice());
+    assert_eq!(
+        rustaceous_public_key_vec.as_slice(),
+        signing_keypair.public_key.as_slice()
+    );
+}
+
 #[cfg(all(feature = "protected", any(unix, windows)))]
 #[test]
 fn test_rustaceous_hmac_and_hkdf_protected() {


### PR DESCRIPTION
## Summary

Add libsodium-compatible Ed25519 secret-key extraction helpers and Rustaceous wrappers for signing keys.

## User Impact

Users can extract the seed and embedded public key from dryoc signing secret keys without manually slicing key material. This improves compatibility with libsodium-style key storage and makes the remaining signature helper gap explicit in the public API.

## Root Cause

Dryoc generated signing secret keys in the same `seed || public_key` layout as libsodium, but did not expose the corresponding `crypto_sign_ed25519_sk_to_seed` and `crypto_sign_ed25519_sk_to_pk` helper APIs or Rustaceous equivalents.

## Fix

Implemented the Classic extraction helpers, re-exported them from `classic::crypto_sign`, added Rustaceous `Seed`, `secret_key_to_seed`, `secret_key_to_public_key`, `SigningKeyPair::to_seed`, and `SigningKeyPair::to_public_key`, and updated README/rustdoc examples and tests.

## Validation

- `cargo test key_extraction`
- `cargo test --doc`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --features default -- -D warnings`
