### PR TITLE
docs: clarify libsodium compatibility scope

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 //! # dryoc: Don't Roll Your Own Crypto™[^1]
 //!
-//! dryoc is a pure-Rust, general-purpose cryptography library. It's also an
-//! implementation of [libsodium](https://libsodium.gitbook.io/doc/), and
-//! designed to be 100% compatible with, and interchangeable with, libsodium's
-//! API.
+//! dryoc is a pure-Rust, general-purpose cryptography library. It implements
+//! many [libsodium](https://libsodium.gitbook.io/doc/)-compatible APIs and wire
+//! formats, so supported operations can interoperate with libsodium across
+//! languages.
 //!
 //! Doing cryptography properly is _hard_. While no human is infallible,
 //! computers are pretty good at following instructions. Humans are bad at


### PR DESCRIPTION
## Summary

Clarifies the crate-level libsodium compatibility wording so it describes interoperability for supported APIs and wire formats without implying full libsodium API coverage.

## User Impact

Readers get a more accurate release-facing compatibility statement before evaluating dryoc as a libsodium alternative.

## Root Cause

The rustdoc opening paragraph used “100% compatible” language that could be read as complete libsodium API parity instead of implemented-operation interoperability.

## Fix

Replaces the broad claim with narrower wording that dryoc implements many libsodium-compatible APIs and wire formats, and that supported operations can interoperate with libsodium across languages.

## Validation

- `cargo test --doc`
