### PR TITLE
fix: harden cryptographic safety invariants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "dryoc"
 readme = "README.md"
 repository = "https://github.com/brndnmtthws/dryoc"
 rust-version = "1.89"
-version = "0.9.1"
+version = "1.0.0"
 
 [dependencies]
 chacha20 = { version = "0.10", features = ["legacy", "zeroize"] }

--- a/src/argon2/mod.rs
+++ b/src/argon2/mod.rs
@@ -1,4 +1,4 @@
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::blake2b;
 use crate::error::Error;
@@ -68,7 +68,7 @@ pub(crate) enum Argon2Type {
     Argon2id = 2,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 #[repr(align(64))]
 struct Block {
     v: [u64; ARGON2_QWORDS_IN_BLOCK],
@@ -157,6 +157,13 @@ struct Argon2Instance {
     type_: Argon2Type,
 }
 
+impl Drop for Argon2Instance {
+    fn drop(&mut self) {
+        self.region.memory.zeroize();
+        self.pseudo_rands.zeroize();
+    }
+}
+
 impl Default for Argon2Instance {
     fn default() -> Self {
         Self {
@@ -181,13 +188,14 @@ impl Argon2Instance {
         lanes: u32,
     ) -> Self {
         let mut ret = Self {
+            region: BlockRegion::default(),
+            pseudo_rands: Vec::new(),
             memory_blocks,
             segment_length,
             type_,
             lane_length: segment_length * ARGON2_SYNC_POINTS,
             passes: t_cost,
             lanes,
-            ..Default::default()
         };
         ret.initialize();
         ret
@@ -336,15 +344,15 @@ fn argon2_finalize(context: Argon2Context, instance: Argon2Instance) -> Result<(
         xor_block(&mut blockhash, &instance.region.memory[last_block_in_lane]);
     }
 
-    let mut blockhash_bytes = [0u8; ARGON2_BLOCK_SIZE];
-    store_block(&mut blockhash_bytes, &blockhash);
-    blake2b::longhash(context.output, &blockhash_bytes)
+    let mut blockhash_bytes = Zeroizing::new([0u8; ARGON2_BLOCK_SIZE]);
+    store_block(&mut blockhash_bytes[..], &blockhash);
+    blake2b::longhash(context.output, &blockhash_bytes[..])
 }
 
 fn argon2_initial_hash(
     context: &Argon2Context,
     type_: Argon2Type,
-) -> Result<[u8; ARGON2_PREHASH_SEED_LENGTH], Error> {
+) -> Result<Zeroizing<[u8; ARGON2_PREHASH_SEED_LENGTH]>, Error> {
     let mut blake2b = blake2b::State::init(ARGON2_PREHASH_DIGEST_LENGTH as u8, None, None, None)?;
     blake2b.update(&context.lanes.to_le_bytes());
     blake2b.update(&(context.output.len() as u32).to_le_bytes());
@@ -380,7 +388,7 @@ fn argon2_initial_hash(
         None => blake2b.update(&(0u32.to_le_bytes())), // ad, unused
     }
 
-    let mut blockhash = [0u8; ARGON2_PREHASH_SEED_LENGTH];
+    let mut blockhash = Zeroizing::new([0u8; ARGON2_PREHASH_SEED_LENGTH]);
     blake2b.finalize(&mut blockhash[..ARGON2_PREHASH_DIGEST_LENGTH])?;
     Ok(blockhash)
 }
@@ -597,34 +605,31 @@ fn xor_block(dst: &mut Block, src: &Block) {
 }
 
 fn argon2_fill_first_blocks(
-    mut blockhash: [u8; ARGON2_PREHASH_SEED_LENGTH],
+    mut blockhash: Zeroizing<[u8; ARGON2_PREHASH_SEED_LENGTH]>,
     instance: &mut Argon2Instance,
 ) -> Result<(), Error> {
-    let mut blockhash_bytes = [0u8; ARGON2_BLOCK_SIZE];
+    let mut blockhash_bytes = Zeroizing::new([0u8; ARGON2_BLOCK_SIZE]);
 
     for l in 0..instance.lanes {
         blockhash[ARGON2_PREHASH_DIGEST_LENGTH..(ARGON2_PREHASH_DIGEST_LENGTH + 4)]
             .copy_from_slice(&[0, 0, 0, 0]);
         blockhash[(ARGON2_PREHASH_DIGEST_LENGTH + 4)..(ARGON2_PREHASH_DIGEST_LENGTH + 8)]
             .copy_from_slice(&l.to_le_bytes());
-        blake2b::longhash(&mut blockhash_bytes, &blockhash)?;
+        blake2b::longhash(&mut blockhash_bytes[..], &blockhash[..])?;
 
         load_block(
             &mut instance.region.memory[(l * instance.lane_length) as usize],
-            &blockhash_bytes,
+            &blockhash_bytes[..],
         );
 
         blockhash[ARGON2_PREHASH_DIGEST_LENGTH..(ARGON2_PREHASH_DIGEST_LENGTH + 4)]
             .copy_from_slice(&[1, 0, 0, 0]);
-        blake2b::longhash(&mut blockhash_bytes, &blockhash)?;
+        blake2b::longhash(&mut blockhash_bytes[..], &blockhash[..])?;
         load_block(
             &mut instance.region.memory[(l * instance.lane_length + 1) as usize],
-            &blockhash_bytes,
+            &blockhash_bytes[..],
         );
     }
-
-    blockhash_bytes.zeroize();
-    blockhash.zeroize();
 
     Ok(())
 }
@@ -651,6 +656,12 @@ mod tests {
     extern crate test;
 
     use super::*;
+
+    #[test]
+    fn secret_working_types_zeroize_on_drop() {
+        assert!(std::mem::needs_drop::<Block>());
+        assert!(std::mem::needs_drop::<Argon2Instance>());
+    }
 
     #[cfg(feature = "nightly")]
     fn bench_argon2id(b: &mut test::Bencher, t_cost: u32, m_cost: u32) {

--- a/src/argon2/mod.rs
+++ b/src/argon2/mod.rs
@@ -159,7 +159,6 @@ struct Argon2Instance {
 
 impl Drop for Argon2Instance {
     fn drop(&mut self) {
-        self.region.memory.zeroize();
         self.pseudo_rands.zeroize();
     }
 }

--- a/src/classic/crypto_box.rs
+++ b/src/classic/crypto_box.rs
@@ -40,7 +40,7 @@
 //! assert_eq!(message, decrypted_message);
 //! ```
 
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use super::crypto_generichash::{
     crypto_generichash_final, crypto_generichash_init, crypto_generichash_update,
@@ -94,7 +94,8 @@ pub fn crypto_box_seed_keypair(seed: &[u8]) -> (PublicKey, SecretKey) {
 /// Resulting shared secret can be used with the precalculation interface.
 ///
 /// Compatible with libsodium's `crypto_box_beforenm`.
-pub fn crypto_box_beforenm(public_key: &PublicKey, secret_key: &SecretKey) -> Key {
+/// Returns an error when `public_key` is an unacceptable low-order key.
+pub fn crypto_box_beforenm(public_key: &PublicKey, secret_key: &SecretKey) -> Result<Key, Error> {
     crypto_box_curve25519xsalsa20poly1305_beforenm(public_key, secret_key)
 }
 
@@ -108,7 +109,7 @@ pub fn crypto_box_detached_afternm(
     message: &[u8],
     nonce: &Nonce,
     key: &Key,
-) {
+) -> Result<(), Error> {
     crypto_secretbox_detached(ciphertext, mac, message, nonce, key)
 }
 
@@ -132,12 +133,13 @@ pub fn crypto_box_detached(
     nonce: &Nonce,
     recipient_public_key: &PublicKey,
     sender_secret_key: &SecretKey,
-) {
-    let mut key = crypto_box_beforenm(recipient_public_key, sender_secret_key);
+) -> Result<(), Error> {
+    let key = Zeroizing::new(crypto_box_beforenm(
+        recipient_public_key,
+        sender_secret_key,
+    )?);
 
-    crypto_box_detached_afternm(ciphertext, mac, message, nonce, &key);
-
-    key.zeroize();
+    crypto_box_detached_afternm(ciphertext, mac, message, nonce, &key)
 }
 
 /// In-place variant of [`crypto_box_detached`].
@@ -148,11 +150,12 @@ pub fn crypto_box_detached_inplace(
     recipient_public_key: &PublicKey,
     sender_secret_key: &SecretKey,
 ) -> Result<(), Error> {
-    let mut key = crypto_box_beforenm(recipient_public_key, sender_secret_key);
+    let key = Zeroizing::new(crypto_box_beforenm(
+        recipient_public_key,
+        sender_secret_key,
+    )?);
 
     crypto_box_detached_afternm_inplace(message, mac, nonce, &key);
-
-    key.zeroize();
 
     Ok(())
 }
@@ -171,17 +174,17 @@ pub fn crypto_box_easy(
     recipient_public_key: &PublicKey,
     sender_secret_key: &SecretKey,
 ) -> Result<(), Error> {
-    if ciphertext.len() < CRYPTO_BOX_MACBYTES {
-        Err(dryoc_error!(format!(
-            "ciphertext length {} less than minimum {}",
-            ciphertext.len(),
-            CRYPTO_BOX_MACBYTES
-        )))
-    } else if message.len() > CRYPTO_BOX_MESSAGEBYTES_MAX {
+    if message.len() > CRYPTO_BOX_MESSAGEBYTES_MAX {
         Err(dryoc_error!(format!(
             "message length {} exceeds max message length {}",
             message.len(),
             CRYPTO_BOX_MESSAGEBYTES_MAX
+        )))
+    } else if ciphertext.len() != message.len() + CRYPTO_BOX_MACBYTES {
+        Err(dryoc_error!(format!(
+            "ciphertext length invalid ({} != {})",
+            ciphertext.len(),
+            message.len() + CRYPTO_BOX_MACBYTES
         )))
     } else {
         let (mac, ciphertext) = ciphertext.split_at_mut(CRYPTO_BOX_MACBYTES);
@@ -193,7 +196,7 @@ pub fn crypto_box_easy(
             nonce,
             recipient_public_key,
             sender_secret_key,
-        );
+        )?;
 
         Ok(())
     }
@@ -219,15 +222,16 @@ pub fn crypto_box_seal(
     message: &[u8],
     recipient_public_key: &PublicKey,
 ) -> Result<(), Error> {
-    if ciphertext.len() < message.len() + CRYPTO_BOX_SEALBYTES {
+    if ciphertext.len() != message.len() + CRYPTO_BOX_SEALBYTES {
         Err(dryoc_error!(format!(
-            "ciphertext length invalid ({} != {}",
+            "ciphertext length invalid ({} != {})",
             ciphertext.len(),
             message.len() + CRYPTO_BOX_SEALBYTES,
         )))
     } else {
         let mut nonce = Nonce::new_byte_array();
-        let (mut epk, mut esk) = crypto_box_keypair();
+        let (mut epk, esk) = crypto_box_keypair();
+        let esk = Zeroizing::new(esk);
         crypto_box_seal_nonce(&mut nonce, &epk, recipient_public_key);
 
         crypto_box_easy(
@@ -241,7 +245,6 @@ pub fn crypto_box_seal(
         ciphertext[..CRYPTO_BOX_PUBLICKEYBYTES].copy_from_slice(&epk);
 
         epk.zeroize();
-        esk.zeroize();
         nonce.zeroize();
 
         Ok(())
@@ -325,11 +328,12 @@ pub fn crypto_box_open_detached(
     recipient_public_key: &PublicKey,
     sender_secret_key: &SecretKey,
 ) -> Result<(), Error> {
-    let mut key = crypto_box_beforenm(recipient_public_key, sender_secret_key);
+    let key = Zeroizing::new(crypto_box_beforenm(
+        recipient_public_key,
+        sender_secret_key,
+    )?);
 
     crypto_box_open_detached_afternm(message, mac, ciphertext, nonce, &key)?;
-
-    key.zeroize();
 
     Ok(())
 }
@@ -342,11 +346,12 @@ pub fn crypto_box_open_detached_inplace(
     recipient_public_key: &PublicKey,
     sender_secret_key: &SecretKey,
 ) -> Result<(), Error> {
-    let mut key = crypto_box_beforenm(recipient_public_key, sender_secret_key);
+    let key = Zeroizing::new(crypto_box_beforenm(
+        recipient_public_key,
+        sender_secret_key,
+    )?);
 
     crypto_box_open_detached_afternm_inplace(data, mac, nonce, &key)?;
-
-    key.zeroize();
 
     Ok(())
 }
@@ -367,6 +372,12 @@ pub fn crypto_box_open_easy(
             "Impossibly small box ({} < {}",
             ciphertext.len(),
             CRYPTO_BOX_MACBYTES
+        )))
+    } else if message.len() != ciphertext.len() - CRYPTO_BOX_MACBYTES {
+        Err(dryoc_error!(format!(
+            "message length invalid ({} != {})",
+            message.len(),
+            ciphertext.len() - CRYPTO_BOX_MACBYTES
         )))
     } else {
         let (mac, ciphertext) = ciphertext.split_at(CRYPTO_BOX_MACBYTES);
@@ -482,6 +493,66 @@ mod tests {
                 .expect_err("expected an error");
         }
     }
+
+    #[test]
+    fn test_crypto_box_rejects_mismatched_buffers_without_mutation() {
+        let (sender_pk, sender_sk) = crypto_box_keypair();
+        let (recipient_pk, recipient_sk) = crypto_box_keypair();
+        let nonce = Nonce::default();
+        let message = b"buffer length validation";
+
+        for output_len in [
+            message.len() + CRYPTO_BOX_MACBYTES - 1,
+            message.len() + CRYPTO_BOX_MACBYTES + 1,
+        ] {
+            let mut output = vec![0xa5; output_len];
+            let original = output.clone();
+            assert!(
+                crypto_box_easy(&mut output, message, &nonce, &recipient_pk, &sender_sk,).is_err()
+            );
+            assert_eq!(output, original);
+        }
+
+        let mut ciphertext = vec![0u8; message.len() + CRYPTO_BOX_MACBYTES];
+        crypto_box_easy(&mut ciphertext, message, &nonce, &recipient_pk, &sender_sk)
+            .expect("encrypt failed");
+
+        for output_len in [message.len() - 1, message.len() + 1] {
+            let mut output = vec![0xa5; output_len];
+            let original = output.clone();
+            assert!(
+                crypto_box_open_easy(&mut output, &ciphertext, &nonce, &sender_pk, &recipient_sk,)
+                    .is_err()
+            );
+            assert_eq!(output, original);
+        }
+    }
+
+    #[test]
+    fn test_crypto_box_rejects_low_order_public_keys() {
+        let (_, secret_key) = crypto_box_keypair();
+        let nonce = Nonce::default();
+        let message = b"message";
+        let mut ciphertext = [0u8; 7];
+        let mut mac = Mac::default();
+        let mut one = PublicKey::default();
+        one[0] = 1;
+
+        for public_key in [PublicKey::default(), one] {
+            assert!(crypto_box_beforenm(&public_key, &secret_key).is_err());
+            assert!(
+                crypto_box_detached(
+                    &mut ciphertext,
+                    &mut mac,
+                    message,
+                    &nonce,
+                    &public_key,
+                    &secret_key,
+                )
+                .is_err()
+            );
+        }
+    }
     #[test]
     fn test_crypto_box_easy_inplace_invalid() {
         for _ in 0..20 {
@@ -515,6 +586,27 @@ mod tests {
     #[cfg(dryoc_native_tests)]
     mod native_tests {
         use super::*;
+
+        #[test]
+        fn test_crypto_box_beforenm_low_order_compatibility() {
+            let (_, secret_key) = crypto_box_keypair();
+            let mut one = PublicKey::default();
+            one[0] = 1;
+
+            for public_key in [PublicKey::default(), one] {
+                let mut sodium_key = Key::default();
+                let sodium_result = unsafe {
+                    libsodium_sys::crypto_box_curve25519xsalsa20poly1305_beforenm(
+                        sodium_key.as_mut_ptr(),
+                        public_key.as_ptr(),
+                        secret_key.as_ptr(),
+                    )
+                };
+
+                assert!(crypto_box_beforenm(&public_key, &secret_key).is_err());
+                assert_eq!(sodium_result, -1);
+            }
+        }
 
         #[test]
         fn test_crypto_box_easy() {

--- a/src/classic/crypto_box_impl.rs
+++ b/src/classic/crypto_box_impl.rs
@@ -1,4 +1,4 @@
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use super::crypto_core::crypto_scalarmult;
 use crate::classic::crypto_box::{PublicKey, SecretKey};
@@ -10,20 +10,21 @@ use crate::constants::{
     CRYPTO_HASH_SHA512_BYTES, CRYPTO_SCALARMULT_BYTES,
 };
 use crate::dryocstream::ByteArray;
+use crate::error::Error;
 use crate::rng::copy_randombytes;
 use crate::scalarmult_curve25519::*;
 
 pub(crate) fn crypto_box_curve25519xsalsa20poly1305_beforenm(
     public_key: &PublicKey,
     secret_key: &SecretKey,
-) -> Key {
-    let mut s = [0u8; CRYPTO_SCALARMULT_BYTES];
-    crypto_scalarmult(&mut s, secret_key.as_array(), public_key.as_array());
+) -> Result<Key, Error> {
+    let mut s = Zeroizing::new([0u8; CRYPTO_SCALARMULT_BYTES]);
+    crypto_scalarmult(&mut s, secret_key.as_array(), public_key.as_array())?;
 
     let mut hash = [0u8; CRYPTO_CORE_HSALSA20_OUTPUTBYTES];
     crypto_core_hsalsa20(&mut hash, &[0u8; CRYPTO_CORE_HSALSA20_INPUTBYTES], &s, None);
 
-    hash
+    Ok(hash)
 }
 
 #[inline]

--- a/src/classic/crypto_core.rs
+++ b/src/classic/crypto_core.rs
@@ -1,4 +1,5 @@
 use curve25519_dalek::edwards::CompressedEdwardsY;
+use subtle::ConstantTimeEq;
 
 use crate::constants::{
     CRYPTO_CORE_ED25519_BYTES, CRYPTO_CORE_HCHACHA20_INPUTBYTES, CRYPTO_CORE_HCHACHA20_KEYBYTES,
@@ -6,6 +7,7 @@ use crate::constants::{
     CRYPTO_CORE_HSALSA20_KEYBYTES, CRYPTO_CORE_HSALSA20_OUTPUTBYTES, CRYPTO_SCALARMULT_BYTES,
     CRYPTO_SCALARMULT_SCALARBYTES,
 };
+use crate::error::Error;
 use crate::scalarmult_curve25519::{
     crypto_scalarmult_curve25519, crypto_scalarmult_curve25519_base,
 };
@@ -41,12 +43,21 @@ pub fn crypto_scalarmult_base(
 /// public key, using a Diffie-Hellman key exchange.
 ///
 /// Compatible with libsodium's `crypto_scalarmult`.
+///
+/// Returns an error when `p` is an unacceptable low-order public key that
+/// produces an all-zero shared secret.
 pub fn crypto_scalarmult(
     q: &mut [u8; CRYPTO_SCALARMULT_BYTES],
     n: &[u8; CRYPTO_SCALARMULT_SCALARBYTES],
     p: &[u8; CRYPTO_SCALARMULT_BYTES],
-) {
-    crypto_scalarmult_curve25519(q, n, p)
+) -> Result<(), Error> {
+    crypto_scalarmult_curve25519(q, n, p);
+
+    if q.ct_eq(&[0u8; CRYPTO_SCALARMULT_BYTES]).into() {
+        Err(dryoc_error!("unacceptable Curve25519 public key"))
+    } else {
+        Ok(())
+    }
 }
 
 #[inline]
@@ -504,6 +515,36 @@ mod tests {
         println!("X25519 key validation: Success");
     }
 
+    #[test]
+    fn test_crypto_scalarmult_rejects_low_order_points() {
+        let scalar = [0x42; CRYPTO_SCALARMULT_SCALARBYTES];
+        let mut one = [0u8; CRYPTO_SCALARMULT_BYTES];
+        one[0] = 1;
+
+        for public_key in [[0u8; CRYPTO_SCALARMULT_BYTES], one] {
+            let mut shared_secret = [0xa5; CRYPTO_SCALARMULT_BYTES];
+            crypto_scalarmult(&mut shared_secret, &scalar, &public_key)
+                .expect_err("low-order public key must be rejected");
+            assert_eq!(shared_secret, [0u8; CRYPTO_SCALARMULT_BYTES]);
+        }
+    }
+
+    #[test]
+    fn test_crypto_scalarmult_ignores_public_key_high_bit() {
+        let scalar = [0x42; CRYPTO_SCALARMULT_SCALARBYTES];
+        let mut canonical = [0u8; CRYPTO_SCALARMULT_BYTES];
+        canonical[0] = 9;
+        let mut high_bit_set = canonical;
+        high_bit_set[CRYPTO_SCALARMULT_BYTES - 1] = 0x80;
+        let mut canonical_secret = [0u8; CRYPTO_SCALARMULT_BYTES];
+        let mut high_bit_secret = [0u8; CRYPTO_SCALARMULT_BYTES];
+
+        crypto_scalarmult(&mut canonical_secret, &scalar, &canonical).unwrap();
+        crypto_scalarmult(&mut high_bit_secret, &scalar, &high_bit_set).unwrap();
+
+        assert_eq!(canonical_secret, high_bit_secret);
+    }
+
     #[cfg(dryoc_native_tests)]
     mod native_tests {
         use super::*;
@@ -544,7 +585,8 @@ mod tests {
                 let (their_pk, _their_sk) = crypto_box_keypair();
 
                 let mut shared_secret = [0u8; CRYPTO_SCALARMULT_BYTES];
-                crypto_scalarmult(&mut shared_secret, &our_sk, &their_pk);
+                crypto_scalarmult(&mut shared_secret, &our_sk, &their_pk)
+                    .expect("scalarmult failed");
 
                 let ge = scalarmult(
                     &Scalar::from_slice(&our_sk).unwrap(),
@@ -555,6 +597,27 @@ mod tests {
                 assert_eq!(
                     general_purpose::STANDARD.encode(ge.as_ref()),
                     general_purpose::STANDARD.encode(shared_secret)
+                );
+            }
+        }
+
+        #[test]
+        fn test_crypto_scalarmult_low_order_compatibility() {
+            use sodiumoxide::crypto::scalarmult::curve25519::{GroupElement, Scalar, scalarmult};
+
+            let scalar = [0x42; CRYPTO_SCALARMULT_SCALARBYTES];
+            let mut one = [0u8; CRYPTO_SCALARMULT_BYTES];
+            one[0] = 1;
+
+            for public_key in [[0u8; CRYPTO_SCALARMULT_BYTES], one] {
+                let mut shared_secret = [0u8; CRYPTO_SCALARMULT_BYTES];
+                assert!(crypto_scalarmult(&mut shared_secret, &scalar, &public_key).is_err());
+                assert!(
+                    scalarmult(
+                        &Scalar::from_slice(&scalar).unwrap(),
+                        &GroupElement::from_slice(&public_key).unwrap(),
+                    )
+                    .is_err()
                 );
             }
         }

--- a/src/classic/crypto_kx.rs
+++ b/src/classic/crypto_kx.rs
@@ -33,7 +33,7 @@
 //! assert_eq!(ctx, srx);
 //! ```
 
-use zeroize::Zeroize;
+use zeroize::Zeroizing;
 
 use super::crypto_core::{crypto_scalarmult, crypto_scalarmult_base};
 use super::crypto_generichash::{
@@ -88,21 +88,18 @@ fn crypto_kx(
     x2: &mut SessionKey,
     client_pk: &PublicKey,
     server_pk: &PublicKey,
-    mut shared_secret: [u8; CRYPTO_SCALARMULT_BYTES],
+    shared_secret: Zeroizing<[u8; CRYPTO_SCALARMULT_BYTES]>,
 ) -> Result<(), Error> {
-    let mut keys = [0u8; 2 * CRYPTO_KX_SESSIONKEYBYTES];
+    let mut keys = Zeroizing::new([0u8; 2 * CRYPTO_KX_SESSIONKEYBYTES]);
 
     let mut hasher = crypto_generichash_init(None, 2 * CRYPTO_KX_SESSIONKEYBYTES)?;
-    crypto_generichash_update(&mut hasher, &shared_secret);
-    shared_secret.zeroize();
+    crypto_generichash_update(&mut hasher, &shared_secret[..]);
     crypto_generichash_update(&mut hasher, client_pk);
     crypto_generichash_update(&mut hasher, server_pk);
-    crypto_generichash_final(hasher, &mut keys)?;
+    crypto_generichash_final(hasher, &mut keys[..])?;
 
     x1.copy_from_slice(&keys[..CRYPTO_KX_SESSIONKEYBYTES]);
     x2.copy_from_slice(&keys[CRYPTO_KX_SESSIONKEYBYTES..]);
-
-    keys.zeroize();
 
     Ok(())
 }
@@ -118,9 +115,9 @@ pub fn crypto_kx_client_session_keys(
     client_sk: &SecretKey,
     server_pk: &PublicKey,
 ) -> Result<(), Error> {
-    let mut shared_secret = [0u8; CRYPTO_SCALARMULT_BYTES];
+    let mut shared_secret = Zeroizing::new([0u8; CRYPTO_SCALARMULT_BYTES]);
 
-    crypto_scalarmult(&mut shared_secret, client_sk, server_pk);
+    crypto_scalarmult(&mut shared_secret, client_sk, server_pk)?;
 
     crypto_kx(rx, tx, client_pk, server_pk, shared_secret)
 }
@@ -136,9 +133,9 @@ pub fn crypto_kx_server_session_keys(
     server_sk: &SecretKey,
     client_pk: &PublicKey,
 ) -> Result<(), Error> {
-    let mut shared_secret = [0u8; CRYPTO_SCALARMULT_BYTES];
+    let mut shared_secret = Zeroizing::new([0u8; CRYPTO_SCALARMULT_BYTES]);
 
-    crypto_scalarmult(&mut shared_secret, server_sk, client_pk);
+    crypto_scalarmult(&mut shared_secret, server_sk, client_pk)?;
 
     crypto_kx(tx, rx, client_pk, server_pk, shared_secret)
 }
@@ -146,6 +143,38 @@ pub fn crypto_kx_server_session_keys(
 #[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_kx_rejects_low_order_public_keys() {
+        use sodiumoxide::crypto::kx;
+
+        let (client_pk, client_sk) = crypto_kx_keypair();
+        let mut rx = SessionKey::default();
+        let mut tx = SessionKey::default();
+        let mut one = PublicKey::default();
+        one[0] = 1;
+
+        for server_pk in [PublicKey::default(), one] {
+            assert!(
+                crypto_kx_client_session_keys(
+                    &mut rx,
+                    &mut tx,
+                    &client_pk,
+                    &client_sk,
+                    &server_pk,
+                )
+                .is_err()
+            );
+            assert!(
+                kx::client_session_keys(
+                    &kx::PublicKey::from_slice(&client_pk).unwrap(),
+                    &kx::SecretKey::from_slice(&client_sk).unwrap(),
+                    &kx::PublicKey::from_slice(&server_pk).unwrap(),
+                )
+                .is_err()
+            );
+        }
+    }
 
     #[test]
     fn test_kx() {

--- a/src/classic/crypto_secretbox.rs
+++ b/src/classic/crypto_secretbox.rs
@@ -60,19 +60,30 @@ pub fn crypto_secretbox_keygen() -> Key {
 /// Detached version of [`crypto_secretbox_easy`].
 ///
 /// Compatible with libsodium's `crypto_secretbox_detached`.
+/// Returns an error if `ciphertext` is shorter than `message`.
 pub fn crypto_secretbox_detached(
     ciphertext: &mut [u8],
     mac: &mut Mac,
     message: &[u8],
     nonce: &Nonce,
     key: &Key,
-) {
+) -> Result<(), Error> {
+    if ciphertext.len() < message.len() {
+        return Err(dryoc_error!(format!(
+            "ciphertext length {} less than message length {}",
+            ciphertext.len(),
+            message.len()
+        )));
+    }
+
     crypto_secretbox_detached_b2b(&mut ciphertext[..message.len()], mac, message, nonce, key);
+    Ok(())
 }
 
 /// Detached version of [`crypto_secretbox_open_easy`].
 ///
 /// Compatible with libsodium's `crypto_secretbox_open_detached`.
+/// Returns an error if `message` is shorter than `ciphertext`.
 pub fn crypto_secretbox_open_detached(
     message: &mut [u8],
     mac: &Mac,
@@ -81,6 +92,14 @@ pub fn crypto_secretbox_open_detached(
     key: &Key,
 ) -> Result<(), Error> {
     let c_len = ciphertext.len();
+    if message.len() < c_len {
+        return Err(dryoc_error!(format!(
+            "message length {} less than ciphertext length {}",
+            message.len(),
+            c_len
+        )));
+    }
+
     crypto_secretbox_open_detached_b2b(&mut message[..c_len], mac, ciphertext, nonce, key)
 }
 
@@ -93,6 +112,18 @@ pub fn crypto_secretbox_easy(
     nonce: &Nonce,
     key: &Key,
 ) -> Result<(), Error> {
+    let expected_len = message
+        .len()
+        .checked_add(CRYPTO_SECRETBOX_MACBYTES)
+        .ok_or_else(|| dryoc_error!("ciphertext length overflow"))?;
+    if ciphertext.len() != expected_len {
+        return Err(dryoc_error!(format!(
+            "ciphertext length invalid ({} != {})",
+            ciphertext.len(),
+            expected_len
+        )));
+    }
+
     let mut mac = Mac::default();
     crypto_secretbox_detached(
         &mut ciphertext[CRYPTO_SECRETBOX_MACBYTES..],
@@ -100,7 +131,7 @@ pub fn crypto_secretbox_easy(
         message,
         nonce,
         key,
-    );
+    )?;
 
     ciphertext[..CRYPTO_SECRETBOX_MACBYTES].copy_from_slice(&mac);
 
@@ -122,6 +153,12 @@ pub fn crypto_secretbox_open_easy(
             ciphertext.len(),
             CRYPTO_SECRETBOX_MACBYTES
         )))
+    } else if message.len() != ciphertext.len() - CRYPTO_SECRETBOX_MACBYTES {
+        Err(dryoc_error!(format!(
+            "message length invalid ({} != {})",
+            message.len(),
+            ciphertext.len() - CRYPTO_SECRETBOX_MACBYTES
+        )))
     } else {
         let (mac, ciphertext) = ciphertext.split_at(CRYPTO_SECRETBOX_MACBYTES);
         let mac = ByteArray::as_array(mac);
@@ -136,6 +173,13 @@ pub fn crypto_secretbox_easy_inplace(
     nonce: &Nonce,
     key: &Key,
 ) -> Result<(), Error> {
+    if data.len() < CRYPTO_SECRETBOX_MACBYTES {
+        return Err(dryoc_error!(format!(
+            "data length {} less than minimum {}",
+            data.len(),
+            CRYPTO_SECRETBOX_MACBYTES
+        )));
+    }
     data.rotate_right(CRYPTO_SECRETBOX_MACBYTES);
     let (mac, data) = data.split_at_mut(CRYPTO_SECRETBOX_MACBYTES);
     let mac = MutByteArray::as_mut_array(mac);
@@ -176,6 +220,63 @@ mod tests {
     extern crate test;
 
     use super::*;
+
+    #[test]
+    fn test_crypto_secretbox_rejects_invalid_buffer_lengths_without_mutation() {
+        let key = Key::default();
+        let nonce = Nonce::default();
+        let message = b"buffer length validation";
+
+        let mut short_detached = vec![0xa5; message.len() - 1];
+        let original_short_detached = short_detached.clone();
+        let mut mac = [0x5a; CRYPTO_SECRETBOX_MACBYTES];
+        let original_mac = mac;
+        assert!(
+            crypto_secretbox_detached(&mut short_detached, &mut mac, message, &nonce, &key)
+                .is_err()
+        );
+        assert_eq!(short_detached, original_short_detached);
+        assert_eq!(mac, original_mac);
+
+        for output_len in [
+            message.len() + CRYPTO_SECRETBOX_MACBYTES - 1,
+            message.len() + CRYPTO_SECRETBOX_MACBYTES + 1,
+        ] {
+            let mut output = vec![0xa5; output_len];
+            let original = output.clone();
+            assert!(crypto_secretbox_easy(&mut output, message, &nonce, &key).is_err());
+            assert_eq!(output, original);
+        }
+
+        let mut ciphertext = vec![0u8; message.len() + CRYPTO_SECRETBOX_MACBYTES];
+        crypto_secretbox_easy(&mut ciphertext, message, &nonce, &key).expect("encrypt failed");
+
+        for output_len in [message.len() - 1, message.len() + 1] {
+            let mut output = vec![0xa5; output_len];
+            let original = output.clone();
+            assert!(crypto_secretbox_open_easy(&mut output, &ciphertext, &nonce, &key).is_err());
+            assert_eq!(output, original);
+        }
+
+        let mut short_open = vec![0xa5; message.len() - 1];
+        let original_short_open = short_open.clone();
+        assert!(
+            crypto_secretbox_open_detached(
+                &mut short_open,
+                ByteArray::as_array(&ciphertext[..CRYPTO_SECRETBOX_MACBYTES]),
+                &ciphertext[CRYPTO_SECRETBOX_MACBYTES..],
+                &nonce,
+                &key,
+            )
+            .is_err()
+        );
+        assert_eq!(short_open, original_short_open);
+
+        let mut too_short_inplace = vec![0xa5; CRYPTO_SECRETBOX_MACBYTES - 1];
+        let original_too_short_inplace = too_short_inplace.clone();
+        assert!(crypto_secretbox_easy_inplace(&mut too_short_inplace, &nonce, &key).is_err());
+        assert_eq!(too_short_inplace, original_too_short_inplace);
+    }
 
     #[test]
     fn test_crypto_secretbox_easy() {
@@ -271,7 +372,8 @@ mod tests {
         let mut ciphertext = vec![0xa5; message.len() + 8];
         let mut mac = Mac::default();
 
-        crypto_secretbox_detached(&mut ciphertext, &mut mac, message, &nonce, &key);
+        crypto_secretbox_detached(&mut ciphertext, &mut mac, message, &nonce, &key)
+            .expect("encrypt failed");
 
         assert_eq!(&ciphertext[message.len()..], &[0xa5; 8]);
 
@@ -297,7 +399,8 @@ mod tests {
         let mut ciphertext = vec![0u8; message.len()];
         let mut mac = Mac::default();
 
-        crypto_secretbox_detached(&mut ciphertext, &mut mac, message, &nonce, &key);
+        crypto_secretbox_detached(&mut ciphertext, &mut mac, message, &nonce, &key)
+            .expect("encrypt failed");
         mac[0] ^= 1;
 
         let mut decrypted = vec![0x5a; message.len()];
@@ -330,7 +433,8 @@ mod tests {
                 test::black_box(&message),
                 test::black_box(&nonce),
                 test::black_box(&key),
-            );
+            )
+            .expect("encrypt failed");
         });
     }
 

--- a/src/classic/crypto_sign_ed25519.rs
+++ b/src/classic/crypto_sign_ed25519.rs
@@ -59,9 +59,11 @@ pub(crate) fn crypto_sign_ed25519_seed_keypair_inplace(
     secret_key: &mut SecretKey,
     seed: &[u8; CRYPTO_SIGN_ED25519_SEEDBYTES],
 ) {
-    let hash: [u8; CRYPTO_HASH_SHA512_BYTES] = Sha512::compute(seed);
+    let mut hash: [u8; CRYPTO_HASH_SHA512_BYTES] = Sha512::compute(seed);
 
-    let mut sk = Scalar::from_bytes_mod_order(clamp_hash(hash));
+    let mut clamped = clamp_hash(&mut hash);
+    let mut sk = Scalar::from_bytes_mod_order(clamped);
+    clamped.zeroize();
 
     let pk = (ED25519_BASEPOINT_TABLE * &sk).compress();
     secret_key[..CRYPTO_SIGN_ED25519_SEEDBYTES].copy_from_slice(seed);
@@ -95,6 +97,7 @@ pub(crate) fn crypto_sign_ed25519_keypair_inplace(
     let mut seed = [0u8; CRYPTO_SIGN_ED25519_SEEDBYTES];
     copy_randombytes(&mut seed);
     crypto_sign_ed25519_seed_keypair_inplace(public_key, secret_key, &seed);
+    seed.zeroize();
 }
 
 /// Generates a random Ed25519 keypair which can be used for signing
@@ -108,7 +111,7 @@ pub(crate) fn crypto_sign_ed25519_keypair() -> (PublicKey, SecretKey) {
 }
 
 fn clamp_hash(
-    mut hash: [u8; CRYPTO_HASH_SHA512_BYTES],
+    hash: &mut [u8; CRYPTO_HASH_SHA512_BYTES],
 ) -> [u8; CRYPTO_SCALARMULT_CURVE25519_SCALARBYTES] {
     let mut scalar = [0u8; CRYPTO_SCALARMULT_CURVE25519_SCALARBYTES];
     scalar.copy_from_slice(&hash[..CRYPTO_SCALARMULT_CURVE25519_SCALARBYTES]);
@@ -143,8 +146,8 @@ pub fn crypto_sign_ed25519_sk_to_curve25519(
     x25519_secret_key: &mut [u8; CRYPTO_SCALARMULT_CURVE25519_BYTES],
     ed25519_secret_key: &SecretKey,
 ) {
-    let hash: [u8; CRYPTO_HASH_SHA512_BYTES] = Sha512::compute(&ed25519_secret_key[..32]);
-    let mut scalar = clamp_hash(hash);
+    let mut hash: [u8; CRYPTO_HASH_SHA512_BYTES] = Sha512::compute(&ed25519_secret_key[..32]);
+    let mut scalar = clamp_hash(&mut hash);
     x25519_secret_key.copy_from_slice(&scalar);
     scalar.zeroize()
 }
@@ -223,7 +226,7 @@ fn crypto_sign_ed25519_detached_impl(
 
         signature[32..].copy_from_slice(&secret_key[32..]);
 
-        let r = Scalar::from_bytes_mod_order_wide(&nonce);
+        let mut r = Scalar::from_bytes_mod_order_wide(&nonce);
         let big_r = (ED25519_BASEPOINT_TABLE * &r).compress();
 
         signature[..32].copy_from_slice(big_r.as_bytes());
@@ -234,16 +237,23 @@ fn crypto_sign_ed25519_detached_impl(
         }
         hasher.update(signature);
         hasher.update(message);
-        let hram: [u8; CRYPTO_HASH_SHA512_BYTES] = hasher.finalize();
+        let mut hram: [u8; CRYPTO_HASH_SHA512_BYTES] = hasher.finalize();
 
-        let k = Scalar::from_bytes_mod_order_wide(&hram);
-        let clamped = clamp_hash(az);
-        let sig = (k * Scalar::from_bytes_mod_order(clamped)) + r;
+        let mut k = Scalar::from_bytes_mod_order_wide(&hram);
+        let mut clamped = clamp_hash(&mut az);
+        let mut signing_scalar = Scalar::from_bytes_mod_order(clamped);
+        clamped.zeroize();
+        let mut sig = (k * signing_scalar) + r;
 
         signature[32..].copy_from_slice(sig.as_bytes());
 
         az.zeroize();
         nonce.zeroize();
+        hram.zeroize();
+        r.zeroize();
+        k.zeroize();
+        signing_scalar.zeroize();
+        sig.zeroize();
 
         Ok(())
     }

--- a/src/classic/salsa20_simd.rs
+++ b/src/classic/salsa20_simd.rs
@@ -575,7 +575,8 @@ mod tests {
         ) {
             let mut simd_ciphertext = message.clone();
             let mut simd_mac = [0u8; 16];
-            crypto_secretbox_detached(&mut simd_ciphertext, &mut simd_mac, &message, &nonce, &key);
+            crypto_secretbox_detached(&mut simd_ciphertext, &mut simd_mac, &message, &nonce, &key)
+                .expect("SIMD secretbox encryption failed");
 
             let mut rustcrypto_ciphertext = message.clone();
             let mut rustcrypto_mac_key = Poly1305Key::new();

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -98,7 +98,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::constants::{
     CRYPTO_BOX_BEFORENMBYTES, CRYPTO_BOX_MACBYTES, CRYPTO_BOX_NONCEBYTES,
@@ -305,7 +305,7 @@ impl<
             nonce.as_array(),
             recipient_public_key.as_array(),
             sender_secret_key.as_array(),
-        );
+        )?;
 
         Ok(dryocbox)
     }
@@ -337,7 +337,7 @@ impl<
             message.as_slice(),
             nonce.as_array(),
             precalc_secret_key.as_array(),
-        );
+        )?;
 
         Ok(dryocbox)
     }
@@ -365,6 +365,7 @@ impl<
 
         let mut nonce = Nonce::new_byte_array();
         let (epk, esk) = crypto_box_keypair();
+        let esk = Zeroizing::new(esk);
         crypto_box_seal_nonce(nonce.as_mut_array(), &epk, recipient_public_key.as_array());
 
         let mut pk = EphemeralPublicKey::new_byte_array();
@@ -385,7 +386,7 @@ impl<
             nonce.as_array(),
             recipient_public_key.as_array(),
             &esk,
-        );
+        )?;
 
         Ok(dryocbox)
     }
@@ -800,7 +801,8 @@ mod tests {
         let precalc_secret_key = PrecalcSecretKey::precalculate(
             &keypair_sender.secret_key,
             &keypair_recipient.public_key,
-        );
+        )
+        .expect("precalculation failed");
 
         let dryocbox: VecBox = DryocBox::precalc_encrypt(message, &nonce, &precalc_secret_key)
             .expect("unable to encrypt");
@@ -822,7 +824,8 @@ mod tests {
         let precalc_secret_key = PrecalcSecretKey::precalculate(
             &keypair_sender.secret_key,
             &keypair_recipient.public_key,
-        );
+        )
+        .expect("precalculation failed");
 
         let dryocbox = DryocBox::precalc_encrypt_to_vecbox(message, &nonce, &precalc_secret_key)
             .expect("unable to encrypt");
@@ -850,7 +853,8 @@ mod tests {
         let precalc_secret_key = PrecalcSecretKey::precalculate(
             &keypair_sender.secret_key,
             &keypair_recipient.public_key,
-        );
+        )
+        .expect("precalculation failed");
 
         for message in &messages {
             let dryocbox: VecBox = DryocBox::precalc_encrypt(message, &nonce, &precalc_secret_key)
@@ -880,7 +884,8 @@ mod tests {
         let precalc_secret_key = PrecalcSecretKey::precalculate(
             &keypair_sender.secret_key,
             &keypair_recipient.public_key,
-        );
+        )
+        .expect("precalculation failed");
 
         for message in &messages {
             let dryocbox =

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -799,8 +799,8 @@ mod tests {
 
         let message = b"To be, or not to be, that is the question:";
         let precalc_secret_key = PrecalcSecretKey::precalculate(
-            &keypair_sender.secret_key,
             &keypair_recipient.public_key,
+            &keypair_sender.secret_key,
         )
         .expect("precalculation failed");
 
@@ -822,8 +822,8 @@ mod tests {
 
         let message = b"All the world's a stage, and all the men and women merely players:";
         let precalc_secret_key = PrecalcSecretKey::precalculate(
-            &keypair_sender.secret_key,
             &keypair_recipient.public_key,
+            &keypair_sender.secret_key,
         )
         .expect("precalculation failed");
 
@@ -851,8 +851,8 @@ mod tests {
         ];
 
         let precalc_secret_key = PrecalcSecretKey::precalculate(
-            &keypair_sender.secret_key,
             &keypair_recipient.public_key,
+            &keypair_sender.secret_key,
         )
         .expect("precalculation failed");
 
@@ -882,8 +882,8 @@ mod tests {
         ];
 
         let precalc_secret_key = PrecalcSecretKey::precalculate(
-            &keypair_sender.secret_key,
             &keypair_recipient.public_key,
+            &keypair_sender.secret_key,
         )
         .expect("precalculation failed");
 

--- a/src/dryocsecretbox.rs
+++ b/src/dryocsecretbox.rs
@@ -222,7 +222,8 @@ impl<
             message.as_slice(),
             nonce.as_array(),
             secret_key.as_array(),
-        );
+        )
+        .expect("allocated ciphertext length matches message length");
 
         new
     }

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -5,6 +5,8 @@
 //!
 //! Refer to the [protected] mod for details on usage with protected memory.
 
+use std::fmt;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
@@ -29,9 +31,9 @@ pub type StackKeyPair = KeyPair<PublicKey, SecretKey>;
 
 #[cfg_attr(
     feature = "serde",
-    derive(Zeroize, ZeroizeOnDrop, Serialize, Deserialize, Debug, Clone)
+    derive(Zeroize, ZeroizeOnDrop, Serialize, Deserialize, Clone)
 )]
-#[cfg_attr(not(feature = "serde"), derive(Zeroize, ZeroizeOnDrop, Debug, Clone))]
+#[cfg_attr(not(feature = "serde"), derive(Zeroize, ZeroizeOnDrop, Clone))]
 /// Public/private keypair for use with [`crate::dryocbox::DryocBox`], aka
 /// libsodium box
 pub struct KeyPair<
@@ -42,6 +44,19 @@ pub struct KeyPair<
     pub public_key: PublicKey,
     /// Secret key
     pub secret_key: SecretKey,
+}
+
+impl<
+    PublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,
+    SecretKey: ByteArray<CRYPTO_BOX_SECRETKEYBYTES> + Zeroize,
+> fmt::Debug for KeyPair<PublicKey, SecretKey>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KeyPair")
+            .field("public_key", &"[REDACTED]")
+            .field("secret_key", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl<
@@ -157,19 +172,10 @@ impl<
     /// Checks if the given public key is valid according to X25519 rules.
     ///
     /// For X25519 ([`crypto_box`](`crate::classic::crypto_box`),
-    /// [`DryocBox`](`crate::dryocbox::DryocBox`)), a public key is considered
-    /// valid if:
-    /// - It is not the all-zero point `[0, ..., 0]`.
-    /// - The high bit of the last byte is 0.
-    ///
-    /// This function verifies these conditions.
-    ///
-    /// **Note:** This validation is specific to X25519 keys used in
-    /// Diffie-Hellman key exchange (`crypto_box`). It primarily aims to
-    /// exclude degenerate keys and does **not** explicitly verify that the
-    /// point lies on the underlying curve, unlike stricter Ed25519 point
-    /// validation (see
-    /// [`crypto_core_ed25519_is_valid_point`](`crate::classic::crypto_core::crypto_core_ed25519_is_valid_point`)).
+    /// [`DryocBox`](`crate::dryocbox::DryocBox`)), this performs a trial scalar
+    /// multiplication and rejects public keys that produce an all-zero shared
+    /// secret, including low-order inputs rejected by libsodium. As required by
+    /// RFC 7748, the high bit of the encoded public key is ignored.
     ///
     /// ## Validating Protected Keys
     ///
@@ -216,23 +222,11 @@ impl<
     /// # }
     /// ```
     pub fn is_valid_public_key<PK: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>>(key: &PK) -> bool {
-        const ZERO_POINT: [u8; CRYPTO_BOX_PUBLICKEYBYTES] = [0u8; CRYPTO_BOX_PUBLICKEYBYTES];
-        let key_array = key.as_array();
+        let scalar = [0u8; CRYPTO_BOX_SECRETKEYBYTES];
+        let mut shared_secret = [0u8; CRYPTO_BOX_PUBLICKEYBYTES];
 
-        // Check 1: Not the all-zero point
-        if key_array == &ZERO_POINT {
-            return false;
-        }
-
-        // Check 2: High bit of the last byte must be 0
-        // Although clamping during generation usually ensures this, we check it.
-        if key_array[CRYPTO_BOX_PUBLICKEYBYTES - 1] & 0x80 != 0 {
-            return false;
-        }
-
-        // If both checks pass, it's considered a valid X25519 public key
-        // representation.
-        true
+        crate::classic::crypto_core::crypto_scalarmult(&mut shared_secret, &scalar, key.as_array())
+            .is_ok()
     }
 
     /// Checks if the given key is a valid Ed25519 public key, using relaxed
@@ -275,7 +269,7 @@ impl<
     pub fn precalculate(
         &self,
         third_party_public_key: &PublicKey,
-    ) -> PrecalcSecretKey<StackByteArray<CRYPTO_BOX_BEFORENMBYTES>> {
+    ) -> Result<PrecalcSecretKey<StackByteArray<CRYPTO_BOX_BEFORENMBYTES>>, Error> {
         PrecalcSecretKey::precalculate(third_party_public_key, &self.secret_key)
     }
 }
@@ -342,7 +336,7 @@ pub mod protected {
         pub fn precalculate_locked<OtherPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>>(
             &self,
             third_party_public_key: &OtherPublicKey,
-        ) -> Result<PrecalcSecretKey<Locked<HeapByteArray<CRYPTO_BOX_BEFORENMBYTES>>>, std::io::Error>
+        ) -> Result<PrecalcSecretKey<Locked<HeapByteArray<CRYPTO_BOX_BEFORENMBYTES>>>, Error>
         {
             PrecalcSecretKey::precalculate_locked(third_party_public_key, &self.secret_key)
         }
@@ -391,10 +385,8 @@ pub mod protected {
         >(
             &self,
             third_party_public_key: &OtherPublicKey,
-        ) -> Result<
-            PrecalcSecretKey<LockedRO<HeapByteArray<CRYPTO_BOX_BEFORENMBYTES>>>,
-            std::io::Error,
-        > {
+        ) -> Result<PrecalcSecretKey<LockedRO<HeapByteArray<CRYPTO_BOX_BEFORENMBYTES>>>, Error>
+        {
             PrecalcSecretKey::precalculate_readonly_locked(third_party_public_key, &self.secret_key)
         }
     }
@@ -425,6 +417,17 @@ mod tests {
 
     use super::*;
     use crate::kx::Session;
+
+    #[test]
+    fn keypair_debug_redacts_keys() {
+        let keypair = StackKeyPair::generate();
+        let debug = format!("{keypair:?}");
+
+        assert_eq!(
+            debug,
+            "KeyPair { public_key: \"[REDACTED]\", secret_key: \"[REDACTED]\" }"
+        );
+    }
 
     fn all_eq<T>(t: &[T], v: T) -> bool
     where
@@ -470,7 +473,7 @@ mod tests {
     fn test_keypair_precalculate() {
         let kp1 = KeyPair::generate_with_defaults();
         let kp2 = KeyPair::generate_with_defaults();
-        let precalc = kp1.precalculate(&kp2.public_key);
+        let precalc = kp1.precalculate(&kp2.public_key).unwrap();
         assert_eq!(precalc.len(), crate::constants::CRYPTO_BOX_BEFORENMBYTES);
     }
 
@@ -545,13 +548,15 @@ mod tests {
             "Known valid key failed validation"
         );
 
-        // Invalid: High bit set
-        let mut invalid_high_bit_bytes = [0u8; CRYPTO_BOX_PUBLICKEYBYTES];
-        invalid_high_bit_bytes[31] = 0x80;
-        let invalid_high_bit = PublicKey::from(invalid_high_bit_bytes);
+        // RFC 7748 requires the high bit to be ignored when decoding X25519
+        // public keys.
+        let mut high_bit_bytes = [0u8; CRYPTO_BOX_PUBLICKEYBYTES];
+        high_bit_bytes[0] = 9;
+        high_bit_bytes[31] = 0x80;
+        let high_bit = PublicKey::from(high_bit_bytes);
         assert!(
-            !KeyPair::<PublicKey, SecretKey>::is_valid_public_key(&invalid_high_bit),
-            "Key with high bit set should be invalid"
+            KeyPair::<PublicKey, SecretKey>::is_valid_public_key(&high_bit),
+            "RFC 7748 high-bit encoding should be accepted"
         );
 
         // Invalid: Zero point
@@ -562,8 +567,13 @@ mod tests {
             "Zero key should be invalid"
         );
 
-        // The identity point [1, 0, ..., 0] is NOT necessarily invalid for X25519,
-        // unlike Ed25519 validation. We don't explicitly test its rejection here.
+        let mut identity_bytes = [0u8; CRYPTO_BOX_PUBLICKEYBYTES];
+        identity_bytes[0] = 1;
+        let identity = PublicKey::from(identity_bytes);
+        assert!(
+            !KeyPair::<PublicKey, SecretKey>::is_valid_public_key(&identity),
+            "Low-order key should be invalid"
+        );
 
         // Generated key should be valid
         let kp = KeyPair::generate_with_defaults();

--- a/src/kx.rs
+++ b/src/kx.rs
@@ -45,6 +45,8 @@
 //! * See <https://doc.libsodium.org/key_exchange> for additional details on key
 //!   exchange
 
+use std::fmt;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
@@ -65,16 +67,24 @@ pub type SecretKey = StackByteArray<CRYPTO_KX_SECRETKEYBYTES>;
 /// Stack-allocated keypair type alias
 pub type KeyPair = crate::keypair::KeyPair<PublicKey, SecretKey>;
 
-#[cfg_attr(
-    feature = "serde",
-    derive(Zeroize, Clone, Debug, Serialize, Deserialize)
-)]
-#[cfg_attr(not(feature = "serde"), derive(Zeroize, Clone, Debug))]
+#[cfg_attr(feature = "serde", derive(Zeroize, Clone, Serialize, Deserialize))]
+#[cfg_attr(not(feature = "serde"), derive(Zeroize, Clone))]
 /// Key derivation implemantation based on Curve25519, Diffie-Hellman, and
 /// Blake2b. Compatible with libsodium's `crypto_kx_*` functions.
 pub struct Session<SessionKey: ByteArray<CRYPTO_KX_SESSIONKEYBYTES> + Zeroize> {
     rx_key: SessionKey,
     tx_key: SessionKey,
+}
+
+impl<SessionKey: ByteArray<CRYPTO_KX_SESSIONKEYBYTES> + Zeroize> fmt::Debug
+    for Session<SessionKey>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Session")
+            .field("rx_key", &"[REDACTED]")
+            .field("tx_key", &"[REDACTED]")
+            .finish()
+    }
 }
 
 /// Stack-allocated type alias for [`Session`]. Provided for convenience.
@@ -255,6 +265,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn session_debug_redacts_keys() {
+        let session = StackSession {
+            rx_key: SessionKey::from([1u8; CRYPTO_KX_SESSIONKEYBYTES]),
+            tx_key: SessionKey::from([2u8; CRYPTO_KX_SESSIONKEYBYTES]),
+        };
+
+        assert_eq!(
+            format!("{session:?}"),
+            "Session { rx_key: \"[REDACTED]\", tx_key: \"[REDACTED]\" }"
+        );
+    }
+
+    #[test]
     fn test_kx() {
         let client_keypair = KeyPair::generate();
         let server_keypair = KeyPair::generate();
@@ -272,5 +295,13 @@ mod tests {
 
         assert_eq!(client_rx, server_tx);
         assert_eq!(client_tx, server_rx);
+    }
+
+    #[test]
+    fn test_kx_rejects_low_order_public_key() {
+        let client_keypair = KeyPair::generate();
+        let low_order_public_key = PublicKey::default();
+
+        assert!(Session::new_client_with_defaults(&client_keypair, &low_order_public_key).is_err());
     }
 }

--- a/src/precalc.rs
+++ b/src/precalc.rs
@@ -3,11 +3,15 @@
 //!
 //! You may want to use `precalc_*` functions if you need to
 //! encrypt/decrypt multiple messages between the same sender and receiver.
+use std::fmt;
+
+use subtle::ConstantTimeEq;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::constants::{
     CRYPTO_BOX_BEFORENMBYTES, CRYPTO_BOX_PUBLICKEYBYTES, CRYPTO_BOX_SECRETKEYBYTES,
 };
+use crate::error::Error;
 use crate::types::{ByteArray, Bytes, MutByteArray, MutBytes, StackByteArray};
 
 type InnerKey = StackByteArray<CRYPTO_BOX_BEFORENMBYTES>;
@@ -22,8 +26,28 @@ type InnerKey = StackByteArray<CRYPTO_BOX_BEFORENMBYTES>;
 ///
 /// Using precalculated secret keys is compatible with libsodium's
 /// `crypto_box_beforenm`.
-#[derive(Zeroize, ZeroizeOnDrop, Debug, PartialEq, Eq, Clone)]
+#[derive(Zeroize, ZeroizeOnDrop, Clone)]
 pub struct PrecalcSecretKey<InnerKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize>(InnerKey);
+
+impl<InnerKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize> fmt::Debug
+    for PrecalcSecretKey<InnerKey>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PrecalcSecretKey")
+            .field(&"[REDACTED]")
+            .finish()
+    }
+}
+
+impl<InnerKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize> PartialEq
+    for PrecalcSecretKey<InnerKey>
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_slice().ct_eq(other.0.as_slice()).into()
+    }
+}
+
+impl<InnerKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize> Eq for PrecalcSecretKey<InnerKey> {}
 
 impl<InnerKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Bytes + Zeroize> Bytes
     for PrecalcSecretKey<InnerKey>
@@ -88,10 +112,12 @@ impl PrecalcSecretKey<InnerKey> {
     >(
         third_party_public_key: &ThirdPartyPublicKey,
         secret_key: &SecretKey,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         use crate::classic::crypto_box::crypto_box_beforenm;
 
-        Self(crypto_box_beforenm(third_party_public_key.as_array(), secret_key.as_array()).into())
+        Ok(Self(
+            crypto_box_beforenm(third_party_public_key.as_array(), secret_key.as_array())?.into(),
+        ))
     }
 }
 
@@ -115,12 +141,12 @@ pub mod protected {
         >(
             third_party_public_key: &ThirdPartyPublicKey,
             secret_key: &SecretKey,
-        ) -> Result<Self, std::io::Error> {
+        ) -> Result<Self, Error> {
             use crate::classic::crypto_box::crypto_box_beforenm;
 
             let mut precalc = HeapByteArray::<CRYPTO_BOX_BEFORENMBYTES>::new_locked()?;
             let mut key =
-                crypto_box_beforenm(third_party_public_key.as_array(), secret_key.as_array());
+                crypto_box_beforenm(third_party_public_key.as_array(), secret_key.as_array())?;
 
             precalc.copy_from_slice(&key);
             key.zeroize();
@@ -141,12 +167,12 @@ pub mod protected {
         >(
             third_party_public_key: &ThirdPartyPublicKey,
             secret_key: &SecretKey,
-        ) -> Result<Self, std::io::Error> {
+        ) -> Result<Self, Error> {
             use crate::classic::crypto_box::crypto_box_beforenm;
 
             let mut precalc = HeapByteArray::<CRYPTO_BOX_BEFORENMBYTES>::new_locked()?;
             let mut key =
-                crypto_box_beforenm(third_party_public_key.as_array(), secret_key.as_array());
+                crypto_box_beforenm(third_party_public_key.as_array(), secret_key.as_array())?;
 
             precalc.copy_from_slice(&key);
             key.zeroize();
@@ -176,21 +202,33 @@ impl<InnerKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize> std::ops::DerefMut
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn precalculated_key_debug_redacts_contents() {
+        let key = PrecalcSecretKey(StackByteArray::from([0xabu8; CRYPTO_BOX_BEFORENMBYTES]));
+
+        assert_eq!(format!("{key:?}"), "PrecalcSecretKey(\"[REDACTED]\")");
+    }
     use crate::constants::{CRYPTO_BOX_PUBLICKEYBYTES, CRYPTO_BOX_SECRETKEYBYTES};
 
     #[test]
     fn test_precalculate() {
-        let public_key = StackByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::default();
+        let mut public_key = StackByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::default();
+        public_key.as_mut_array()[0] = 9;
         let secret_key = StackByteArray::<CRYPTO_BOX_SECRETKEYBYTES>::default();
-        let precalc_key = PrecalcSecretKey::precalculate(&public_key, &secret_key);
+        let precalc_key = PrecalcSecretKey::precalculate(&public_key, &secret_key).unwrap();
         assert!(!precalc_key.is_empty());
         assert_eq!(precalc_key.len(), CRYPTO_BOX_BEFORENMBYTES);
+
+        let low_order_public_key = StackByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::default();
+        assert!(PrecalcSecretKey::precalculate(&low_order_public_key, &secret_key).is_err());
     }
 
     #[cfg(all(feature = "protected", any(unix, windows)))]
     #[test]
     fn test_precalculate_locked() {
-        let public_key = StackByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::default();
+        let mut public_key = StackByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::default();
+        public_key.as_mut_array()[0] = 9;
         let secret_key = StackByteArray::<CRYPTO_BOX_SECRETKEYBYTES>::default();
         let mut precalc_key =
             PrecalcSecretKey::precalculate_locked(&public_key, &secret_key).unwrap();
@@ -200,13 +238,13 @@ mod tests {
         // should be able to write now without blowing up
         precalc_key.as_mut_slice()[0] = 0;
         precalc_key.as_mut_array()[0] = 1;
-        precalc_key.copy_from_slice(&precalc_key.as_slice().to_owned());
     }
 
     #[cfg(all(feature = "protected", any(unix, windows)))]
     #[test]
     fn test_precalculate_readonly_locked() {
-        let public_key = StackByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::default();
+        let mut public_key = StackByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::default();
+        public_key.as_mut_array()[0] = 9;
         let secret_key = StackByteArray::<CRYPTO_BOX_SECRETKEYBYTES>::default();
         let precalc_key =
             PrecalcSecretKey::precalculate_readonly_locked(&public_key, &secret_key).unwrap();

--- a/src/precalc.rs
+++ b/src/precalc.rs
@@ -204,10 +204,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn precalculated_key_debug_redacts_contents() {
+    fn precalculated_key_debug_redacts_contents_and_equality_is_value_based() {
         let key = PrecalcSecretKey(StackByteArray::from([0xabu8; CRYPTO_BOX_BEFORENMBYTES]));
+        let same = key.clone();
+        let different = PrecalcSecretKey(StackByteArray::from([0xcdu8; CRYPTO_BOX_BEFORENMBYTES]));
 
         assert_eq!(format!("{key:?}"), "PrecalcSecretKey(\"[REDACTED]\")");
+        assert_eq!(key, same);
+        assert_ne!(key, different);
     }
     use crate::constants::{CRYPTO_BOX_PUBLICKEYBYTES, CRYPTO_BOX_SECRETKEYBYTES};
 
@@ -238,6 +242,9 @@ mod tests {
         // should be able to write now without blowing up
         precalc_key.as_mut_slice()[0] = 0;
         precalc_key.as_mut_array()[0] = 1;
+
+        let low_order_public_key = StackByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::default();
+        assert!(PrecalcSecretKey::precalculate_locked(&low_order_public_key, &secret_key).is_err());
     }
 
     #[cfg(all(feature = "protected", any(unix, windows)))]
@@ -250,5 +257,11 @@ mod tests {
             PrecalcSecretKey::precalculate_readonly_locked(&public_key, &secret_key).unwrap();
         assert!(!precalc_key.is_empty());
         assert_eq!(precalc_key.len(), CRYPTO_BOX_BEFORENMBYTES);
+
+        let low_order_public_key = StackByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::default();
+        assert!(
+            PrecalcSecretKey::precalculate_readonly_locked(&low_order_public_key, &secret_key)
+                .is_err()
+        );
     }
 }

--- a/src/protected.rs
+++ b/src/protected.rs
@@ -1162,7 +1162,7 @@ unsafe impl Allocator for PageAlignedAllocator {
     #[inline]
     fn allocate(&self, layout: std::alloc::Layout) -> Result<NonNull<[u8]>, AllocError> {
         let pagesize = *PAGESIZE;
-        if pagesize % layout.align() != 0 {
+        if !pagesize.is_multiple_of(layout.align()) {
             return Err(AllocError);
         }
 

--- a/src/protected.rs
+++ b/src/protected.rs
@@ -148,6 +148,7 @@ use std::marker::PhantomData;
 use std::ptr::{self, NonNull};
 use std::sync::LazyLock;
 
+use subtle::ConstantTimeEq;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::error;
@@ -749,7 +750,8 @@ impl Lockable<HeapBytes> for HeapBytes {
 #[derive(Clone)]
 /// Custom page-aligned allocator implementation. Creates blocks of page-aligned
 /// heap-allocated memory regions, with no-access pages before and after the
-/// allocated region of memory.
+/// allocated region of memory. Allocations whose requested alignment does not
+/// divide the host page size are rejected.
 pub struct PageAlignedAllocator;
 
 #[cfg(unix)]
@@ -1045,13 +1047,16 @@ impl Clone for ProtectedBuffer {
 
 impl fmt::Debug for ProtectedBuffer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_list().entries(self.as_slice()).finish()
+        f.debug_struct("ProtectedBuffer")
+            .field("len", &self.len())
+            .field("contents", &"[REDACTED]")
+            .finish()
     }
 }
 
 impl PartialEq for ProtectedBuffer {
     fn eq(&self, other: &Self) -> bool {
-        self.as_slice() == other.as_slice()
+        self.as_slice().ct_eq(other.as_slice()).into()
     }
 }
 
@@ -1156,6 +1161,11 @@ impl_index_protected_buffer!(std::ops::RangeToInclusive<usize>);
 unsafe impl Allocator for PageAlignedAllocator {
     #[inline]
     fn allocate(&self, layout: std::alloc::Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let pagesize = *PAGESIZE;
+        if pagesize % layout.align() != 0 {
+            return Err(AllocError);
+        }
+
         let raw = allocate_raw_region(layout.size()).map_err(|_| AllocError)?;
         // SAFETY: `raw.data` points to the unique user-visible allocation
         // region returned by `allocate_raw_region`.
@@ -1851,6 +1861,15 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn protected_byte_array_debug_redacts_contents() {
+        let bytes = HeapByteArray::from(StackByteArray::from([0xabu8; 4]));
+        let debug = format!("{bytes:?}");
+
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("171"));
+    }
+
     fn interesting_lengths() -> impl Strategy<Value = usize> {
         let pagesize = *PAGESIZE;
         let max = pagesize.saturating_mul(2).saturating_add(8);
@@ -1936,6 +1955,44 @@ mod tests {
         vec.resize(5, 0);
 
         assert_eq!([1, 2, 3, 0, 1], vec.as_slice());
+    }
+
+    #[cfg(feature = "nightly")]
+    #[test]
+    fn test_allocator_honors_supported_alignment() {
+        let allocator = PageAlignedAllocator;
+        let layout = std::alloc::Layout::from_size_align(1, *PAGESIZE).unwrap();
+        let allocation = allocator.allocate(layout).unwrap();
+        let data = allocation.as_ptr() as *mut u8;
+
+        assert_eq!(data.addr() % layout.align(), 0);
+
+        // SAFETY: `data` was returned by `allocator` for this exact `layout`.
+        unsafe { allocator.deallocate(NonNull::new_unchecked(data), layout) };
+    }
+
+    #[cfg(feature = "nightly")]
+    #[test]
+    fn test_allocator_rejects_unsupported_alignment() {
+        let unsupported_alignment = PAGESIZE.checked_mul(2).unwrap();
+        let layout = std::alloc::Layout::from_size_align(1, unsupported_alignment).unwrap();
+
+        assert!(PageAlignedAllocator.allocate(layout).is_err());
+    }
+
+    #[cfg(feature = "nightly")]
+    #[test]
+    fn test_allocator_handles_zero_sized_layout() {
+        let allocator = PageAlignedAllocator;
+        let layout = std::alloc::Layout::from_size_align(0, 1).unwrap();
+        let allocation = allocator.allocate(layout).unwrap();
+        let data = allocation.as_ptr() as *mut u8;
+
+        assert_eq!(allocation.len(), 0);
+        assert_eq!(data.addr() % layout.align(), 0);
+
+        // SAFETY: `data` was returned by `allocator` for this exact `layout`.
+        unsafe { allocator.deallocate(NonNull::new_unchecked(data), layout) };
     }
 
     #[test]

--- a/src/scalarmult_curve25519.rs
+++ b/src/scalarmult_curve25519.rs
@@ -1,6 +1,7 @@
 use curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
 use curve25519_dalek::montgomery::MontgomeryPoint;
 use curve25519_dalek::scalar::Scalar;
+use zeroize::Zeroize;
 
 use crate::constants::{
     CRYPTO_SCALARMULT_CURVE25519_BYTES, CRYPTO_SCALARMULT_CURVE25519_SCALARBYTES,
@@ -20,10 +21,13 @@ pub(crate) fn crypto_scalarmult_curve25519_base(
     q: &mut [u8; CRYPTO_SCALARMULT_CURVE25519_BYTES],
     n: &[u8; CRYPTO_SCALARMULT_CURVE25519_SCALARBYTES],
 ) {
-    let sk = Scalar::from_bytes_mod_order(clamp(n));
+    let mut clamped = clamp(n);
+    let mut sk = Scalar::from_bytes_mod_order(clamped);
+    clamped.zeroize();
     let pk = (ED25519_BASEPOINT_TABLE * &sk).to_montgomery();
 
     q.copy_from_slice(pk.as_bytes());
+    sk.zeroize();
 }
 
 pub(crate) fn crypto_scalarmult_curve25519(
@@ -31,9 +35,14 @@ pub(crate) fn crypto_scalarmult_curve25519(
     n: &[u8; CRYPTO_SCALARMULT_CURVE25519_SCALARBYTES],
     p: &[u8; CRYPTO_SCALARMULT_CURVE25519_BYTES],
 ) {
-    let sk = Scalar::from_bytes_mod_order(clamp(n));
-    let pk = MontgomeryPoint(*p);
-    let shared_secret = sk * pk;
+    // RFC 7748 requires X25519 implementations to ignore the most significant
+    // bit of the final input byte for compatibility with existing point
+    // formats.
+    let mut encoded_point = *p;
+    encoded_point[CRYPTO_SCALARMULT_CURVE25519_BYTES - 1] &= 0x7f;
+    let pk = MontgomeryPoint(encoded_point);
+    let mut shared_secret = pk.mul_clamped(*n);
 
     q.copy_from_slice(shared_secret.as_bytes());
+    shared_secret.zeroize();
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -93,10 +93,12 @@
 //! * For stream encryption, see [`DryocStream`](crate::dryocstream)
 //! * See the [protected] mod for an example using the protected memory features
 
+use std::fmt;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::classic::crypto_sign::{
     SignerState, crypto_sign_detached, crypto_sign_ed25519_sk_to_pk,
@@ -148,9 +150,9 @@ pub fn secret_key_to_public_key<
 
 #[cfg_attr(
     feature = "serde",
-    derive(Zeroize, ZeroizeOnDrop, Serialize, Deserialize, Debug, Clone)
+    derive(Zeroize, ZeroizeOnDrop, Serialize, Deserialize, Clone)
 )]
-#[cfg_attr(not(feature = "serde"), derive(Zeroize, ZeroizeOnDrop, Debug, Clone))]
+#[cfg_attr(not(feature = "serde"), derive(Zeroize, ZeroizeOnDrop, Clone))]
 /// An Ed25519 keypair for public-key signatures
 pub struct SigningKeyPair<
     PublicKey: ByteArray<CRYPTO_SIGN_PUBLICKEYBYTES> + Zeroize,
@@ -160,6 +162,19 @@ pub struct SigningKeyPair<
     pub public_key: PublicKey,
     /// Secret key
     pub secret_key: SecretKey,
+}
+
+impl<
+    PublicKey: ByteArray<CRYPTO_SIGN_PUBLICKEYBYTES> + Zeroize,
+    SecretKey: ByteArray<CRYPTO_SIGN_SECRETKEYBYTES> + Zeroize,
+> fmt::Debug for SigningKeyPair<PublicKey, SecretKey>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SigningKeyPair")
+            .field("public_key", &"[REDACTED]")
+            .field("secret_key", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl<
@@ -198,10 +213,10 @@ impl<
     /// Derives a signing keypair from `secret_key`, and consumes it, returning
     /// a new keypair.
     pub fn from_secret_key(secret_key: SecretKey) -> Self {
-        let mut seed = [0u8; 32];
+        let mut seed = Zeroizing::new([0u8; 32]);
         seed.copy_from_slice(&secret_key.as_slice()[..32]);
 
-        Self::from_seed(&seed)
+        Self::from_seed(&*seed)
     }
 
     /// Derives a signing keypair from `seed`, returning

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -647,6 +647,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn signing_keypair_debug_redacts_keys_and_secret_key_reconstructs_keypair() {
+        let keypair = SigningKeyPair::<PublicKey, SecretKey>::generate();
+        let debug = format!("{keypair:?}");
+        let reconstructed = SigningKeyPair::from_secret_key(keypair.secret_key.clone());
+
+        assert_eq!(
+            debug,
+            "SigningKeyPair { public_key: \"[REDACTED]\", secret_key: \"[REDACTED]\" }"
+        );
+        assert_eq!(reconstructed, keypair);
+    }
+
+    #[test]
     fn test_message_signing() {
         let keypair = SigningKeyPair::generate_with_defaults();
         let message = b"hello my frens";

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,13 +1,32 @@
+use std::fmt;
 use std::ops::{Deref, DerefMut};
 
+use subtle::ConstantTimeEq;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::rng::copy_randombytes;
 
 /// A stack-allocated fixed-length byte array for working with data, with
 /// optional [Serde](https://serde.rs) features.
-#[derive(Zeroize, ZeroizeOnDrop, Debug, PartialEq, Eq, Clone)]
+#[derive(Zeroize, ZeroizeOnDrop, Clone)]
 pub struct StackByteArray<const LENGTH: usize>([u8; LENGTH]);
+
+impl<const LENGTH: usize> fmt::Debug for StackByteArray<LENGTH> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StackByteArray")
+            .field("len", &LENGTH)
+            .field("contents", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl<const LENGTH: usize> PartialEq for StackByteArray<LENGTH> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.ct_eq(&other.0).into()
+    }
+}
+
+impl<const LENGTH: usize> Eq for StackByteArray<LENGTH> {}
 
 /// Fixed-length byte array.
 pub trait ByteArray<const LENGTH: usize>: Bytes {
@@ -572,5 +591,14 @@ mod tests {
     fn test_vec_as_mut_array_out_of_bounds_ok() {
         let mut vec = vec![1, 2];
         let _ = <Vec<u8> as MutByteArray<2>>::as_mut_array(&mut vec)[1];
+    }
+
+    #[test]
+    fn stack_byte_array_debug_redacts_contents() {
+        let bytes = StackByteArray::from([0xabu8; 4]);
+        let debug = format!("{bytes:?}");
+
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("171"));
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -377,7 +377,8 @@ fn test_dryocbox() {
     assert_eq!(message, decrypted.as_slice());
 
     let shared_key =
-        PrecalcSecretKey::precalculate(&recipient_keypair.public_key, &sender_keypair.secret_key);
+        PrecalcSecretKey::precalculate(&recipient_keypair.public_key, &sender_keypair.secret_key)
+            .expect("precalculation failed");
 
     let dryocbox = DryocBox::precalc_encrypt_to_vecbox(message, &nonce, &shared_key)
         .expect("unable to encrypt");

--- a/tests/wasm_tests.rs
+++ b/tests/wasm_tests.rs
@@ -39,7 +39,8 @@ fn dryocbox_precalc_roundtrip() {
     let nonce = Nonce::generate();
     let message = b"wasm dryocbox precalc";
     let shared_key =
-        PrecalcSecretKey::precalculate(&recipient_keypair.public_key, &sender_keypair.secret_key);
+        PrecalcSecretKey::precalculate(&recipient_keypair.public_key, &sender_keypair.secret_key)
+            .expect("precalculation failed");
 
     let dryocbox =
         DryocBox::precalc_encrypt_to_vecbox(message, &nonce, &shared_key).expect("encrypt failed");


### PR DESCRIPTION
## Summary

Harden cryptographic boundary checks, secret cleanup, protected allocation behavior, and sensitive type formatting following a security-focused crate audit.

## User Impact

Unacceptable low-order X25519 public keys are now rejected instead of producing an all-zero shared secret. Box and secretbox APIs reject malformed buffer lengths without mutating output, sensitive values no longer appear in `Debug` output, secret comparisons use constant-time equality, and unsupported protected-memory alignments fail safely.

This changes several Classic and Rustaceous box/precalculation APIs to return `Result`; callers must handle the new error path.

## Breaking Changes

This is a breaking API change for callers of the affected functions and methods. This PR sets the crate version to `1.0.0` for the next release:

- `crypto_scalarmult`, `crypto_box_beforenm`, `crypto_box_detached`, `crypto_box_detached_afternm`, and `crypto_secretbox_detached` now return `Result`.
- `KeyPair::precalculate` and `PrecalcSecretKey::precalculate` now return `Result`.
- `KeyPair::{precalculate_locked, precalculate_readonly_locked}` and `PrecalcSecretKey::{precalculate_locked, precalculate_readonly_locked}` now return `dryoc::Error` instead of `std::io::Error`.
- Box and secretbox APIs with separate input/output buffers now reject mismatched lengths instead of accepting oversized outputs or panicking on undersized outputs.
- Low-order X25519 public keys now return an error through scalarmult, box, key-exchange, and precalculation APIs.
- `Debug` output for `StackByteArray`, protected buffers, keypairs, sessions, and precalculated keys is now redacted.

Callers should handle the new results with `?`, `match`, or an explicit `.expect(...)`. Protected-precalculation callers that name the error type must update it to `dryoc::Error`.

## Root Cause

Several cryptographic APIs assumed valid peer keys and correctly sized buffers, temporary secrets were not uniformly protected by drop-based zeroization, generic debug/equality implementations were unsuitable for secret-bearing types, and the protected allocator assumed every requested alignment was compatible with the host page size.

## Fix

- implement RFC 7748 X25519 decoding semantics and reject all-zero shared secrets across scalarmult, box, key exchange, and precalculation APIs
- enforce buffer-size contracts before encryption or decryption and preserve outputs on validation failures
- zeroize Argon2, Ed25519, Curve25519, box, and key-exchange intermediates on success and error paths
- redact secret-bearing `Debug` output and use constant-time equality for fixed and protected byte arrays
- validate page-aligned allocator requests and cover supported, unsupported, and zero-sized layouts
- add libsodium compatibility and regression tests for the hardened behavior

## Validation

- `cargo test`
- `cargo test --features serde`
- `cargo test --features wincode`
- `cargo +nightly test --features serde,nightly,wincode`
- `cargo +nightly test --features simd_backend,nightly`
- `cargo clippy --all-targets --features default -- -D warnings`
- `cargo +nightly fmt --all -- --check`