### PR TITLE
docs: overhaul public API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,44 +4,32 @@
 
 # dryoc: Don't Roll Your Own Crypto™<sup>[^1]</sup>
 
-dryoc is a pure-Rust, general-purpose cryptography library that's hard to misuse. It's based on the excellent
-[libsodium](https://github.com/jedisct1/libsodium) library, but in _pure_ Rust. It
-also includes protected memory features throughout, which makes it dead simple
-to build secure, robust, and safe cryptographic software. The original goal of this library was to provide a pure-Rust alternative to libsodium.
+dryoc is a pure-Rust, general-purpose cryptography library based on
+[libsodium](https://github.com/jedisct1/libsodium). Many supported operations
+use libsodium-compatible algorithms and wire formats, allowing dryoc and
+libsodium applications to interoperate.
 
 ![Granny says no](dryoc.png)
 
-The purpose of this project is to provide a pure-Rust, mostly drop-in
-replacement for libsodium. This library has nearly the same ergonomics as
-libsodium (referred to in dryoc as the _Classic_ API), such that people
-familiar with libsodium can use this library nearly interchangeably. While
-the API is not 100% identical to libsodium, most functions have the same or
-very similar signatures.
+The _Classic_ API closely follows libsodium's functions and types. It is not
+identical to libsodium, but most implemented functions have the same or similar
+signatures.
 
-In addition to the Classic API, there's a _Rustaceous_ API which aims to bring
-an idiomatic Rust implementation of libsodium's core features: public and
-secret key authenticated cryptography and general-purpose cryptography tools.
+The _Rustaceous_ API wraps the same operations in Rust types that make key,
+nonce, and output sizes explicit. The two APIs can be used together.
 
-Not all features from libsodium are implemented here, either because there
-exist better implementations in other crates, or because they aren't
-necessary as part of this crate.
+dryoc does not implement every libsodium feature. See [Project status](#project-status)
+for current coverage.
 
-Additionally, this crate provides exceptionally safe cryptography thanks to
-Rust's safety features. The Rustaceous API is designed designed to make it
-difficult to shoot yourself in the foot. It's worth noting, however, you
-certainly can still shoot yourself if you choose (either by leaking private
-data, using insecure hardware, OPSEC issues, etc).
-
-For example usage, refer to the
-[official docs](https://docs.rs/dryoc/latest/dryoc/) or the
-[integration tests](/tests/integration_tests.rs).
+See the [API documentation](https://docs.rs/dryoc/latest/dryoc/) and
+[integration tests](tests/integration_tests.rs) for examples.
 
 ## Features
 
-* 100% pure Rust, no hidden C libraries
-* mostly free of unsafe code[^2]
-* Hard to misuse, helping you avoid common costly cryptography mistakes
-* Many libsodium features implemented with both Classic and Rustaceous API
+* Pure Rust, with no hidden C libraries
+* Limited use of unsafe code[^2]
+* Typed Rustaceous APIs for keys, nonces, and outputs
+* Classic and Rustaceous APIs for many libsodium operations
 * Protected memory handling (`mprotect()` + `mlock()`, along with Windows
   equivalents) on stable Rust for Unix and Windows targets, enabled by default
   with the `protected` feature
@@ -56,7 +44,8 @@ For example usage, refer to the
     AArch64 where dryoc keeps the soft backend because the portable-SIMD path
     is slower there
 * [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek) (used by public/private key functions) selects its own serial or x86_64 vector backend at build time
-* [SHA2](https://github.com/RustCrypto/hashes/tree/master/sha2) (used by sealed boxes) includes SIMD implementation for AVX2
+* [SHA2](https://github.com/RustCrypto/hashes/tree/master/sha2) (used for SHA-256
+  and SHA-512 hashing and seeded box key generation) includes an AVX2 backend
 * [SHA3](https://github.com/RustCrypto/hashes/tree/master/sha3) (used by SHA-3 compatibility hashing)
 * [ChaCha20](https://github.com/RustCrypto/stream-ciphers/tree/master/chacha20) (used by streaming interface) includes SIMD implementations for NEON, AVX2, and SSE2
 
@@ -82,11 +71,6 @@ Poly1305 is a special exception on AArch64: even with `simd_backend` and
 `nightly` enabled, dryoc uses the soft Poly1305 backend because profiling shows
 the portable-SIMD implementation is slower on that architecture.
 
-_Note that eventually this project will converge on portable SIMD implementations
-for all the core algos which will work across all platforms supported by LLVM,
-rather than relying on hand-coded assembly or intrinsics, but this is a work in
-progress_.
-
 See [BENCHMARKS.md](BENCHMARKS.md) for side-by-side software and SIMD benchmark
 results.
 
@@ -101,11 +85,18 @@ and [`wincode::SchemaRead`](https://docs.rs/wincode/latest/wincode/trait.SchemaR
 for supported Rustaceous box types, including `DryocBox` and
 `DryocSecretBox`, plus AEAD boxes and envelopes from `dryocaead`.
 
+## Security
+
+dryoc has not undergone a third-party security audit. Its compatibility tests,
+Rust types, and limited use of unsafe code reduce some classes of defects, but
+do not guarantee that an application is secure. Applications must still follow
+the documented key and nonce rules, protect secret material, handle errors, and
+choose primitives appropriate for their protocol.
+
 ## Project status
 
-The following libsodium features are currently implemented, or awaiting
-implementation. This list has been reviewed against
-[libsodium 1.0.22](https://github.com/jedisct1/libsodium/releases/tag/1.0.22-RELEASE):
+The following features are implemented. The libsodium-compatible entries have
+been reviewed against [libsodium 1.0.22](https://github.com/jedisct1/libsodium/releases/tag/1.0.22-RELEASE):
 
 * [x] [Public-key cryptography](https://docs.rs/dryoc/latest/dryoc/dryocbox/index.html) (`crypto_box_*`) [libsodium link](https://doc.libsodium.org/public-key_cryptography)
 * [x] [Secret-key cryptography](https://docs.rs/dryoc/latest/dryoc/dryocsecretbox/index.html) (`crypto_secretbox_*`) [libsodium link](https://doc.libsodium.org/secret-key_cryptography)
@@ -125,8 +116,8 @@ implementation. This list has been reviewed against
 * [x] [Public-key signatures](https://docs.rs/dryoc/latest/dryoc/sign/index.html) (`crypto_sign_*`) [libsodium link](https://doc.libsodium.org/public-key_cryptography/public-key_signatures)
 * [x] [Ed25519 to Curve25519](https://docs.rs/dryoc/latest/dryoc/classic/crypto_sign_ed25519/index.html) (`crypto_sign_ed25519_*`) [libsodium link](https://doc.libsodium.org/advanced/ed25519-curve25519)
 * [x] [Signature secret-key extraction helpers](https://docs.rs/dryoc/latest/dryoc/classic/crypto_sign_ed25519/index.html) (`crypto_sign_ed25519_sk_to_seed`, `crypto_sign_ed25519_sk_to_pk`) [libsodium link](https://doc.libsodium.org/public-key_cryptography/public-key_signatures)
-* [x] [SHA-2 hashing](https://docs.rs/dryoc/latest/dryoc/classic/crypto_hash/index.html) (`crypto_hash_sha256_*`, `crypto_hash_sha512_*`) [libsodium link](https://doc.libsodium.org/hashing/sha-2)
-* [x] [SHA-3 hashing](https://docs.rs/dryoc/latest/dryoc/sha3/index.html) (`crypto_hash_sha3256_*`, `crypto_hash_sha3512_*`) [NIST FIPS 202 link](https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.202.pdf)
+* [x] [SHA-2 hashing](https://docs.rs/dryoc/latest/dryoc/classic/crypto_hash/index.html) (`crypto_hash_sha256_*`, `crypto_hash_sha512_*`) [libsodium link](https://doc.libsodium.org/advanced/sha-2_hash_function)
+* [x] [SHA-3 hashing](https://docs.rs/dryoc/latest/dryoc/sha3/index.html) (`crypto_hash_sha3256_*`, `crypto_hash_sha3512_*`; dryoc extension) [NIST FIPS 202 link](https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.202.pdf)
 * [x] [Short-input hashing](https://docs.rs/dryoc/latest/dryoc/classic/crypto_shorthash/index.html) (`crypto_shorthash`) [libsodium link](https://doc.libsodium.org/hashing/short-input_hashing)
 * [x] [Password hashing](https://docs.rs/dryoc/latest/dryoc/pwhash/index.html) (`crypto_pwhash_*`) [libsodium link](https://doc.libsodium.org/password_hashing/default_phf)
 * [x] [HKDF key derivation variants](https://docs.rs/dryoc/latest/dryoc/hkdf/index.html) (`crypto_kdf_hkdf_sha256_*`, `crypto_kdf_hkdf_sha512_*`) [libsodium link](https://doc.libsodium.org/key_derivation/hkdf)
@@ -151,7 +142,7 @@ crates:
   * [ ] [Finite field and group arithmetic](https://doc.libsodium.org/advanced/point-arithmetic) (`crypto_core_ed25519_*`, `crypto_core_ristretto255_*`; try the [curve25519-dalek](https://crates.io/crates/curve25519-dalek) crate)
   * [ ] Ed25519 and Ristretto255 scalar multiplication variants (`crypto_scalarmult_ed25519_*`, `crypto_scalarmult_ristretto255_*`)
 
-## Other NaCl-related Rust implementations worth mentioning
+## Other NaCl-related Rust implementations
 
 * [sodiumoxide](https://crates.io/crates/sodiumoxide)
 * [crypto_box](https://crates.io/crates/crypto_box)
@@ -163,10 +154,8 @@ available on Unix and Windows targets with the default `protected` feature.
 Unsupported targets do not expose the protected-memory API. These features
 require custom memory allocation, system calls, and pointer arithmetic, which
 are unsafe in Rust. Some optional SIMD code, including dependency-provided SIMD
-implementations and small internal helpers, may contain unsafe code. In
-particular, many SIMD implementations are considered "unsafe" due to their use
-of assembly or intrinsics, however without SIMD-based cryptography you may be
-exposed to timing attacks. The in-crate unsafe inventory includes fixed-size
+implementations and small internal helpers, may contain unsafe code. The
+in-crate unsafe inventory includes fixed-size
 byte views, optional wincode schema impls for Rustaceous boxes and AEAD
 envelopes, BLAKE2b parameter byte views, protected memory guarded heap buffers
 and OS protection calls, and Salsa20 SIMD unaligned in-place and

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -9,7 +9,10 @@
 //! * you have a pre-shared key between both parties
 //! * (optionally) you want to share the authentication tag publicly
 //!
-//! # Rustaceous API example, one-time interface
+//! The same HMAC key can authenticate multiple messages. Keep the key secret,
+//! and use separate keys when protocols require domain separation.
+//!
+//! # Rustaceous API example, single-part interface
 //!
 //! ```
 //! use dryoc::auth::*;
@@ -18,12 +21,11 @@
 //! // Generate a random key
 //! let key = Key::generate();
 //!
-//! // Compute the mac in one shot. Here we clone the key for the purpose of this
-//! // example, but normally you would not do this as you never want to re-use a
-//! // key.
+//! // Compute the MAC in one shot. This API takes ownership of the key, so clone
+//! // it when the same key is also needed for verification.
 //! let mac = Auth::compute_to_vec(key.clone(), b"Data to authenticate");
 //!
-//! // Verify the mac
+//! // Verify the MAC
 //! Auth::compute_and_verify(&mac, key, b"Data to authenticate").expect("verify failed");
 //! ```
 //!
@@ -36,19 +38,19 @@
 //! // Generate a random key
 //! let key = Key::generate();
 //!
-//! // Initialize the MAC, clone the key (don't do this)
+//! // Initialize the MAC
 //! let mut mac = Auth::new(key.clone());
 //! mac.update(b"Multi-part");
 //! mac.update(b"data");
 //! let mac = mac.finalize_to_vec();
 //!
-//! // Verify it's correct, clone the key (don't do this)
+//! // Verify the MAC
 //! let mut verify_mac = Auth::new(key.clone());
 //! verify_mac.update(b"Multi-part");
 //! verify_mac.update(b"data");
 //! verify_mac.verify(&mac).expect("verify failed");
 //!
-//! // Check that invalid data fails, consume the key
+//! // Check that invalid data fails
 //! let mut verify_mac = Auth::new(key);
 //! verify_mac.update(b"Multi-part");
 //! verify_mac.update(b"bad data");
@@ -75,11 +77,9 @@ pub type Mac = StackByteArray<CRYPTO_AUTH_BYTES>;
 #[cfg(any(all(feature = "protected", any(unix, windows)), all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "protected")))]
 pub mod protected {
-    //! #  Protected memory type aliases for [`Auth`]
+    //! # Protected memory type aliases for [`Auth`]
     //!
-    //! This mod provides re-exports of type aliases for protected memory usage
-    //! with [`Auth`]. These type aliases are provided for
-    //! convenience.
+    //! Protected-memory aliases for authentication keys and codes.
     //!
     //! ## Example
     //!
@@ -91,17 +91,17 @@ pub mod protected {
     //! let key = Key::generate_readonly_locked().expect("generate failed");
     //! let input =
     //!     HeapBytes::from_slice_into_readonly_locked(b"super secret input").expect("input failed");
-    //! // Compute the message authentication code, consuming the key.
+    //! // Compute the message authentication code. This takes ownership of the key.
     //! let mac: Locked<Mac> = Auth::compute(key, &input);
     //! ```
     use super::*;
     pub use crate::protected::*;
 
-    /// Heap-allocated, page-aligned secret key for the generic hash algorithm,
-    /// for use with protected memory.
+    /// Heap-allocated, page-aligned secret key for authentication with
+    /// protected memory.
     pub type Key = HeapByteArray<CRYPTO_AUTH_KEYBYTES>;
-    /// Heap-allocated, page-aligned hash output for the generic hash algorithm,
-    /// for use with protected memory.
+    /// Heap-allocated, page-aligned authentication code for use with protected
+    /// memory.
     pub type Mac = HeapByteArray<CRYPTO_AUTH_BYTES>;
 }
 
@@ -112,9 +112,10 @@ pub struct Auth {
 }
 
 impl Auth {
-    /// Single-part interface for [`Auth`]. Computes (and returns) the
-    /// message authentication code for `input` using `key`. The `key` is
-    /// consumed to prevent accidental re-use of the same key.
+    /// Computes the message authentication code for `input` using `key`.
+    ///
+    /// This function takes ownership of `key`, but HMAC keys may be reused for
+    /// multiple messages. Clone the key first when it is needed again.
     pub fn compute<
         Key: ByteArray<CRYPTO_AUTH_KEYBYTES>,
         Input: Bytes,
@@ -128,9 +129,9 @@ impl Auth {
         output
     }
 
-    /// Convience wrapper around [`Auth::compute`]. Returns the message
-    /// authentication code as a [`Vec`]. The `key` is
-    /// consumed to prevent accidental re-use of the same key.
+    /// Computes the message authentication code and returns it as a [`Vec`].
+    ///
+    /// This is a convenience wrapper around [`Auth::compute`].
     pub fn compute_to_vec<Key: ByteArray<CRYPTO_AUTH_KEYBYTES>, Input: Bytes>(
         key: Key,
         input: &Input,
@@ -138,9 +139,12 @@ impl Auth {
         Self::compute(key, input)
     }
 
-    /// Verifies the message authentication code `other_mac` matches the
-    /// expected code for `key` and `input`. The `key` is
-    /// consumed to prevent accidental re-use of the same key.
+    /// Verifies that `other_mac` authenticates `input` under `key`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `other_mac` does not match the authentication code
+    /// computed from `key` and `input`.
     pub fn compute_and_verify<
         OtherMac: ByteArray<CRYPTO_AUTH_BYTES>,
         Key: ByteArray<CRYPTO_AUTH_KEYBYTES>,
@@ -153,8 +157,10 @@ impl Auth {
         crypto_auth_verify(other_mac.as_array(), input.as_slice(), key.as_array())
     }
 
-    /// Returns a new secret-key authenticator for `key`. The `key` is
-    /// consumed to prevent accidental re-use of the same key.
+    /// Returns a new incremental authenticator for `key`.
+    ///
+    /// This function takes ownership of `key`, but HMAC keys may be reused for
+    /// multiple messages. Clone the key first when it is needed again.
     pub fn new<Key: ByteArray<CRYPTO_AUTH_KEYBYTES>>(key: Key) -> Self {
         Self {
             state: crypto_auth_init(key.as_array()),
@@ -183,6 +189,11 @@ impl Auth {
 
     /// Finalizes this authenticator, and verifies that the computed code
     /// matches `other_mac` using a constant-time comparison.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `other_mac` does not match the authentication code
+    /// computed from the data passed to [`Auth::update`].
     pub fn verify<OtherMac: ByteArray<CRYPTO_AUTH_BYTES>>(
         self,
         other_mac: &OtherMac,

--- a/src/classic/crypto_aead_xchacha20poly1305_ietf.rs
+++ b/src/classic/crypto_aead_xchacha20poly1305_ietf.rs
@@ -176,6 +176,11 @@ fn verify_mac(mac: &Mac, computed_mac: &Mac) -> Result<(), Error> {
 ///
 /// Compatible with libsodium's
 /// `crypto_aead_xchacha20poly1305_ietf_encrypt_detached`.
+///
+/// # Errors
+///
+/// Returns an error if `message` exceeds the maximum supported length or
+/// `ciphertext.len()` does not equal `message.len()`.
 pub fn crypto_aead_xchacha20poly1305_ietf_encrypt_detached(
     ciphertext: &mut [u8],
     mac: &mut Mac,
@@ -201,6 +206,10 @@ pub fn crypto_aead_xchacha20poly1305_ietf_encrypt_detached(
 
 /// In-place detached variant of
 /// [`crypto_aead_xchacha20poly1305_ietf_encrypt_detached`].
+///
+/// # Errors
+///
+/// Returns an error if `data` exceeds the maximum supported message length.
 pub fn crypto_aead_xchacha20poly1305_ietf_encrypt_detached_inplace(
     data: &mut [u8],
     mac: &mut Mac,
@@ -225,6 +234,11 @@ pub fn crypto_aead_xchacha20poly1305_ietf_encrypt_detached_inplace(
 ///
 /// Compatible with libsodium's
 /// `crypto_aead_xchacha20poly1305_ietf_decrypt_detached`.
+///
+/// # Errors
+///
+/// Returns an error if `ciphertext` is too long, `message.len()` does not equal
+/// `ciphertext.len()`, or authentication fails.
 pub fn crypto_aead_xchacha20poly1305_ietf_decrypt_detached(
     message: &mut [u8],
     ciphertext: &[u8],
@@ -250,6 +264,11 @@ pub fn crypto_aead_xchacha20poly1305_ietf_decrypt_detached(
 
 /// In-place detached variant of
 /// [`crypto_aead_xchacha20poly1305_ietf_decrypt_detached`].
+///
+/// # Errors
+///
+/// Returns an error if `data` exceeds the maximum supported message length or
+/// authentication fails.
 pub fn crypto_aead_xchacha20poly1305_ietf_decrypt_detached_inplace(
     data: &mut [u8],
     mac: &Mac,
@@ -273,6 +292,11 @@ pub fn crypto_aead_xchacha20poly1305_ietf_decrypt_detached_inplace(
 /// Encrypts `message` with `nonce`, `key`, and optional associated data.
 ///
 /// Compatible with libsodium's `crypto_aead_xchacha20poly1305_ietf_encrypt`.
+///
+/// # Errors
+///
+/// Returns an error if `message` exceeds the maximum supported length or
+/// `ciphertext` is not exactly one authentication tag longer than `message`.
 pub fn crypto_aead_xchacha20poly1305_ietf_encrypt(
     ciphertext: &mut [u8],
     message: &[u8],
@@ -302,6 +326,11 @@ pub fn crypto_aead_xchacha20poly1305_ietf_encrypt(
 /// Decrypts `ciphertext` with `nonce`, `key`, and optional associated data.
 ///
 /// Compatible with libsodium's `crypto_aead_xchacha20poly1305_ietf_decrypt`.
+///
+/// # Errors
+///
+/// Returns an error if `ciphertext` is shorter than an authentication tag,
+/// `message` has the wrong length, or authentication fails.
 pub fn crypto_aead_xchacha20poly1305_ietf_decrypt(
     message: &mut [u8],
     ciphertext: &[u8],
@@ -328,6 +357,11 @@ pub fn crypto_aead_xchacha20poly1305_ietf_decrypt(
 ///
 /// The last [`CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES`] bytes are reserved
 /// for the tag and are ignored as plaintext input.
+///
+/// # Errors
+///
+/// Returns an error if `data` is shorter than an authentication tag or its
+/// plaintext portion exceeds the maximum supported message length.
 pub fn crypto_aead_xchacha20poly1305_ietf_encrypt_inplace(
     data: &mut [u8],
     associated_data: Option<&[u8]>,
@@ -350,6 +384,11 @@ pub fn crypto_aead_xchacha20poly1305_ietf_encrypt_inplace(
 ///
 /// After success, the first `data.len() -
 /// CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES` bytes contain the plaintext.
+///
+/// # Errors
+///
+/// Returns an error if `data` is shorter than an authentication tag or
+/// authentication fails.
 pub fn crypto_aead_xchacha20poly1305_ietf_decrypt_inplace(
     data: &mut [u8],
     associated_data: Option<&[u8]>,

--- a/src/classic/crypto_auth.rs
+++ b/src/classic/crypto_auth.rs
@@ -67,6 +67,10 @@ pub fn crypto_auth(mac: &mut Mac, message: &[u8], key: &Key) {
 /// Returns `Ok(())` if the message authentication code is valid.
 ///
 /// Equivalent to libsodium's `crypto_auth_verify`.
+///
+/// # Errors
+///
+/// Returns an error if `mac` is not valid for `input` under `key`.
 pub fn crypto_auth_verify(mac: &Mac, input: &[u8], key: &Key) -> Result<(), Error> {
     crypto_auth_hmacsha512256_verify(mac, input, key)
 }

--- a/src/classic/crypto_auth_hmacsha256.rs
+++ b/src/classic/crypto_auth_hmacsha256.rs
@@ -60,6 +60,10 @@ pub fn crypto_auth_hmacsha256(mac: &mut Mac, message: &[u8], key: &Key) {
 }
 
 /// Verifies that `mac` is the correct authenticator for `message` using `key`.
+///
+/// # Errors
+///
+/// Returns an error if `mac` is not valid for `input` under `key`.
 pub fn crypto_auth_hmacsha256_verify(mac: &Mac, input: &[u8], key: &Key) -> Result<(), Error> {
     hmac_verify::<Sha256, CRYPTO_AUTH_HMACSHA256_KEYBYTES, 64, CRYPTO_AUTH_HMACSHA256_BYTES>(
         mac, input, key,

--- a/src/classic/crypto_auth_hmacsha512.rs
+++ b/src/classic/crypto_auth_hmacsha512.rs
@@ -63,6 +63,10 @@ pub fn crypto_auth_hmacsha512(mac: &mut Mac, message: &[u8], key: &Key) {
 }
 
 /// Verifies that `mac` is the correct authenticator for `message` using `key`.
+///
+/// # Errors
+///
+/// Returns an error if `mac` is not valid for `input` under `key`.
 pub fn crypto_auth_hmacsha512_verify(mac: &Mac, input: &[u8], key: &Key) -> Result<(), Error> {
     hmac_verify::<Sha512, CRYPTO_AUTH_HMACSHA512_KEYBYTES, 128, CRYPTO_AUTH_HMACSHA512_BYTES>(
         mac, input, key,

--- a/src/classic/crypto_auth_hmacsha512256.rs
+++ b/src/classic/crypto_auth_hmacsha512256.rs
@@ -70,6 +70,10 @@ pub fn crypto_auth_hmacsha512256(mac: &mut Mac, message: &[u8], key: &Key) {
 }
 
 /// Verifies that `mac` is the correct authenticator for `message` using `key`.
+///
+/// # Errors
+///
+/// Returns an error if `mac` is not valid for `input` under `key`.
 pub fn crypto_auth_hmacsha512256_verify(mac: &Mac, input: &[u8], key: &Key) -> Result<(), Error> {
     let mut computed_mac = Mac::default();
     crypto_auth_hmacsha512256(&mut computed_mac, input, key);

--- a/src/classic/crypto_box.rs
+++ b/src/classic/crypto_box.rs
@@ -94,7 +94,10 @@ pub fn crypto_box_seed_keypair(seed: &[u8]) -> (PublicKey, SecretKey) {
 /// Resulting shared secret can be used with the precalculation interface.
 ///
 /// Compatible with libsodium's `crypto_box_beforenm`.
-/// Returns an error when `public_key` is an unacceptable low-order key.
+///
+/// # Errors
+///
+/// Returns an error if `public_key` is an unacceptable low-order key.
 pub fn crypto_box_beforenm(public_key: &PublicKey, secret_key: &SecretKey) -> Result<Key, Error> {
     crypto_box_curve25519xsalsa20poly1305_beforenm(public_key, secret_key)
 }
@@ -103,6 +106,10 @@ pub fn crypto_box_beforenm(public_key: &PublicKey, secret_key: &SecretKey) -> Re
 /// [`crypto_box_easy`].
 ///
 /// Compatible with libsodium's `crypto_box_detached_afternm`.
+///
+/// # Errors
+///
+/// Returns an error if `ciphertext` is shorter than `message`.
 pub fn crypto_box_detached_afternm(
     ciphertext: &mut [u8],
     mac: &mut Mac,
@@ -126,6 +133,11 @@ pub fn crypto_box_detached_afternm_inplace(
 /// Detached variant of [`crypto_box_easy`].
 ///
 /// Compatible with libsodium's `crypto_box_detached`.
+///
+/// # Errors
+///
+/// Returns an error if `recipient_public_key` is unacceptable or `ciphertext`
+/// is shorter than `message`.
 pub fn crypto_box_detached(
     ciphertext: &mut [u8],
     mac: &mut Mac,
@@ -143,6 +155,10 @@ pub fn crypto_box_detached(
 }
 
 /// In-place variant of [`crypto_box_detached`].
+///
+/// # Errors
+///
+/// Returns an error if `recipient_public_key` is unacceptable.
 pub fn crypto_box_detached_inplace(
     message: &mut [u8],
     mac: &mut Mac,
@@ -167,6 +183,11 @@ pub fn crypto_box_detached_inplace(
 /// [`CRYPTO_BOX_MACBYTES`] bytes, for the message tag.
 ///
 /// Compatible with libsodium's `crypto_box_easy`.
+///
+/// # Errors
+///
+/// Returns an error if `message` is too long, `ciphertext` has the wrong
+/// length, or `recipient_public_key` is unacceptable.
 pub fn crypto_box_easy(
     ciphertext: &mut [u8],
     message: &[u8],
@@ -217,6 +238,16 @@ pub(crate) fn crypto_box_seal_nonce(nonce: &mut Nonce, epk: &PublicKey, rpk: &Se
 /// tag and ephemeral public key.
 ///
 /// Compatible with libsodium's `crypto_box_seal`.
+///
+/// # Errors
+///
+/// Returns an error if `ciphertext` has the wrong length, `message` is too
+/// long, or `recipient_public_key` is unacceptable.
+///
+/// # Panics
+///
+/// Panics if the operating system's random number generator fails while
+/// creating the ephemeral keypair.
 pub fn crypto_box_seal(
     ciphertext: &mut [u8],
     message: &[u8],
@@ -255,7 +286,7 @@ pub fn crypto_box_seal(
 ///
 /// Encrypts `message` with recipient's public key `recipient_public_key` and
 /// sender's secret key `sender_secret_key` using `nonce` in-place in `data`,
-/// without allocated additional memory for the message.
+/// without allocating additional memory for the message.
 ///
 /// The caller of this function is responsible for allocating `data` such that
 /// there's enough capacity for the message plus the additional
@@ -264,6 +295,11 @@ pub fn crypto_box_seal(
 /// For this reason, the last [`CRYPTO_BOX_MACBYTES`] bytes from the input
 /// is ignored. The length of `data` should be the length of your message plus
 /// [`CRYPTO_BOX_MACBYTES`] bytes.
+///
+/// # Errors
+///
+/// Returns an error if `data` is too short or too long, or
+/// `recipient_public_key` is unacceptable.
 pub fn crypto_box_easy_inplace(
     data: &mut [u8],
     nonce: &Nonce,
@@ -297,6 +333,11 @@ pub fn crypto_box_easy_inplace(
 /// Precalculation variant of [`crypto_box_open_easy`].
 ///
 /// Compatible with libsodium's `crypto_box_open_detached_afternm`.
+///
+/// # Errors
+///
+/// Returns an error if `message` is shorter than `ciphertext` or authentication
+/// fails.
 pub fn crypto_box_open_detached_afternm(
     message: &mut [u8],
     mac: &Mac,
@@ -308,6 +349,10 @@ pub fn crypto_box_open_detached_afternm(
 }
 
 /// In-place variant of [`crypto_box_open_detached_afternm`].
+///
+/// # Errors
+///
+/// Returns an error if authentication fails.
 pub fn crypto_box_open_detached_afternm_inplace(
     data: &mut [u8],
     mac: &Mac,
@@ -320,6 +365,11 @@ pub fn crypto_box_open_detached_afternm_inplace(
 /// Detached variant of [`crypto_box_open_easy`].
 ///
 /// Compatible with libsodium's `crypto_box_open_detached`.
+///
+/// # Errors
+///
+/// Returns an error if `recipient_public_key` is unacceptable, `message` is
+/// shorter than `ciphertext`, or authentication fails.
 pub fn crypto_box_open_detached(
     message: &mut [u8],
     mac: &Mac,
@@ -339,6 +389,11 @@ pub fn crypto_box_open_detached(
 }
 
 /// In-place variant of [`crypto_box_open_detached`].
+///
+/// # Errors
+///
+/// Returns an error if `recipient_public_key` is unacceptable or
+/// authentication fails.
 pub fn crypto_box_open_detached_inplace(
     data: &mut [u8],
     mac: &Mac,
@@ -360,6 +415,12 @@ pub fn crypto_box_open_detached_inplace(
 /// sender's public key `sender_public_key` using `nonce`.
 ///
 /// Compatible with libsodium's `crypto_box_open_easy`.
+///
+/// # Errors
+///
+/// Returns an error if `ciphertext` is shorter than an authentication tag,
+/// `message` has the wrong length, `sender_public_key` is unacceptable, or
+/// authentication fails.
 pub fn crypto_box_open_easy(
     message: &mut [u8],
     ciphertext: &[u8],
@@ -398,11 +459,16 @@ pub fn crypto_box_open_easy(
 ///
 /// Decrypts a sealed box from `ciphertext` with recipient's secret key
 /// `recipient_secret_key`, placing the result into `message`. The nonce and
-/// public are derived from `ciphertext`. `message` length should be equal to
+/// public key are derived from `ciphertext`. `message` length should equal
 /// the length of `ciphertext` minus [`CRYPTO_BOX_SEALBYTES`] bytes for the
 /// message tag and ephemeral public key.
 ///
 /// Compatible with libsodium's `crypto_box_seal_open`.
+///
+/// # Errors
+///
+/// Returns an error if `ciphertext` is too short, `message` has the wrong
+/// length, the ephemeral public key is unacceptable, or authentication fails.
 pub fn crypto_box_seal_open(
     message: &mut [u8],
     ciphertext: &[u8],
@@ -442,7 +508,7 @@ pub fn crypto_box_seal_open(
 ///
 /// Decrypts `ciphertext` with recipient's secret key `recipient_secret_key` and
 /// sender's public key `sender_public_key` with `nonce` in-place in `data`,
-/// without allocated additional memory for the message.
+/// without allocating additional memory for the message.
 ///
 /// The caller of this function is responsible for allocating `data` such that
 /// there's enough capacity for the message plus the additional
@@ -450,6 +516,11 @@ pub fn crypto_box_seal_open(
 ///
 /// After opening the box, the last [`CRYPTO_BOX_MACBYTES`] bytes can be
 /// discarded or ignored at the caller's preference.
+///
+/// # Errors
+///
+/// Returns an error if `data` is shorter than an authentication tag,
+/// `sender_public_key` is unacceptable, or authentication fails.
 pub fn crypto_box_open_easy_inplace(
     data: &mut [u8],
     nonce: &Nonce,

--- a/src/classic/crypto_core.rs
+++ b/src/classic/crypto_core.rs
@@ -44,7 +44,9 @@ pub fn crypto_scalarmult_base(
 ///
 /// Compatible with libsodium's `crypto_scalarmult`.
 ///
-/// Returns an error when `p` is an unacceptable low-order public key that
+/// # Errors
+///
+/// Returns an error if `p` is an unacceptable low-order public key that
 /// produces an all-zero shared secret.
 pub fn crypto_scalarmult(
     q: &mut [u8; CRYPTO_SCALARMULT_BYTES],
@@ -85,8 +87,6 @@ pub fn crypto_core_hchacha20(
 ) {
     let input = input.as_array();
     let key = key.as_array();
-    assert_eq!(input.len(), 16);
-    assert_eq!(key.len(), 32);
     let (mut x0, mut x1, mut x2, mut x3) =
         constants.unwrap_or((0x61707865, 0x3320646e, 0x79622d32, 0x6b206574));
     let (

--- a/src/classic/crypto_generichash.rs
+++ b/src/classic/crypto_generichash.rs
@@ -1,11 +1,12 @@
 //! # Generic hashing
 //!
-//! Implements libsodium's generic hashing functions, based on blake2b. Can also
-//! be used as an HMAC function, if a key is provided.
+//! Implements libsodium's generic hashing functions with BLAKE2b. With a secret
+//! key, BLAKE2b acts as a message authentication code (MAC) or pseudorandom
+//! function (PRF); it is not HMAC.
 //!
 //! For details, refer to [libsodium docs](https://libsodium.gitbook.io/doc/hashing/generic_hashing).
 //!
-//! # Classic API example, one-time interface
+//! # Classic API example, single-part interface
 //!
 //! ```
 //! use base64::Engine as _;
@@ -15,7 +16,7 @@
 //!
 //! // Use the default hash length
 //! let mut output = [0u8; CRYPTO_GENERICHASH_BYTES];
-//! // Compute the hash using the one-time interface
+//! // Compute the hash using the single-part interface
 //! crypto_generichash(&mut output, b"a string of bytes", None).ok();
 //!
 //! assert_eq!(
@@ -59,7 +60,11 @@ Computes a hash from `input` and `key`, copying the result into `output`.
 | `output` | [`CRYPTO_GENERICHASH_BYTES`](crate::constants::CRYPTO_GENERICHASH_BYTES) | [`CRYPTO_GENERICHASH_BYTES_MIN`](crate::constants::CRYPTO_GENERICHASH_BYTES_MIN) | [ `CRYPTO_GENERICHASH_BYTES_MAX`](crate::constants::CRYPTO_GENERICHASH_BYTES_MAX) |
 | `key` | [`CRYPTO_GENERICHASH_KEYBYTES`] | [`CRYPTO_GENERICHASH_KEYBYTES_MIN`](crate::constants::CRYPTO_GENERICHASH_KEYBYTES_MIN) | [ `CRYPTO_GENERICHASH_KEYBYTES_MAX`](crate::constants::CRYPTO_GENERICHASH_KEYBYTES_MAX) |
 
-Compatible with libsodium's `crypto_generichash_final`
+Compatible with libsodium's `crypto_generichash`.
+
+# Errors
+
+Returns an error if the output or key length is outside the supported range.
 */
 #[inline]
 pub fn crypto_generichash(
@@ -83,7 +88,11 @@ Initializes the state for the generic hash function using `outlen` for the expec
 | `outlen` | [`CRYPTO_GENERICHASH_BYTES`](crate::constants::CRYPTO_GENERICHASH_BYTES) | [`CRYPTO_GENERICHASH_BYTES_MIN`](crate::constants::CRYPTO_GENERICHASH_BYTES_MIN) | [`CRYPTO_GENERICHASH_BYTES_MAX`](crate::constants::CRYPTO_GENERICHASH_BYTES_MAX) |
 | `key` | [`CRYPTO_GENERICHASH_KEYBYTES`] | [`CRYPTO_GENERICHASH_KEYBYTES_MIN`](crate::constants::CRYPTO_GENERICHASH_KEYBYTES_MIN) | [ `CRYPTO_GENERICHASH_KEYBYTES_MAX`](crate::constants::CRYPTO_GENERICHASH_KEYBYTES_MAX) |
 
-Equivalent to libsodium's `crypto_generichash_final`
+Equivalent to libsodium's `crypto_generichash_init`.
+
+# Errors
+
+Returns an error if `outlen` or the key length is outside the supported range.
 */
 #[inline]
 pub fn crypto_generichash_init(
@@ -107,6 +116,11 @@ pub fn crypto_generichash_update(state: &mut GenericHashState, input: &[u8]) {
 /// [`crypto_generichash_init`].
 ///
 /// Equivalent to libsodium's `crypto_generichash_final`
+///
+/// # Errors
+///
+/// Returns an error if `output` is empty or longer than the maximum supported
+/// digest.
 #[inline]
 pub fn crypto_generichash_final(state: GenericHashState, output: &mut [u8]) -> Result<(), Error> {
     crypto_generichash_blake2b_final(state.state, output)

--- a/src/classic/crypto_kdf.rs
+++ b/src/classic/crypto_kdf.rs
@@ -126,6 +126,10 @@ pub fn crypto_kdf_hkdf_sha512_keygen() -> HkdfSha512Key {
 /// Derives `subkey` from `main_key`, using `context` and `subkey_id` such that
 /// `subkey` will always be the same for the given set of inputs, but `main_key`
 /// cannot be derived from `subkey`.
+///
+/// # Errors
+///
+/// Returns an error if `subkey` is outside the supported length range.
 pub fn crypto_kdf_derive_from_key(
     subkey: &mut [u8],
     subkey_id: u64,
@@ -196,6 +200,11 @@ pub fn crypto_kdf_hkdf_sha256_extract_final(state: HkdfSha256State, prk: &mut Hk
 }
 
 /// Expands an HKDF-SHA-256 pseudorandom key into output keying material.
+///
+/// # Errors
+///
+/// Returns an error if `output` is outside the supported HKDF-SHA-256 output
+/// length range.
 pub fn crypto_kdf_hkdf_sha256_expand(
     output: &mut [u8],
     context: &[u8],
@@ -235,6 +244,11 @@ pub fn crypto_kdf_hkdf_sha512_extract_final(state: HkdfSha512State, prk: &mut Hk
 }
 
 /// Expands an HKDF-SHA-512 pseudorandom key into output keying material.
+///
+/// # Errors
+///
+/// Returns an error if `output` is outside the supported HKDF-SHA-512 output
+/// length range.
 pub fn crypto_kdf_hkdf_sha512_expand(
     output: &mut [u8],
     context: &[u8],

--- a/src/classic/crypto_kx.rs
+++ b/src/classic/crypto_kx.rs
@@ -58,6 +58,11 @@ pub type SessionKey = [u8; CRYPTO_KX_SESSIONKEYBYTES];
 /// upon success. Uses the Blake2b function to derive a secret from `seed`.
 ///
 /// Compatible with libsodium's `crypto_kx_seed_keypair`.
+///
+/// # Errors
+///
+/// Returns an error if the underlying generic hash rejects the output. The
+/// fixed output length used here is valid.
 pub fn crypto_kx_seed_keypair(
     seed: &[u8; CRYPTO_KX_SEEDBYTES],
 ) -> Result<(PublicKey, SecretKey), Error> {
@@ -108,6 +113,11 @@ fn crypto_kx(
 /// `client_sk`, and `server_pk`. Returns unit `()` upon success.
 ///
 /// Compatible with libsodium's `crypto_kx_client_session_keys`.
+///
+/// # Errors
+///
+/// Returns an error if `server_pk` is an unacceptable low-order public key or
+/// session-key derivation fails.
 pub fn crypto_kx_client_session_keys(
     rx: &mut SessionKey,
     tx: &mut SessionKey,
@@ -122,10 +132,15 @@ pub fn crypto_kx_client_session_keys(
     crypto_kx(rx, tx, client_pk, server_pk, shared_secret)
 }
 
-/// Computes server session keys for `rx` and `tx`, using `client_pk`,
-/// `client_sk`, and `server_pk`. Returns unit `()` upon success.
+/// Computes server session keys for `rx` and `tx`, using `server_pk`,
+/// `server_sk`, and `client_pk`. Returns unit `()` upon success.
 ///
 /// Compatible with libsodium's `crypto_kx_server_session_keys`.
+///
+/// # Errors
+///
+/// Returns an error if `client_pk` is an unacceptable low-order public key or
+/// session-key derivation fails.
 pub fn crypto_kx_server_session_keys(
     rx: &mut SessionKey,
     tx: &mut SessionKey,

--- a/src/classic/crypto_onetimeauth.rs
+++ b/src/classic/crypto_onetimeauth.rs
@@ -111,6 +111,10 @@ pub fn crypto_onetimeauth(mac: &mut Mac, message: &[u8], key: &Key) {
 /// Returns `Ok(())` if the message authentication code is valid.
 ///
 /// Equivalent to libsodium's `crypto_onetimeauth_verify`.
+///
+/// # Errors
+///
+/// Returns an error if `mac` is not valid for `input` under `key`.
 pub fn crypto_onetimeauth_verify(mac: &Mac, input: &[u8], key: &Key) -> Result<(), Error> {
     crypto_onetimeauth_poly1305_verify(mac, input, key)
 }

--- a/src/classic/crypto_pwhash.rs
+++ b/src/classic/crypto_pwhash.rs
@@ -112,6 +112,11 @@ impl From<PasswordHashAlgorithm> for argon2::Argon2Type {
 ///   [`CRYPTO_PWHASH_MEMLIMIT_SENSITIVE`] for sensitive operations
 ///
 /// Compatible with libsodium's `crypto_pwhash`.
+///
+/// # Errors
+///
+/// Returns an error if the cost parameters, salt length, or output length are
+/// invalid, or if Argon2 cannot hash the password with the requested settings.
 pub fn crypto_pwhash(
     output: &mut [u8],
     password: &[u8],
@@ -256,6 +261,15 @@ pub(crate) fn convert_costs(opslimit: u64, memlimit: usize) -> (u32, u32) {
 /// password using [`crypto_pwhash_str_verify`].
 ///
 /// Compatible with libsodium's `crypto_pwhash_str`.
+///
+/// # Errors
+///
+/// Returns an error if `opslimit` or `memlimit` is outside the supported range,
+/// or if Argon2 cannot hash the password.
+///
+/// # Panics
+///
+/// Panics if the operating system's random number generator fails.
 #[cfg(any(feature = "base64", all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "base64")))]
 pub fn crypto_pwhash_str(password: &[u8], opslimit: u64, memlimit: usize) -> Result<String, Error> {
@@ -353,7 +367,7 @@ impl Pwhash {
         // Check if version is supported
         if pwhash.version.is_none() || pwhash.version.unwrap() != ARGON2_VERSION_NUMBER {
             Err(dryoc_error!("unsupported password hash"))
-        // Verify correct value for parallism
+        // Verify the parallelism value
         } else if pwhash.parallelism.is_none() || pwhash.parallelism.unwrap() != 1 {
             Err(dryoc_error!("parallelism missing or invalid"))
         // Check for missing fields
@@ -377,26 +391,49 @@ impl Pwhash {
 /// password was encoded using `crypto_pwhash_str`.
 ///
 /// Compatible with libsodium's `crypto_pwhash_str_verify`.
+///
+/// # Errors
+///
+/// Returns an error if `hashed_password` is malformed, uses unsupported
+/// parameters, or does not match `password`.
 #[cfg(any(feature = "base64", all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "base64")))]
 pub fn crypto_pwhash_str_verify(hashed_password: &str, password: &[u8]) -> Result<(), Error> {
     let mut hash = [0u8; STR_HASHBYTES];
 
     let pwhash = Pwhash::parse_encoded_pwhash(hashed_password)?;
+    let t_cost = pwhash
+        .t_cost
+        .ok_or_else(|| dryoc_error!("password hash computation cost missing"))?;
+    let m_cost = pwhash
+        .m_cost
+        .ok_or_else(|| dryoc_error!("password hash memory cost missing"))?;
+    let parallelism = pwhash
+        .parallelism
+        .ok_or_else(|| dryoc_error!("password hash parallelism missing"))?;
+    let salt = pwhash
+        .salt
+        .ok_or_else(|| dryoc_error!("password salt missing"))?;
+    let algorithm = pwhash
+        .type_
+        .ok_or_else(|| dryoc_error!("password hash algorithm missing"))?;
+    let expected_hash = pwhash
+        .pwhash
+        .ok_or_else(|| dryoc_error!("password hash missing"))?;
 
     argon2_hash(
-        pwhash.t_cost.unwrap(),
-        pwhash.m_cost.unwrap(),
-        pwhash.parallelism.unwrap(),
+        t_cost,
+        m_cost,
+        parallelism,
         password,
-        pwhash.salt.unwrap().as_ref(),
+        &salt,
         None,
         None,
         &mut hash,
-        pwhash.type_.unwrap().into(),
+        algorithm.into(),
     )?;
 
-    if hash.ct_eq(pwhash.pwhash.unwrap().as_ref()).unwrap_u8() == 1 {
+    if hash.ct_eq(expected_hash.as_slice()).unwrap_u8() == 1 {
         Ok(())
     } else {
         Err(dryoc_error!("password hashes do not match"))
@@ -408,6 +445,11 @@ pub fn crypto_pwhash_str_verify(hashed_password: &str, password: &[u8]) -> Resul
 /// parameters are mismatched (requiring a rehash).
 ///
 /// Compatible with libsodium's `crypto_pwhash_str_needs_rehash`.
+///
+/// # Errors
+///
+/// Returns an error if `hashed_password` is malformed or uses unsupported
+/// parameters.
 #[cfg(any(feature = "base64", all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "base64")))]
 pub fn crypto_pwhash_str_needs_rehash(
@@ -416,10 +458,16 @@ pub fn crypto_pwhash_str_needs_rehash(
     memlimit: usize,
 ) -> Result<bool, Error> {
     let pwhash = Pwhash::parse_encoded_pwhash(hashed_password)?;
+    let parsed_t_cost = pwhash
+        .t_cost
+        .ok_or_else(|| dryoc_error!("password hash computation cost missing"))?;
+    let parsed_m_cost = pwhash
+        .m_cost
+        .ok_or_else(|| dryoc_error!("password hash memory cost missing"))?;
 
     let (t_cost, m_cost) = convert_costs(opslimit, memlimit);
 
-    if t_cost != pwhash.t_cost.unwrap() || m_cost != pwhash.m_cost.unwrap() {
+    if t_cost != parsed_t_cost || m_cost != parsed_m_cost {
         Ok(true)
     } else {
         Ok(false)

--- a/src/classic/crypto_secretbox.rs
+++ b/src/classic/crypto_secretbox.rs
@@ -60,6 +60,9 @@ pub fn crypto_secretbox_keygen() -> Key {
 /// Detached version of [`crypto_secretbox_easy`].
 ///
 /// Compatible with libsodium's `crypto_secretbox_detached`.
+///
+/// # Errors
+///
 /// Returns an error if `ciphertext` is shorter than `message`.
 pub fn crypto_secretbox_detached(
     ciphertext: &mut [u8],
@@ -83,7 +86,11 @@ pub fn crypto_secretbox_detached(
 /// Detached version of [`crypto_secretbox_open_easy`].
 ///
 /// Compatible with libsodium's `crypto_secretbox_open_detached`.
-/// Returns an error if `message` is shorter than `ciphertext`.
+///
+/// # Errors
+///
+/// Returns an error if `message` is shorter than `ciphertext` or
+/// authentication fails.
 pub fn crypto_secretbox_open_detached(
     message: &mut [u8],
     mac: &Mac,
@@ -106,6 +113,11 @@ pub fn crypto_secretbox_open_detached(
 /// Encrypts `message` with `nonce` and `key`.
 ///
 /// Compatible with libsodium's `crypto_secretbox_easy`.
+///
+/// # Errors
+///
+/// Returns an error if the required ciphertext length overflows `usize` or
+/// `ciphertext` is not exactly one authentication tag longer than `message`.
 pub fn crypto_secretbox_easy(
     ciphertext: &mut [u8],
     message: &[u8],
@@ -141,6 +153,11 @@ pub fn crypto_secretbox_easy(
 /// Decrypts `ciphertext` with `nonce` and `key`.
 ///
 /// Compatible with libsodium's `crypto_secretbox_open_easy`.
+///
+/// # Errors
+///
+/// Returns an error if `ciphertext` is shorter than an authentication tag,
+/// `message` has the wrong length, or authentication fails.
 pub fn crypto_secretbox_open_easy(
     message: &mut [u8],
     ciphertext: &[u8],
@@ -167,7 +184,11 @@ pub fn crypto_secretbox_open_easy(
 }
 
 /// Encrypts `message` with `nonce` and `key` in-place, without allocating
-/// additional memory for the ciphertext.
+/// additional memory for ciphertext.
+///
+/// # Errors
+///
+/// Returns an error if `data` is shorter than an authentication tag.
 pub fn crypto_secretbox_easy_inplace(
     data: &mut [u8],
     nonce: &Nonce,
@@ -191,6 +212,11 @@ pub fn crypto_secretbox_easy_inplace(
 
 /// Decrypts `ciphertext` with `nonce` and `key` in-place, without allocating
 /// additional memory for the message.
+///
+/// # Errors
+///
+/// Returns an error if `ciphertext` is shorter than an authentication tag or
+/// authentication fails.
 pub fn crypto_secretbox_open_easy_inplace(
     ciphertext: &mut [u8],
     nonce: &Nonce,

--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -251,6 +251,11 @@ pub fn crypto_secretstream_xchacha20poly1305_rekey(state: &mut State) {
 /// was left in place, and is reflected in this implementation for compatibility
 /// purposes. Refer to [commit
 /// 290197ba3ee72245fdab5e971c8de43a82b19874](https://github.com/jedisct1/libsodium/commit/290197ba3ee72245fdab5e971c8de43a82b19874#diff-dbd9b6026ac3fd057df0ddf00e4d671af16e5df99b4cc7d08b73b61f193d10f5)
+///
+/// # Errors
+///
+/// Returns an error if `message` exceeds the maximum supported length or
+/// `ciphertext` is not exactly one authentication tag longer than `message`.
 pub fn crypto_secretstream_xchacha20poly1305_push(
     state: &mut State,
     ciphertext: &mut [u8],
@@ -356,6 +361,11 @@ pub fn crypto_secretstream_xchacha20poly1305_push(
 /// was left in place, and is reflected in this implementation for compatibility
 /// purposes. Refer to [commit
 /// 290197ba3ee72245fdab5e971c8de43a82b19874](https://github.com/jedisct1/libsodium/commit/290197ba3ee72245fdab5e971c8de43a82b19874#diff-dbd9b6026ac3fd057df0ddf00e4d671af16e5df99b4cc7d08b73b61f193d10f5)
+///
+/// # Errors
+///
+/// Returns an error if `ciphertext` is too short or too long, `message` lacks
+/// space for the plaintext, or authentication fails.
 pub fn crypto_secretstream_xchacha20poly1305_pull(
     state: &mut State,
     message: &mut [u8],

--- a/src/classic/crypto_sign.rs
+++ b/src/classic/crypto_sign.rs
@@ -90,8 +90,13 @@ pub fn crypto_sign_seed_keypair(seed: &[u8; 32]) -> (PublicKey, SecretKey) {
 /// `signed_message` should be the length of the message plus
 /// [`CRYPTO_SIGN_BYTES`].
 ///
-/// This function is compatible with libsodium`s `crypto_sign`, however the
+/// This function is compatible with libsodium's `crypto_sign`; the
 /// `ED25519_NONDETERMINISTIC` feature is not supported.
+///
+/// # Errors
+///
+/// Returns an error if `signed_message` is not exactly one signature longer
+/// than `message`, or signing fails.
 pub fn crypto_sign(
     signed_message: &mut [u8],
     message: &[u8],
@@ -112,8 +117,13 @@ pub fn crypto_sign(
 /// `message`. The length of `message` should be the length of the signed
 /// message minus [`CRYPTO_SIGN_BYTES`].
 ///
-/// This function is compatible with libsodium`s `crypto_sign_open`, however the
+/// This function is compatible with libsodium's `crypto_sign_open`; the
 /// `ED25519_NONDETERMINISTIC` feature is not supported.
+///
+/// # Errors
+///
+/// Returns an error if `signed_message` is too short, `message` has the wrong
+/// length, or the signature or public key is invalid.
 pub fn crypto_sign_open(
     message: &mut [u8],
     signed_message: &[u8],
@@ -139,8 +149,14 @@ pub fn crypto_sign_open(
 /// Signs `message`, placing the signature into `signature` upon success.
 /// Detached variant of [`crypto_sign_open`].
 ///
-/// This function is compatible with libsodium`s `crypto_sign_detached`, however
-/// the `ED25519_NONDETERMINISTIC` feature is not supported.
+/// This function is compatible with libsodium's `crypto_sign_detached`; the
+/// `ED25519_NONDETERMINISTIC` feature is not supported.
+///
+/// # Errors
+///
+/// The fixed-size signature and secret-key types satisfy the current
+/// implementation's requirements, so this function does not return an error
+/// in normal use. The [`Result`] is retained for API compatibility.
 pub fn crypto_sign_detached(
     signature: &mut Signature,
     message: &[u8],
@@ -152,8 +168,13 @@ pub fn crypto_sign_detached(
 /// Verifies that `signature` is a valid signature for `message` using the given
 /// `public_key`.
 ///
-/// This function is compatible with libsodium`s `crypto_sign_verify_detached`,
-/// however the `ED25519_NONDETERMINISTIC` feature is not supported.
+/// This function is compatible with libsodium's `crypto_sign_verify_detached`;
+/// the `ED25519_NONDETERMINISTIC` feature is not supported.
+///
+/// # Errors
+///
+/// Returns an error if `signature` or `public_key` is malformed, or if the
+/// signature does not authenticate `message`.
 pub fn crypto_sign_verify_detached(
     signature: &Signature,
     message: &[u8],
@@ -181,6 +202,12 @@ pub fn crypto_sign_update(state: &mut SignerState, message: &[u8]) {
 
 /// Finalizes the incremental signature for `state`, using `secret_key`, copying
 /// the result into `signature` upon success, and consuming the state.
+///
+/// # Errors
+///
+/// The fixed-size signature and secret-key types satisfy the current
+/// implementation's requirements, so this function does not return an error
+/// in normal use. The [`Result`] is retained for API compatibility.
 pub fn crypto_sign_final_create(
     state: SignerState,
     signature: &mut Signature,
@@ -191,6 +218,11 @@ pub fn crypto_sign_final_create(
 
 /// Verifies the computed signature for `state` and `public_key` matches
 /// `signature`, consuming the state.
+///
+/// # Errors
+///
+/// Returns an error if `signature` or `public_key` is malformed, or if the
+/// signature does not match the accumulated message.
 pub fn crypto_sign_final_verify(
     state: SignerState,
     signature: &Signature,

--- a/src/classic/crypto_sign_ed25519.rs
+++ b/src/classic/crypto_sign_ed25519.rs
@@ -125,7 +125,12 @@ fn clamp_hash(
 /// Converts an Ed25519 public key `ed25519_public_key` into an X25519 public
 /// key, placing the result into `x25519_public_key` upon success.
 ///
-/// Compatible with libsodium's `crypto_sign_ed25519_pk_to_curve25519`
+/// Compatible with libsodium's `crypto_sign_ed25519_pk_to_curve25519`.
+///
+/// # Errors
+///
+/// Returns an error if `ed25519_public_key` does not encode a valid
+/// Edwards25519 point.
 pub fn crypto_sign_ed25519_pk_to_curve25519(
     x25519_public_key: &mut [u8; CRYPTO_SCALARMULT_CURVE25519_BYTES],
     ed25519_public_key: &PublicKey,

--- a/src/dryocaead.rs
+++ b/src/dryocaead.rs
@@ -9,6 +9,10 @@
 //! dryoc to generate a random XChaCha nonce and store it with the ciphertext as
 //! `nonce || ciphertext || tag`.
 //!
+//! XChaCha20 nonces are public, but a nonce must never repeat with the same
+//! key. [`DryocAeadEnvelope`] generates and stores a nonce for each message;
+//! callers using [`DryocAead`] must manage this uniqueness themselves.
+//!
 //! If the `serde` feature is enabled, [`serde::Deserialize`] and
 //! [`serde::Serialize`] are implemented for [`AeadBox`] and [`AeadEnvelope`].
 //! If the `wincode` feature is enabled,
@@ -313,6 +317,11 @@ impl<
 > AeadBox<XChaCha20Poly1305Ietf, Mac, Data>
 {
     /// Encrypts a message using `key`, `nonce`, and optional associated data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message exceeds the construction's maximum
+    /// length or the output storage does not resize to the message length.
     pub fn encrypt<
         Message: Bytes + ?Sized,
         Nonce: ByteArray<CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES>,
@@ -353,6 +362,15 @@ impl<
 {
     /// Encrypts a message with a generated nonce and stores that nonce with the
     /// ciphertext and tag.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message exceeds the construction's maximum
+    /// length or the output storage does not resize to the message length.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the operating system's random number generator fails.
     pub fn seal<
         Message: Bytes + ?Sized,
         SecretKey: ByteArray<CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES>,
@@ -388,6 +406,11 @@ impl<
 > AeadBox<XChaCha20Poly1305Ietf, Mac, Data>
 {
     /// Initializes an [`AeadBox`] from `ciphertext || tag`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `bytes` is shorter than one authentication tag or
+    /// the tag cannot be converted to `Mac`.
     pub fn from_bytes(bytes: &'a [u8]) -> Result<Self, Error> {
         if bytes.len() < CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES {
             Err(dryoc_error!(format!(
@@ -419,6 +442,12 @@ impl<
 > AeadEnvelope<XChaCha20Poly1305Ietf, Nonce, Mac, Data>
 {
     /// Initializes an [`AeadEnvelope`] from `nonce || ciphertext || tag`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `bytes` is shorter than one nonce plus one
+    /// authentication tag, or if either field cannot be converted to its
+    /// target type.
     pub fn from_bytes(bytes: &'a [u8]) -> Result<Self, Error> {
         let minimum_len = CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES
             + CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES;
@@ -488,6 +517,13 @@ impl<Mac: ByteArray<CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES>, Data: Bytes>
     AeadBox<XChaCha20Poly1305Ietf, Mac, Data>
 {
     /// Decrypts this box using `key`, `nonce`, and optional associated data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the ciphertext exceeds the construction's maximum
+    /// length, the output storage has the wrong length, or authentication
+    /// fails. Authentication fails when the key, nonce, associated data,
+    /// ciphertext, or tag does not match the value used during encryption.
     pub fn decrypt<
         Output: ResizableBytes + NewBytes,
         Nonce: ByteArray<CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES>,
@@ -576,6 +612,14 @@ impl<
 > AeadEnvelope<XChaCha20Poly1305Ietf, Nonce, Mac, Data>
 {
     /// Decrypts this envelope using `key` and optional associated data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the ciphertext exceeds the construction's maximum
+    /// length, the output storage has the wrong length, or authentication
+    /// fails. Authentication fails when the key, associated data, stored
+    /// nonce, ciphertext, or tag does not match the value used during
+    /// encryption.
     pub fn open<
         Output: ResizableBytes + NewBytes,
         SecretKey: ByteArray<CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES>,
@@ -604,6 +648,11 @@ impl<
 
 impl DryocAead<Mac, Vec<u8>> {
     /// Encrypts a message and returns a [`VecBox`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message exceeds the construction's maximum
+    /// length.
     pub fn encrypt_to_vecbox<
         Message: Bytes + ?Sized,
         SecretKey: ByteArray<CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES>,
@@ -617,6 +666,12 @@ impl DryocAead<Mac, Vec<u8>> {
     }
 
     /// Decrypts this box and returns the plaintext as a [`Vec`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the ciphertext exceeds the construction's maximum
+    /// length or authentication fails because the key, nonce, associated data,
+    /// ciphertext, or tag does not match.
     pub fn decrypt_to_vec<SecretKey: ByteArray<CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES>>(
         &self,
         associated_data: Option<&[u8]>,
@@ -640,6 +695,15 @@ impl DryocAead<Mac, Vec<u8>> {
 
 impl DryocAeadEnvelope<Nonce, Mac, Vec<u8>> {
     /// Encrypts a message with a generated nonce and returns a [`VecEnvelope`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message exceeds the construction's maximum
+    /// length.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the operating system's random number generator fails.
     pub fn seal_to_vec<
         Message: Bytes + ?Sized,
         SecretKey: ByteArray<CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES>,
@@ -652,6 +716,12 @@ impl DryocAeadEnvelope<Nonce, Mac, Vec<u8>> {
     }
 
     /// Decrypts this envelope and returns the plaintext as a [`Vec`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the ciphertext exceeds the construction's maximum
+    /// length or authentication fails because the key, associated data, stored
+    /// nonce, ciphertext, or tag does not match.
     pub fn open_to_vec<SecretKey: ByteArray<CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES>>(
         &self,
         associated_data: Option<&[u8]>,

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -11,17 +11,22 @@
 //!   secret
 //! * avoid secret sharing between parties
 //!
-//! The public keys of the sender and recipient must be known ahead of time, but
-//! the sender's secret key can be used once and discarded, if desired. The
-//! [`DryocBox::seal`] and corresponding [`DryocBox::unseal`] functions do just
-//! this, by generating an ephemeral secret key, deriving a nonce, and including
-//! the sender's public key in the box.
+//! [`DryocBox::encrypt`] authenticates the sender, so the sender and recipient
+//! public keys must be known ahead of time. [`DryocBox::seal`] instead sends an
+//! anonymous sealed box: it generates a one-time ephemeral keypair and stores
+//! the ephemeral public key with the ciphertext. Sealed boxes authenticate the
+//! ciphertext for the recipient, but not the sender's identity.
 //!
-//! If the `serde` feature is enabled, the [`serde::Deserialize`] and
-//! [`serde::Serialize`] traits will be implemented for [`DryocBox`]. If the
-//! `wincode` feature is enabled, the
-//! [`wincode::SchemaRead`] and [`wincode::SchemaWrite`] traits will be
-//! implemented.
+//! Box nonces are public, but a nonce must never repeat for the same pair of
+//! keypairs. The two parties share one nonce space across both communication
+//! directions unless they use direction-specific keys. Callers of
+//! [`DryocBox::encrypt`] must coordinate this uniqueness. [`DryocBox::seal`]
+//! derives its nonce from a newly generated ephemeral public key and the
+//! recipient public key.
+//!
+//! With the `serde` feature, [`serde::Deserialize`] and [`serde::Serialize`]
+//! are implemented for [`DryocBox`]. With `wincode`, [`wincode::SchemaRead`]
+//! and [`wincode::SchemaWrite`] are implemented.
 //!
 //! ## Rustaceous API example
 //!
@@ -123,10 +128,9 @@ pub type KeyPair = crate::keypair::KeyPair<PublicKey, SecretKey>;
 #[cfg(any(all(feature = "protected", any(unix, windows)), all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "protected")))]
 pub mod protected {
-    //! #  Protected memory type aliases for [`DryocBox`]
+    //! # Protected memory type aliases for [`DryocBox`]
     //!
-    //! This mod provides re-exports of type aliases for protected memory usage
-    //! with [`DryocBox`]. These type aliases are provided for convenience.
+    //! Type aliases for using [`DryocBox`] with protected memory.
     //!
     //! ## Example
     //!
@@ -276,7 +280,12 @@ impl<
 > DryocBox<EphemeralPublicKey, Mac, Data>
 {
     /// Encrypts a message using `sender_secret_key` for `recipient_public_key`,
-    /// and returns a new [DryocBox] with ciphertext and tag.
+    /// and returns a new [`DryocBox`] with ciphertext and tag.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `recipient_public_key` is an unacceptable low-order
+    /// key or the output storage does not resize to the message length.
     pub fn encrypt<
         Message: Bytes + ?Sized,
         Nonce: ByteArray<CRYPTO_BOX_NONCEBYTES>,
@@ -310,8 +319,13 @@ impl<
         Ok(dryocbox)
     }
 
-    /// Encrypts a message using `precalc_secret_key`,
-    /// and returns a new [DryocBox] with ciphertext and tag.
+    /// Encrypts a message using `precalc_secret_key`, and returns a new
+    /// [`DryocBox`] with ciphertext and tag.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output storage does not resize to the message
+    /// length.
     pub fn precalc_encrypt<
         PrecalcSecretKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize,
         Message: Bytes + ?Sized,
@@ -350,8 +364,18 @@ impl<
 > DryocBox<EphemeralPublicKey, Mac, Data>
 {
     /// Encrypts a message for `recipient_public_key`, using an ephemeral secret
-    /// key and nonce. Returns a new [DryocBox] with ciphertext, tag, and
+    /// key and nonce. Returns a new [`DryocBox`] with ciphertext, tag, and
     /// ephemeral public key.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `recipient_public_key` is an unacceptable low-order
+    /// key or the output storage does not resize to the message length.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the operating system's random number generator fails while
+    /// creating the ephemeral keypair.
     pub fn seal<
         Message: Bytes + ?Sized,
         RecipientPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
@@ -402,6 +426,11 @@ impl<
     /// Initializes a [`DryocBox`] from a slice. Expects the first
     /// [`CRYPTO_BOX_MACBYTES`] bytes to contain the message authentication tag,
     /// with the remaining bytes containing the encrypted message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `bytes` is shorter than one authentication tag or
+    /// the tag cannot be converted to `Mac`.
     pub fn from_bytes(bytes: &'a [u8]) -> Result<Self, Error> {
         if bytes.len() < CRYPTO_BOX_MACBYTES {
             Err(dryoc_error!(format!(
@@ -423,6 +452,12 @@ impl<
     /// [`CRYPTO_BOX_PUBLICKEYBYTES`] bytes to contain the ephemeral public key,
     /// the next [`CRYPTO_BOX_MACBYTES`] bytes to be the message authentication
     /// tag, with the remaining bytes containing the encrypted message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `bytes` is shorter than one ephemeral public key
+    /// plus one authentication tag, or if either field cannot be converted to
+    /// its target type.
     pub fn from_sealed_bytes(bytes: &'a [u8]) -> Result<Self, Error> {
         if bytes.len() < CRYPTO_BOX_SEALBYTES {
             Err(dryoc_error!(format!(
@@ -474,6 +509,12 @@ impl<
 
     /// Decrypts this box using `nonce`, `recipient_secret_key`, and
     /// `sender_public_key`, returning the decrypted message upon success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `sender_public_key` is an unacceptable low-order
+    /// key, the output storage has the wrong length, or authentication fails.
+    /// Authentication fails for a wrong key, nonce, tag, or ciphertext.
     pub fn decrypt<
         Nonce: ByteArray<CRYPTO_BOX_NONCEBYTES>,
         SenderPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
@@ -502,8 +543,14 @@ impl<
         Ok(message)
     }
 
-    /// Decrypts this box using `nonce`, `precalc_secret_key`, and
-    /// `sender_public_key`, returning the decrypted message upon success.
+    /// Decrypts this box using `nonce` and `precalc_secret_key`, returning the
+    /// decrypted message upon success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output storage has the wrong length or
+    /// authentication fails because the precomputed key, nonce, tag, or
+    /// ciphertext does not match.
     pub fn precalc_decrypt<
         PrecalcSecretKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize,
         Nonce: ByteArray<CRYPTO_BOX_NONCEBYTES>,
@@ -529,8 +576,14 @@ impl<
         Ok(message)
     }
 
-    /// Decrypts this sealed box using `recipient_secret_key`, and
-    /// returning the decrypted message upon success.
+    /// Decrypts this sealed box using `recipient_keypair`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the box has no ephemeral public key, that key is an
+    /// unacceptable low-order key, the output storage has the wrong length, or
+    /// authentication fails. Authentication fails for the wrong recipient key
+    /// pair or modified box data.
     pub fn unseal<
         RecipientPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,
         RecipientSecretKey: ByteArray<CRYPTO_BOX_SECRETKEYBYTES> + Zeroize,
@@ -595,7 +648,12 @@ impl<
 
 impl DryocBox<PublicKey, Mac, Vec<u8>> {
     /// Encrypts a message using `sender_secret_key` for `recipient_public_key`,
-    /// and returns a new [DryocBox] with ciphertext and tag.
+    /// and returns a new [`DryocBox`] with ciphertext and tag.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `recipient_public_key` is an unacceptable low-order
+    /// key.
     pub fn encrypt_to_vecbox<
         Message: Bytes + ?Sized,
         SecretKey: ByteArray<CRYPTO_BOX_SECRETKEYBYTES>,
@@ -608,8 +666,12 @@ impl DryocBox<PublicKey, Mac, Vec<u8>> {
         Self::encrypt(message, nonce, recipient_public_key, sender_secret_key)
     }
 
-    /// Encrypts a message using `precalc_secret_key`,
-    /// and returns a new [DryocBox] with ciphertext and tag.
+    /// Encrypts a message using `precalc_secret_key`, and returns a new
+    /// [`DryocBox`] with ciphertext and tag.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output storage cannot hold the ciphertext.
     pub fn precalc_encrypt_to_vecbox<
         Message: Bytes + ?Sized,
         PrecalcSecretKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize,
@@ -622,8 +684,18 @@ impl DryocBox<PublicKey, Mac, Vec<u8>> {
     }
 
     /// Encrypts a message for `recipient_public_key`, using an ephemeral secret
-    /// key and nonce, and returns a new [DryocBox] with the ciphertext,
+    /// key and nonce, and returns a new [`DryocBox`] with the ciphertext,
     /// ephemeral public key, and tag.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `recipient_public_key` is an unacceptable low-order
+    /// key.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the operating system's random number generator fails while
+    /// creating the ephemeral keypair.
     pub fn seal_to_vecbox<Message: Bytes + ?Sized>(
         message: &Message,
         recipient_public_key: &PublicKey,
@@ -633,6 +705,12 @@ impl DryocBox<PublicKey, Mac, Vec<u8>> {
 
     /// Decrypts this box using `nonce`, `recipient_secret_key` and
     /// `sender_public_key`, returning the decrypted message upon success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `sender_public_key` is an unacceptable low-order
+    /// key or authentication fails because a key, nonce, tag, or ciphertext is
+    /// wrong.
     pub fn decrypt_to_vec<SecretKey: ByteArray<CRYPTO_BOX_SECRETKEYBYTES>>(
         &self,
         nonce: &Nonce,
@@ -645,6 +723,11 @@ impl DryocBox<PublicKey, Mac, Vec<u8>> {
     /// Decrypts this box using `nonce` and
     /// `precalc_secret_key`, returning the decrypted message upon
     /// success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if authentication fails because the precomputed key,
+    /// nonce, tag, or ciphertext does not match.
     pub fn precalc_decrypt_to_vec<
         PrecalcSecretKey: ByteArray<CRYPTO_BOX_BEFORENMBYTES> + Zeroize,
     >(
@@ -655,8 +738,13 @@ impl DryocBox<PublicKey, Mac, Vec<u8>> {
         self.precalc_decrypt(nonce, precalc_secret_key)
     }
 
-    /// Decrypts this sealed box using `recipient_secret_key`, returning the
-    /// decrypted message upon success.
+    /// Decrypts this sealed box using `recipient_keypair`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the box has no ephemeral public key, that key is an
+    /// unacceptable low-order key, or authentication fails because the
+    /// recipient key pair or box data is wrong.
     pub fn unseal_to_vec<
         RecipientPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,
         RecipientSecretKey: ByteArray<CRYPTO_BOX_SECRETKEYBYTES> + Zeroize,
@@ -675,9 +763,8 @@ impl<
     Data: Bytes + ResizableBytes + From<&'a [u8]> + Zeroize,
 > DryocBox<EphemeralPublicKey, Mac, Data>
 {
-    /// Returns a new box with `data` and `tag`, with data copied from `input`
-    /// and `tag` consumed. The ephemeral public key is assumed not to be
-    /// present.
+    /// Returns a new box with ciphertext copied from `input` and the supplied
+    /// `tag`. The box has no ephemeral public key.
     pub fn new_with_data_and_mac(tag: Mac, input: &'a [u8]) -> Self {
         Self {
             ephemeral_pk: None,
@@ -686,8 +773,8 @@ impl<
         }
     }
 
-    /// Returns a new sealed box with `ephemeral_pk`, `data` and `tag`, where
-    /// data copied from `input` and `ephemeral_pk` & `tag` are consumed.
+    /// Returns a new sealed box with ciphertext copied from `input` and the
+    /// supplied `ephemeral_pk` and `tag`.
     pub fn new_with_epk_data_and_mac(
         ephemeral_pk: EphemeralPublicKey,
         tag: Mac,

--- a/src/dryocsecretbox.rs
+++ b/src/dryocsecretbox.rs
@@ -14,11 +14,17 @@
 //!   * a passphrase with a strong password hashing function, such as
 //!     [`crypto_pwhash`](crate::classic::crypto_pwhash)
 //!
-//! If the `serde` feature is enabled, the [`serde::Deserialize`] and
-//! [`serde::Serialize`] traits will be implemented for [`DryocSecretBox`]. If
-//! the `wincode` feature is enabled, the
-//! [`wincode::SchemaRead`] and [`wincode::SchemaWrite`] traits will be
-//! implemented.
+//! Every holder of the shared key can create valid messages. In a group,
+//! secretbox authenticates membership in the group, not which member sent a
+//! message.
+//!
+//! Secretbox nonces are public, but a nonce must never repeat with the same
+//! key. Store each nonce with its ciphertext or use a counter that cannot
+//! repeat for that key.
+//!
+//! With the `serde` feature, [`serde::Deserialize`] and [`serde::Serialize`]
+//! are implemented for [`DryocSecretBox`]. With `wincode`,
+//! [`wincode::SchemaRead`] and [`wincode::SchemaWrite`] are implemented.
 //!
 //! ## Rustaceous API example
 //!
@@ -28,7 +34,7 @@
 //! // Generate a random secret key and nonce
 //! let secret_key = Key::generate();
 //! let nonce = Nonce::generate();
-//! let message = b"Why hello there, fren";
+//! let message = b"A message to encrypt";
 //!
 //! // Encrypt `message`, into a Vec-based box
 //! let dryocsecretbox = DryocSecretBox::encrypt_to_vecbox(message, &nonce, &secret_key);
@@ -77,11 +83,9 @@ pub type Mac = StackByteArray<CRYPTO_SECRETBOX_MACBYTES>;
 #[cfg(any(all(feature = "protected", any(unix, windows)), all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "protected")))]
 pub mod protected {
-    //! #  Protected memory type aliases for [`DryocSecretBox`]
+    //! # Protected memory type aliases for [`DryocSecretBox`]
     //!
-    //! This mod provides re-exports of type aliases for protected memory usage
-    //! with [`DryocSecretBox`]. These type aliases are provided for
-    //! convenience.
+    //! Type aliases for using [`DryocSecretBox`] with protected memory.
     //!
     //! ## Example
     //!
@@ -197,8 +201,13 @@ impl<
     Data: NewBytes + ResizableBytes + Zeroize,
 > DryocSecretBox<Mac, Data>
 {
-    /// Encrypts a message using `secret_key`, and returns a new
-    /// [DryocSecretBox] with ciphertext and tag
+    /// Encrypts a message using `secret_key` and returns a new
+    /// [`DryocSecretBox`] with ciphertext and tag.
+    ///
+    /// # Panics
+    ///
+    /// Panics if allocation or resizing panics, or if a custom `Data`
+    /// implementation leaves its buffer shorter than the message.
     pub fn encrypt<
         Message: Bytes + ?Sized,
         Nonce: ByteArray<CRYPTO_SECRETBOX_NONCEBYTES>,
@@ -239,6 +248,11 @@ impl<
     /// [`CRYPTO_SECRETBOX_MACBYTES`] bytes to contain the message
     /// authentication tag, with the remaining bytes containing the
     /// encrypted message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `bytes` is shorter than one authentication tag or
+    /// the tag cannot be converted to `Mac`.
     pub fn from_bytes(bytes: &'a [u8]) -> Result<Self, Error> {
         if bytes.len() < CRYPTO_SECRETBOX_MACBYTES {
             Err(dryoc_error!(format!(
@@ -259,12 +273,12 @@ impl<
 impl<Mac: ByteArray<CRYPTO_SECRETBOX_MACBYTES> + Zeroize, Data: Bytes + Zeroize>
     DryocSecretBox<Mac, Data>
 {
-    /// Returns a new box with `tag` and `data`, consuming both
+    /// Returns a new box with `tag` and `data`, consuming both.
     pub fn from_parts(tag: Mac, data: Data) -> Self {
         Self { tag, data }
     }
 
-    /// Copies `self` into a new [`Vec`]
+    /// Copies `self` into a new [`Vec`].
     pub fn to_vec(&self) -> Vec<u8> {
         self.to_bytes()
     }
@@ -278,8 +292,13 @@ impl<Mac: ByteArray<CRYPTO_SECRETBOX_MACBYTES> + Zeroize, Data: Bytes + Zeroize>
 impl<Mac: ByteArray<CRYPTO_SECRETBOX_MACBYTES> + Zeroize, Data: Bytes + Zeroize>
     DryocSecretBox<Mac, Data>
 {
-    /// Decrypts `ciphertext` using `secret_key`, returning a new
-    /// [DryocSecretBox] with decrypted message
+    /// Decrypts this box using `secret_key`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output storage is shorter than the ciphertext
+    /// or authentication fails. Authentication fails when the key, nonce, tag,
+    /// or ciphertext does not match the value used during encryption.
     pub fn decrypt<
         Output: ResizableBytes + NewBytes,
         Nonce: ByteArray<CRYPTO_SECRETBOX_NONCEBYTES>,
@@ -317,8 +336,8 @@ impl<Mac: ByteArray<CRYPTO_SECRETBOX_MACBYTES> + Zeroize, Data: Bytes + Zeroize>
 }
 
 impl DryocSecretBox<Mac, Vec<u8>> {
-    /// Encrypts a message using `secret_key`, and returns a new
-    /// [DryocSecretBox] with ciphertext and tag
+    /// Encrypts a message using `secret_key` and returns a new
+    /// [`DryocSecretBox`] with ciphertext and tag.
     pub fn encrypt_to_vecbox<
         Message: Bytes + ?Sized,
         Nonce: ByteArray<CRYPTO_SECRETBOX_NONCEBYTES>,
@@ -331,8 +350,12 @@ impl DryocSecretBox<Mac, Vec<u8>> {
         Self::encrypt(message, nonce, secret_key)
     }
 
-    /// Decrypts `ciphertext` using `secret_key`, returning a new
-    /// [DryocSecretBox] with decrypted message
+    /// Decrypts this box using `secret_key` and returns the plaintext.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if authentication fails because the key, nonce, tag,
+    /// or ciphertext does not match.
     pub fn decrypt_to_vec<
         Nonce: ByteArray<CRYPTO_SECRETBOX_NONCEBYTES>,
         SecretKey: ByteArray<CRYPTO_SECRETBOX_KEYBYTES>,
@@ -344,7 +367,7 @@ impl DryocSecretBox<Mac, Vec<u8>> {
         self.decrypt(nonce, secret_key)
     }
 
-    /// Consumes this box and returns it as a Vec
+    /// Consumes this box and returns `tag || ciphertext` as a [`Vec`].
     pub fn into_vec(mut self) -> Vec<u8> {
         self.data
             .resize(self.data.len() + CRYPTO_SECRETBOX_MACBYTES, 0);
@@ -375,8 +398,8 @@ impl<
     Data: Bytes + ResizableBytes + From<&'a [u8]> + Zeroize,
 > DryocSecretBox<Mac, Data>
 {
-    /// Returns a new box with `data` and `tag`, with data copied from `input`
-    /// and `tag` consumed.
+    /// Returns a new box with ciphertext copied from `input` and the supplied
+    /// `tag`.
     pub fn with_data_and_mac(tag: Mac, input: &'a [u8]) -> Self {
         Self {
             tag,

--- a/src/dryocstream.rs
+++ b/src/dryocstream.rs
@@ -4,9 +4,9 @@
 //! encryption, also known as a _secretstream_. This implementation uses the
 //! XChaCha20 stream cipher, and Poly1305 for message authentication.
 //!
-//! You should use a [`DryocStream`] when you want to:
+//! Use [`DryocStream`] to:
 //!
-//! * read and write messages from/to a file or network socket
+//! * encrypt a sequence of messages written to a file or network socket
 //! * exchange messages between two parties
 //! * send messages in a particular sequence, and authenticate the order of
 //!   messages
@@ -17,6 +17,10 @@
 //!   * [`Kx`](crate::kx)
 //!   * a passphrase with a strong password hashing function, such as
 //!     [`crypto_pwhash`](crate::classic::crypto_pwhash)
+//!
+//! [`DryocStream::init_push`] generates a public header for each stream. Send
+//! that header to the pull side and do not reuse the same key/header pair for a
+//! separate stream, because doing so repeats the stream's initial state.
 //!
 //! # Rustaceous API example
 //!
@@ -107,10 +111,9 @@ pub type Header = StackByteArray<CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_HEADERBYT
 #[cfg(any(all(feature = "protected", any(unix, windows)), all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "protected")))]
 pub mod protected {
-    //! #  Protected memory type aliases for [`DryocStream`]
+    //! # Protected memory type aliases for [`DryocStream`]
     //!
-    //! This mod provides re-exports of type aliases for protected memory usage
-    //! with [`DryocStream`]. These type aliases are provided for convenience.
+    //! Type aliases for using [`DryocStream`] with protected memory.
     //!
     //! ## Example
     //! ```
@@ -142,7 +145,7 @@ pub mod protected {
     //!     .push(&message3, None, Tag::FINAL)
     //!     .expect("Encrypt failed");
     //!
-    //! // Initialized the pull stream
+    //! // Initialize the pull stream
     //! let mut pull_stream = DryocStream::init_pull(&key, &header);
     //!
     //! // Decrypt the set of messages, putting everything into locked memory
@@ -187,11 +190,9 @@ impl<Mode> Drop for DryocStream<Mode> {
 
 impl<M> DryocStream<M> {
     /// Manually rekeys the stream. Both the push and pull sides of the stream
-    /// need to manually rekey if you use this function (i.e., it's not handled
-    /// by the library).
+    /// must rekey at the same position.
     ///
-    /// Automatic rekeying will occur normally, and you generally shouldn't need
-    /// to manually rekey.
+    /// Automatic rekeying normally makes manual rekeying unnecessary.
     ///
     /// Refer to the [libsodium
     /// docs](https://libsodium.gitbook.io/doc/secret-key_cryptography/secretstream#rekeying)
@@ -227,6 +228,12 @@ impl DryocStream<Push> {
 
     /// Encrypts `message` for this stream with `associated_data` and `tag`,
     /// returning the ciphertext.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message exceeds the stream's maximum message
+    /// length or the output storage does not resize to exactly the required
+    /// ciphertext length.
     pub fn push<Input: Bytes, Output: NewBytes + ResizableBytes>(
         &mut self,
         message: &Input,
@@ -251,6 +258,11 @@ impl DryocStream<Push> {
 
     /// Encrypts `message` for this stream with `associated_data` and `tag`,
     /// returning the ciphertext.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message exceeds the stream's maximum message
+    /// length.
     pub fn push_to_vec<Input: Bytes>(
         &mut self,
         message: &Input,
@@ -284,6 +296,18 @@ impl DryocStream<Pull> {
 
     /// Decrypts `ciphertext` for this stream with `associated_data`, returning
     /// the decrypted message and tag.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the ciphertext is too short or too long, the output
+    /// storage cannot hold the plaintext, or authentication fails.
+    /// Authentication fails for a wrong key or header, mismatched associated
+    /// data, modified ciphertext, or messages processed out of order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an authenticated ciphertext contains tag bits that are not
+    /// represented by [`Tag`]. Rustaceous push streams only emit valid tags.
     pub fn pull<Input: Bytes, Output: MutBytes + Default + ResizableBytes>(
         &mut self,
         ciphertext: &Input,
@@ -317,6 +341,17 @@ impl DryocStream<Pull> {
 
     /// Decrypts `ciphertext` for this stream with `associated_data`, returning
     /// the decrypted message and tag into a [`Vec`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the ciphertext is too short or too long, or
+    /// authentication fails because the key, header, associated data, stream
+    /// position, or ciphertext does not match.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an authenticated ciphertext contains tag bits that are not
+    /// represented by [`Tag`]. Rustaceous push streams only emit valid tags.
     pub fn pull_to_vec<Input: Bytes>(
         &mut self,
         ciphertext: &Input,

--- a/src/generichash.rs
+++ b/src/generichash.rs
@@ -1,17 +1,18 @@
 //! # Generic hashing
 //!
-//! [`GenericHash`] implements libsodium's generic hashing, based on the Blake2b
-//! algorithm. Can also be used as an HMAC function, if a key is provided.
+//! [`GenericHash`] implements libsodium's generic hashing with BLAKE2b. Without
+//! a key, it produces a general-purpose cryptographic hash. With a secret key,
+//! it acts as a message authentication code (MAC) or pseudorandom function
+//! (PRF). Keyed BLAKE2b is not HMAC.
 //!
-//! # Rustaceous API example, one-time interface
+//! # Rustaceous API example, single-part interface
 //!
 //! ```
 //! use base64::Engine as _;
 //! use base64::engine::general_purpose;
 //! use dryoc::generichash::{GenericHash, Key};
 //!
-//! // NOTE: The type for `key` param must be specified, the compiler cannot infer it when
-//! // we pass `None`.
+//! // The key type must be specified because `None` does not identify it.
 //! let hash =
 //!     GenericHash::hash_with_defaults_to_vec::<_, Key>(b"hello", None).expect("hash failed");
 //!
@@ -28,7 +29,7 @@
 //! use base64::engine::general_purpose;
 //! use dryoc::generichash::{GenericHash, Key};
 //!
-//! // The compiler cannot infer the `Key` type, so we pass it below.
+//! // The key type must be specified because `None` does not identify it.
 //! let mut hasher = GenericHash::new_with_defaults::<Key>(None).expect("new failed");
 //! hasher.update(b"hello");
 //! let hash = hasher.finalize_to_vec().expect("finalize failed");
@@ -55,11 +56,9 @@ pub type Key = StackByteArray<CRYPTO_GENERICHASH_KEYBYTES>;
 #[cfg(any(all(feature = "protected", any(unix, windows)), all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "protected")))]
 pub mod protected {
-    //! #  Protected memory type aliases for [`GenericHash`]
+    //! # Protected memory type aliases for [`GenericHash`]
     //!
-    //! This mod provides re-exports of type aliases for protected memory usage
-    //! with [`GenericHash`]. These type aliases are provided for
-    //! convenience.
+    //! Protected-memory aliases for generic-hash keys and outputs.
     //!
     //! ## Example
     //!
@@ -91,7 +90,12 @@ pub struct GenericHash<const KEY_LENGTH: usize, const OUTPUT_LENGTH: usize> {
 }
 
 impl<const KEY_LENGTH: usize, const OUTPUT_LENGTH: usize> GenericHash<KEY_LENGTH, OUTPUT_LENGTH> {
-    /// Returns a new hasher instance, with `key`.
+    /// Returns a new incremental hasher with an optional secret `key`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `OUTPUT_LENGTH` or the length of `key` is outside
+    /// the range supported by libsodium's generic hash function.
     pub fn new<Key: ByteArray<KEY_LENGTH>>(key: Option<&Key>) -> Result<Self, Error> {
         Ok(Self {
             state: crypto_generichash_init(key.map(|k| k.as_slice()), OUTPUT_LENGTH)?,
@@ -104,6 +108,11 @@ impl<const KEY_LENGTH: usize, const OUTPUT_LENGTH: usize> GenericHash<KEY_LENGTH
     }
 
     /// Computes and returns the final hash value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying BLAKE2b finalization rejects the
+    /// output. Initialization normally guarantees a valid output length.
     pub fn finalize<Output: NewByteArray<OUTPUT_LENGTH>>(self) -> Result<Output, Error> {
         let mut output = Output::new_byte_array();
 
@@ -114,13 +123,24 @@ impl<const KEY_LENGTH: usize, const OUTPUT_LENGTH: usize> GenericHash<KEY_LENGTH
 
     /// Computes and returns the final hash value as a [`Vec`]. Provided for
     /// convenience.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying BLAKE2b finalization rejects the
+    /// output. Initialization normally guarantees a valid output length.
     pub fn finalize_to_vec(self) -> Result<Vec<u8>, Error> {
         self.finalize()
     }
 
-    /// Onet-time interface for the generic hash function. Computes the hash for
-    /// `input` with optional `key`. The output length is determined by the type
-    /// signature of `Output`.
+    /// Computes the hash of `input` with an optional secret `key`.
+    ///
+    /// The output length is determined by `Output`. Providing a key selects
+    /// keyed BLAKE2b, which can be used as a MAC or PRF.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `OUTPUT_LENGTH` or the length of `key` is outside
+    /// the range supported by libsodium's generic hash function.
     ///
     /// # Example
     ///
@@ -155,6 +175,10 @@ impl<const KEY_LENGTH: usize, const OUTPUT_LENGTH: usize> GenericHash<KEY_LENGTH
     }
 
     /// Convenience wrapper for [`GenericHash::hash`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error under the same conditions as [`GenericHash::hash`].
     pub fn hash_to_vec<Input: Bytes, Key: ByteArray<KEY_LENGTH>>(
         input: &Input,
         key: Option<&Key>,
@@ -166,6 +190,12 @@ impl<const KEY_LENGTH: usize, const OUTPUT_LENGTH: usize> GenericHash<KEY_LENGTH
 impl GenericHash<CRYPTO_GENERICHASH_KEYBYTES, CRYPTO_GENERICHASH_BYTES> {
     /// Returns an instance of [`GenericHash`] with the default output and key
     /// length parameters.
+    ///
+    /// # Errors
+    ///
+    /// The default lengths are valid, so this method does not return an error
+    /// for valid [`ByteArray`] implementations. Its return type matches the
+    /// generic initialization interface.
     pub fn new_with_defaults<Key: ByteArray<CRYPTO_GENERICHASH_KEYBYTES>>(
         key: Option<&Key>,
     ) -> Result<Self, Error> {
@@ -176,6 +206,12 @@ impl GenericHash<CRYPTO_GENERICHASH_KEYBYTES, CRYPTO_GENERICHASH_BYTES> {
 
     /// Hashes `input` using `key`, with the default length parameters. Provided
     /// for convenience.
+    ///
+    /// # Errors
+    ///
+    /// The default lengths are valid, so this method does not return an error
+    /// for valid [`ByteArray`] implementations. Its return type matches the
+    /// generic hashing interface.
     pub fn hash_with_defaults<
         Input: Bytes + ?Sized,
         Key: ByteArray<CRYPTO_GENERICHASH_KEYBYTES>,
@@ -189,6 +225,12 @@ impl GenericHash<CRYPTO_GENERICHASH_KEYBYTES, CRYPTO_GENERICHASH_BYTES> {
 
     /// Hashes `input` using `key`, with the default length parameters,
     /// returning a [`Vec`]. Provided for convenience.
+    ///
+    /// # Errors
+    ///
+    /// The default lengths are valid, so this method does not return an error
+    /// for valid [`ByteArray`] implementations. Its return type matches the
+    /// generic hashing interface.
     pub fn hash_with_defaults_to_vec<
         Input: Bytes + ?Sized,
         Key: ByteArray<CRYPTO_GENERICHASH_KEYBYTES>,

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -156,9 +156,19 @@ pub trait HkdfVariant<const PRK_LENGTH: usize> {
     /// Creates a PRK from input keying material and optional salt.
     fn extract(prk: &mut [u8; PRK_LENGTH], salt: Option<&[u8]>, ikm: &[u8]);
     /// Expands a PRK into output keying material.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `output.len()` is outside the range supported by
+    /// this variant.
     fn expand(output: &mut [u8], context: &[u8], prk: &[u8; PRK_LENGTH]) -> Result<(), Error>;
 
     /// Validates an output length before allocating output storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `output_len` is smaller than
+    /// [`Self::OUTPUT_BYTES_MIN`] or larger than [`Self::OUTPUT_BYTES_MAX`].
     fn validate_output_len(output_len: usize) -> Result<(), Error> {
         if output_len < Self::OUTPUT_BYTES_MIN || output_len > Self::OUTPUT_BYTES_MAX {
             Err(dryoc_error!(format!(
@@ -264,6 +274,11 @@ where
     }
 
     /// One-shot HKDF extract-and-expand into a fixed-size output type.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `OUTPUT_LENGTH` is outside the range supported by
+    /// the selected HKDF variant.
     pub fn extract_and_expand<
         const OUTPUT_LENGTH: usize,
         Salt: Bytes + ?Sized,
@@ -279,6 +294,11 @@ where
     }
 
     /// One-shot HKDF extract-and-expand into a [`Vec`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `output_len` is outside the range supported by the
+    /// selected HKDF variant.
     pub fn extract_and_expand_to_vec<
         Salt: Bytes + ?Sized,
         Ikm: Bytes + ?Sized,
@@ -293,6 +313,11 @@ where
     }
 
     /// One-shot HKDF extract-and-expand into a runtime-sized byte container.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `output_len` is outside the range supported by the
+    /// selected HKDF variant.
     pub fn extract_and_expand_to_bytes<
         Salt: Bytes + ?Sized,
         Ikm: Bytes + ?Sized,
@@ -327,6 +352,11 @@ where
     }
 
     /// Expands this PRK into a fixed-size output type.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `OUTPUT_LENGTH` is outside the range supported by
+    /// the selected HKDF variant.
     pub fn expand<const OUTPUT_LENGTH: usize, Context: Bytes + ?Sized, Output>(
         &self,
         context: &Context,
@@ -345,6 +375,11 @@ where
     }
 
     /// Expands this PRK into a [`Vec`] of `output_len` bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `output_len` is outside the range supported by the
+    /// selected HKDF variant.
     pub fn expand_to_vec<Context: Bytes + ?Sized>(
         &self,
         output_len: usize,
@@ -354,6 +389,11 @@ where
     }
 
     /// Expands this PRK into a runtime-sized byte container.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `output_len` is outside the range supported by the
+    /// selected HKDF variant.
     pub fn expand_to_bytes<Context: Bytes + ?Sized, Output: NewBytes + ResizableBytes>(
         &self,
         output_len: usize,

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -164,6 +164,10 @@ pub trait HmacVariant<const KEY_LENGTH: usize, const MAC_LENGTH: usize> {
     /// Computes a MAC in one shot.
     fn compute(mac: &mut [u8; MAC_LENGTH], input: &[u8], key: &[u8; KEY_LENGTH]);
     /// Verifies a MAC in one shot.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `mac` does not authenticate `input` under `key`.
     fn verify(mac: &[u8; MAC_LENGTH], input: &[u8], key: &[u8; KEY_LENGTH]) -> Result<(), Error>;
     /// Initializes incremental authentication.
     fn init(key: &[u8; KEY_LENGTH]) -> Self::State;
@@ -291,7 +295,10 @@ where
     Variant: HmacVariant<KEY_LENGTH, MAC_LENGTH>,
 {
     /// Computes and returns the message authentication code for `input` using
-    /// `key`. The `key` is consumed to discourage accidental re-use.
+    /// `key`.
+    ///
+    /// This function takes ownership of `key`, but HMAC keys may authenticate
+    /// multiple messages. Clone the key first when it is needed again.
     pub fn compute<
         Key: ByteArray<KEY_LENGTH>,
         Input: Bytes + ?Sized,
@@ -314,6 +321,11 @@ where
     }
 
     /// Verifies `other_mac` against `input` using `key`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `other_mac` does not authenticate `input` under
+    /// `key`.
     pub fn compute_and_verify<
         OtherMac: ByteArray<MAC_LENGTH>,
         Key: ByteArray<KEY_LENGTH>,
@@ -326,8 +338,10 @@ where
         Variant::verify(other_mac.as_array(), input.as_slice(), key.as_array())
     }
 
-    /// Returns a new incremental authenticator for `key`. The `key` is consumed
-    /// to discourage accidental re-use.
+    /// Returns a new incremental authenticator for `key`.
+    ///
+    /// This function takes ownership of `key`, but HMAC keys may authenticate
+    /// multiple messages. Clone the key first when it is needed again.
     pub fn new<Key: ByteArray<KEY_LENGTH>>(key: Key) -> Self {
         Self {
             state: Variant::init(key.as_array()),
@@ -355,6 +369,11 @@ where
 
     /// Finalizes this authenticator and verifies that the computed code matches
     /// `other_mac` using a constant-time comparison.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `other_mac` does not match the authentication code
+    /// computed from the data passed to [`Hmac::update`].
     pub fn verify<OtherMac: ByteArray<MAC_LENGTH>>(
         self,
         other_mac: &OtherMac,

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -70,11 +70,9 @@ pub type StackKdf = Kdf<Key, Context>;
 #[cfg(any(all(feature = "protected", any(unix, windows)), all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "protected")))]
 pub mod protected {
-    //! #  Protected memory type aliases for [`Kdf`]
+    //! # Protected memory type aliases for [`Kdf`]
     //!
-    //! This mod provides re-exports of type aliases for protected memory usage
-    //! with [`Kdf`]. These type aliases are provided for
-    //! convenience.
+    //! Protected-memory aliases for key derivation.
     //!
     //! ## Example
     //!
@@ -138,6 +136,11 @@ impl<
 > Kdf<Key, Context>
 {
     /// Derives a subkey for `subkey_id`, returning it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the requested subkey length is rejected. The
+    /// fixed-size Rustaceous subkey type uses a supported length.
     pub fn derive_subkey<Subkey: NewByteArray<CRYPTO_KDF_KEYBYTES>>(
         &self,
         subkey_id: u64,
@@ -154,6 +157,11 @@ impl<
 
     /// Derives a subkey for `subkey_id`, returning it as a [`Vec`]. Provided
     /// for convenience.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if subkey derivation fails. See
+    /// [`Kdf::derive_subkey`].
     pub fn derive_subkey_to_vec(&self, subkey_id: u64) -> Result<Vec<u8>, Error> {
         self.derive_subkey(subkey_id)
     }

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -34,8 +34,8 @@ pub type StackKeyPair = KeyPair<PublicKey, SecretKey>;
     derive(Zeroize, ZeroizeOnDrop, Serialize, Deserialize, Clone)
 )]
 #[cfg_attr(not(feature = "serde"), derive(Zeroize, ZeroizeOnDrop, Clone))]
-/// Public/private keypair for use with [`crate::dryocbox::DryocBox`], aka
-/// libsodium box
+/// Public/secret keypair for use with [`crate::dryocbox::DryocBox`] and
+/// libsodium-compatible public-key encryption.
 pub struct KeyPair<
     PublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,
     SecretKey: ByteArray<CRYPTO_BOX_SECRETKEYBYTES> + Zeroize,
@@ -95,8 +95,8 @@ impl<
         Self::generate()
     }
 
-    /// Derives a keypair from `secret_key`, and consumes it, and returns a new
-    /// keypair.
+    /// Derives the public key for `secret_key` and returns the complete
+    /// keypair, consuming the secret key.
     pub fn from_secret_key(secret_key: SecretKey) -> Self {
         use crate::classic::crypto_core::crypto_scalarmult_base;
 
@@ -109,8 +109,7 @@ impl<
         }
     }
 
-    /// Derives a keypair from `seed`, returning
-    /// a new keypair.
+    /// Deterministically derives a keypair from `seed`.
     pub fn from_seed<Seed: Bytes>(seed: &Seed) -> Self {
         let mut public_key = PublicKey::new_byte_array();
         let mut secret_key = SecretKey::new_byte_array();
@@ -154,6 +153,10 @@ impl<
 {
     /// Constructs a new keypair from key slices, consuming them. Does not check
     /// validity or authenticity of keypair.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either slice does not have the required key length.
     pub fn from_slices(public_key: &'a [u8], secret_key: &'a [u8]) -> Result<Self, Error> {
         Ok(Self {
             public_key: PublicKey::try_from(public_key)
@@ -245,6 +248,11 @@ impl<
 
     /// Creates new client session keys using this keypair and
     /// `server_public_key`, assuming this keypair is for the client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `server_public_key` is unacceptable, including a
+    /// low-order point that would produce an all-zero shared secret.
     pub fn kx_new_client_session<SessionKey: NewByteArray<CRYPTO_KX_SESSIONKEYBYTES> + Zeroize>(
         &self,
         server_public_key: &PublicKey,
@@ -254,6 +262,11 @@ impl<
 
     /// Creates new server session keys using this keypair and
     /// `client_public_key`, assuming this keypair is for the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `client_public_key` is unacceptable, including a
+    /// low-order point that would produce an all-zero shared secret.
     pub fn kx_new_server_session<SessionKey: NewByteArray<CRYPTO_KX_SESSIONKEYBYTES> + Zeroize>(
         &self,
         client_public_key: &PublicKey,
@@ -265,6 +278,11 @@ impl<
     /// this keypair and `third_party_public_key`.
     ///
     /// Compatible with libsodium's `crypto_box_beforenm`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `third_party_public_key` is an unacceptable
+    /// low-order point.
     #[inline]
     pub fn precalculate(
         &self,
@@ -287,7 +305,7 @@ impl<
 #[cfg(any(all(feature = "protected", any(unix, windows)), all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "protected")))]
 pub mod protected {
-    //! #  Protected memory for [`KeyPair`]
+    //! # Protected memory for [`KeyPair`]
     use super::*;
     use crate::classic::crypto_box::crypto_box_keypair_inplace;
     pub use crate::protected::*;
@@ -298,7 +316,17 @@ pub mod protected {
             Locked<HeapByteArray<CRYPTO_BOX_SECRETKEYBYTES>>,
         >
     {
-        /// Returns a new locked keypair.
+        /// Returns a new zero-filled locked keypair.
+        ///
+        /// # Errors
+        ///
+        /// Returns an OS error if either allocation cannot be locked, commonly
+        /// because the process has reached its locked-memory limit.
+        ///
+        /// # Panics
+        ///
+        /// Panics if either page-aligned allocation cannot be created or its
+        /// size cannot be represented with guard pages.
         pub fn new_locked_keypair() -> Result<Self, std::io::Error> {
             Ok(Self {
                 public_key: HeapByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::new_locked()?,
@@ -307,6 +335,16 @@ pub mod protected {
         }
 
         /// Returns a new randomly generated locked keypair.
+        ///
+        /// # Errors
+        ///
+        /// Returns an OS error if either allocation cannot be locked.
+        ///
+        /// # Panics
+        ///
+        /// Panics if either page-aligned allocation cannot be created, its
+        /// size cannot be represented with guard pages, or the operating
+        /// system's random number generator fails.
         pub fn generate_locked_keypair() -> Result<Self, std::io::Error> {
             let mut res = Self::new_locked_keypair()?;
 
@@ -322,6 +360,16 @@ pub mod protected {
         ///
         /// Prefer [`generate_locked_keypair`](Self::generate_locked_keypair).
         /// This method is retained for compatibility.
+        ///
+        /// # Errors
+        ///
+        /// Returns the same errors as
+        /// [`generate_locked_keypair`](Self::generate_locked_keypair).
+        ///
+        /// # Panics
+        ///
+        /// Panics under the same conditions as
+        /// [`generate_locked_keypair`](Self::generate_locked_keypair).
         #[deprecated(note = "use generate_locked_keypair() instead")]
         pub fn gen_locked_keypair() -> Result<Self, std::io::Error> {
             Self::generate_locked_keypair()
@@ -332,6 +380,16 @@ pub mod protected {
         /// `third_party_public_key`.
         ///
         /// Compatible with libsodium's `crypto_box_beforenm`.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if `third_party_public_key` is an unacceptable
+        /// low-order point or the shared-key allocation cannot be locked.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the page-aligned shared-key allocation cannot be created
+        /// or its size cannot be represented with guard pages.
         #[inline]
         pub fn precalculate_locked<OtherPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>>(
             &self,
@@ -349,6 +407,17 @@ pub mod protected {
         >
     {
         /// Returns a new randomly generated locked, read-only keypair.
+        ///
+        /// # Errors
+        ///
+        /// Returns an OS error if either allocation cannot be locked or its
+        /// page permissions cannot be changed to read-only.
+        ///
+        /// # Panics
+        ///
+        /// Panics if either page-aligned allocation cannot be created, its
+        /// size cannot be represented with guard pages, or the operating
+        /// system's random number generator fails.
         pub fn generate_readonly_locked_keypair() -> Result<Self, std::io::Error> {
             let mut public_key = HeapByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::new_locked()?;
             let mut secret_key = HeapByteArray::<CRYPTO_BOX_SECRETKEYBYTES>::new_locked()?;
@@ -369,6 +438,16 @@ pub mod protected {
         /// Prefer
         /// [`generate_readonly_locked_keypair`](Self::generate_readonly_locked_keypair).
         /// This method is retained for compatibility.
+        ///
+        /// # Errors
+        ///
+        /// Returns the same errors as
+        /// [`generate_readonly_locked_keypair`](Self::generate_readonly_locked_keypair).
+        ///
+        /// # Panics
+        ///
+        /// Panics under the same conditions as
+        /// [`generate_readonly_locked_keypair`](Self::generate_readonly_locked_keypair).
         #[deprecated(note = "use generate_readonly_locked_keypair() instead")]
         pub fn gen_readonly_locked_keypair() -> Result<Self, std::io::Error> {
             Self::generate_readonly_locked_keypair()
@@ -379,6 +458,17 @@ pub mod protected {
         /// `third_party_public_key`.
         ///
         /// Compatible with libsodium's `crypto_box_beforenm`.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if `third_party_public_key` is an unacceptable
+        /// low-order point, the shared-key allocation cannot be locked, or its
+        /// page permissions cannot be changed to read-only.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the page-aligned shared-key allocation cannot be created
+        /// or its size cannot be represented with guard pages.
         #[inline]
         pub fn precalculate_readonly_locked<
             OtherPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,

--- a/src/kx.rs
+++ b/src/kx.rs
@@ -69,7 +69,7 @@ pub type KeyPair = crate::keypair::KeyPair<PublicKey, SecretKey>;
 
 #[cfg_attr(feature = "serde", derive(Zeroize, Clone, Serialize, Deserialize))]
 #[cfg_attr(not(feature = "serde"), derive(Zeroize, Clone))]
-/// Key derivation implemantation based on Curve25519, Diffie-Hellman, and
+/// Key derivation implementation based on Curve25519, Diffie-Hellman, and
 /// Blake2b. Compatible with libsodium's `crypto_kx_*` functions.
 pub struct Session<SessionKey: ByteArray<CRYPTO_KX_SESSIONKEYBYTES> + Zeroize> {
     rx_key: SessionKey,
@@ -93,11 +93,9 @@ pub type StackSession = Session<SessionKey>;
 #[cfg(any(all(feature = "protected", any(unix, windows)), all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "protected")))]
 pub mod protected {
-    //! #  Protected memory type aliases for [`Session`]
+    //! # Protected memory type aliases for [`Session`]
     //!
-    //! This mod provides re-exports of type aliases for protected memory usage
-    //! with [`Session`]. These type aliases are provided for
-    //! convenience.
+    //! Protected-memory aliases for key exchange.
     //!
     //! ## Example
     //!
@@ -132,20 +130,20 @@ pub mod protected {
     use super::*;
     pub use crate::keypair::protected::*;
 
-    /// Heap-allocated, paged-aligned session key type alias for use with
+    /// Heap-allocated, page-aligned session key type alias for use with
     /// protected memory
     pub type SessionKey = HeapByteArray<CRYPTO_KX_SESSIONKEYBYTES>;
-    /// Heap-allocated, paged-aligned public key type alias for use with
+    /// Heap-allocated, page-aligned public key type alias for use with
     /// protected memory
     pub type PublicKey = HeapByteArray<CRYPTO_KX_PUBLICKEYBYTES>;
-    /// Heap-allocated, paged-aligned secret key type alias for use with
+    /// Heap-allocated, page-aligned secret key type alias for use with
     /// protected memory
     pub type SecretKey = HeapByteArray<CRYPTO_KX_SECRETKEYBYTES>;
 
-    /// Heap-allocated, paged-aligned keypair type alias for use with
+    /// Heap-allocated, page-aligned keypair type alias for use with
     /// protected memory
     pub type LockedKeyPair = crate::keypair::KeyPair<Locked<PublicKey>, Locked<SecretKey>>;
-    /// Heap-allocated, paged-aligned keypair type alias for use with
+    /// Heap-allocated, page-aligned keypair type alias for use with
     /// protected memory
     pub type LockedROKeyPair = crate::keypair::KeyPair<LockedRO<PublicKey>, LockedRO<SecretKey>>;
     /// Locked session keys type alias, for use with protected memory
@@ -155,6 +153,11 @@ pub mod protected {
 impl<SessionKey: NewByteArray<CRYPTO_KX_SESSIONKEYBYTES> + Zeroize> Session<SessionKey> {
     /// Computes client session keys, given `client_keypair` and
     /// `server_public_key`, returning a new session upon success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `server_public_key` is unacceptable, including a
+    /// low-order point that would produce an all-zero shared secret.
     pub fn new_client<
         PublicKey: ByteArray<CRYPTO_KX_PUBLICKEYBYTES> + Zeroize,
         SecretKey: ByteArray<CRYPTO_KX_SECRETKEYBYTES> + Zeroize,
@@ -178,6 +181,11 @@ impl<SessionKey: NewByteArray<CRYPTO_KX_SESSIONKEYBYTES> + Zeroize> Session<Sess
 
     /// Computes server session keys, given `server_keypair` and
     /// `client_public_key`, returning a new session upon success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `client_public_key` is unacceptable, including a
+    /// low-order point that would produce an all-zero shared secret.
     pub fn new_server<
         PublicKey: ByteArray<CRYPTO_KX_PUBLICKEYBYTES> + Zeroize,
         SecretKey: ByteArray<CRYPTO_KX_SECRETKEYBYTES> + Zeroize,
@@ -204,6 +212,11 @@ impl Session<SessionKey> {
     /// Returns a new client session upon success using the default types for
     /// the given `client_keypair` and `server_public_key`. Wraps
     /// [`Session::new_client`], provided for convenience.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `server_public_key` is unacceptable. See
+    /// [`Session::new_client`].
     pub fn new_client_with_defaults<
         PublicKey: ByteArray<CRYPTO_KX_PUBLICKEYBYTES> + Zeroize,
         SecretKey: ByteArray<CRYPTO_KX_SECRETKEYBYTES> + Zeroize,
@@ -217,6 +230,11 @@ impl Session<SessionKey> {
     /// Returns a new server session upon success using the default types for
     /// the given `server_keypair` and `client_public_key`. Wraps
     /// [`Session::new_server`], provided for convenience.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `client_public_key` is unacceptable. See
+    /// [`Session::new_server`].
     pub fn new_server_with_defaults<
         PublicKey: ByteArray<CRYPTO_KX_PUBLICKEYBYTES> + Zeroize,
         SecretKey: ByteArray<CRYPTO_KX_SECRETKEYBYTES> + Zeroize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,31 +5,20 @@
 //! formats, so supported operations can interoperate with libsodium across
 //! languages.
 //!
-//! Doing cryptography properly is _hard_. While no human is infallible,
-//! computers are pretty good at following instructions. Humans are bad at
-//! following instructions, but they do a decent job of giving instructions,
-//! provided they can effectively communicate intent. Thus, if the instructions
-//! humans give the computer are correct, we can be reasonably assured
-//! that the operations the computer does are correct too.
-//!
-//! This library tries to make it easy to give the computer the correct
-//! instructions, and it does so by providing well-known implementations of
-//! general-purpose cryptography functions, in an API that's relatively easy to
-//! use, type safe, and hard to use incorrectly.
-//!
-//! As the name of this library implies, one should avoid trying to "roll their
-//! own crypto", as it often results in avoidable mistakes. In the context of
-//! cryptography, mistakes can be very costly.
+//! dryoc provides a libsodium-like Classic API and a typed Rustaceous API. The
+//! Rustaceous types make key, nonce, and output sizes explicit; the Classic API
+//! eases migration from libsodium. Both APIs use the same implementations and
+//! can be used together.
 //!
 //! This crate uses the Rust 2024 edition. The minimum supported Rust version
 //! (MSRV) is **Rust 1.89** or newer.
 //!
 //! ## Features
 //!
-//! * 100% pure Rust, no hidden C libraries
-//! * mostly free of unsafe code[^2]
-//! * Hard to misuse, helping you avoid common costly cryptography mistakes
-//! * Many libsodium features implemented with both Classic and Rustaceous API
+//! * Pure Rust, with no hidden C libraries
+//! * Limited use of unsafe code[^2]
+//! * Typed Rustaceous APIs for keys, nonces, and outputs
+//! * Classic and Rustaceous APIs for many libsodium operations
 //! * Protected memory handling (`mprotect()` + `mlock()`, along with Windows
 //!   equivalents) on stable Rust for Unix and Windows targets, enabled by
 //!   default with the `protected` feature
@@ -48,8 +37,11 @@
 //! * [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek)
 //!   (used by public/private key functions) selects its own serial or x86_64
 //!   vector backend at build time
-//! * [SHA2](https://github.com/RustCrypto/hashes/tree/master/sha2) (used by
-//!   sealed boxes) includes SIMD implementation for AVX2
+//! * [SHA2](https://github.com/RustCrypto/hashes/tree/master/sha2) (used for
+//!   SHA-256 and SHA-512 hashing and seeded box key generation) includes an
+//!   AVX2 backend
+//! * [SHA3](https://github.com/RustCrypto/hashes/tree/master/sha3) (used for
+//!   SHA-3 hashing)
 //! * [ChaCha20](https://github.com/RustCrypto/stream-ciphers/tree/master/chacha20)
 //!   (used by streaming interface) includes SIMD implementations for NEON,
 //!   AVX2, and SSE2
@@ -71,33 +63,20 @@
 //! `nightly` enabled, dryoc uses the soft Poly1305 backend because profiling
 //! shows the portable-SIMD implementation is slower on that architecture.
 //!
-//! _Note that eventually this project will converge on portable SIMD
-//! implementations for all the core algos which will work across all platforms
-//! supported by LLVM, rather than relying on hand-coded assembly or intrinsics,
-//! but this is a work in progress_.
-//!
 //! See [BENCHMARKS.md](https://github.com/brndnmtthws/dryoc/blob/main/BENCHMARKS.md)
 //! for side-by-side software and SIMD benchmark results.
 //!
 //! ## APIs
 //!
-//! This library includes both a _Classic_ API, which is very similar to the
-//! original libsodium API, and _Rustaceous_ API with Rust-specific features.
-//! Both APIs can be used together interchangeably, according to your
-//! preferences. The Rustaceous API is a wrapper around the underlying classic
-//! API.
+//! The _Classic_ API closely follows libsodium's functions and types. The
+//! _Rustaceous_ API wraps the same operations in Rust types.
 //!
-//! It's recommended that you use the Rustaceous API unless you have strong
-//! feelings about using the Classic API. The Classic API includes some pitfalls
-//! and traps that are also present in the original libsodium API, and unless
-//! you're extra careful you could make mistakes. With the Rustaceous API, it's
-//! harder to make mistakes thanks to strict type and safety features.
+//! Prefer the Rustaceous API for new code. Use the Classic API when porting
+//! libsodium code or when its byte-array interface is a better fit.
 //!
-//! The Rustaceous API is, arguably, somewhat trickier to use, especially if
-//! you're new to Rust. The Rustaceous API requires knowing and specifying the
-//! desired type in many cases. For your convenience, type aliases are provided
-//! for common types within each module. The Classic API only uses base types
-//! (fixed length byte arrays and byte slices).
+//! Rustaceous functions sometimes require an explicit output type. Each module
+//! provides type aliases for its common key, nonce, and output types. The
+//! Classic API instead uses fixed-size byte arrays and byte slices.
 //!
 //! | Feature | Rustaceous API | Classic API | Reference |
 //! |-|-|-|-|
@@ -105,7 +84,8 @@
 //! | Secret-key authenticated boxes | [`DryocSecretBox`](dryocsecretbox) | [`crypto_secretbox`](classic::crypto_secretbox) | [Link](https://libsodium.gitbook.io/doc/secret-key_cryptography/secretbox) |
 //! | Authenticated encryption with additional data | [`DryocAead`](dryocaead) | [`crypto_aead_xchacha20poly1305_ietf`](classic::crypto_aead_xchacha20poly1305_ietf) | [Link](https://doc.libsodium.org/secret-key_cryptography/aead/chacha20-poly1305/xchacha20-poly1305_construction) |
 //! | Streaming encryption | [`DryocStream`](dryocstream) | [`crypto_secretstream_xchacha20poly1305`](classic::crypto_secretstream_xchacha20poly1305) | [Link](https://libsodium.gitbook.io/doc/secret-key_cryptography/secretstream) |
-//! | Generic hashing, HMAC | [`GenericHash`](generichash) | [`crypto_generichash`](classic::crypto_generichash) | [Link](https://doc.libsodium.org/hashing/generic_hashing) |
+//! | Generic hashing and keyed hashing | [`GenericHash`](generichash) | [`crypto_generichash`](classic::crypto_generichash) | [Link](https://doc.libsodium.org/hashing/generic_hashing) |
+//! | SHA-2 hashing | [`Sha256`](sha256::Sha256), [`Sha512`](sha512::Sha512) | [`crypto_hash`](classic::crypto_hash) | [Link](https://doc.libsodium.org/advanced/sha-2_hash_function) |
 //! | SHA-3 hashing | [`Sha3256`](sha3::Sha3256), [`Sha3512`](sha3::Sha3512) | [`crypto_hash`](classic::crypto_hash) | [Link](https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.202.pdf) |
 //! | Secret-key authentication | [`Auth`](auth) | [`crypto_auth`](classic::crypto_auth) | [Link](https://doc.libsodium.org/secret-key_cryptography/secret-key_authentication) |
 //! | Direct HMAC authentication | [`Hmac`](hmac) | [`crypto_auth_hmacsha256`](classic::crypto_auth_hmacsha256), [`crypto_auth_hmacsha512`](classic::crypto_auth_hmacsha512), [`crypto_auth_hmacsha512256`](classic::crypto_auth_hmacsha512256) | [Link](https://doc.libsodium.org/secret-key_cryptography/secret-key_authentication) |
@@ -154,21 +134,17 @@
 //!
 //! ## Security notes
 //!
-//! This crate has not been audited by any 3rd parties. It uses well-known
-//! implementations of the underlying algorithms which have been previously
-//! verified as using constant-time operations.
-//!
-//! With that out of the way, the deterministic nature of cryptography and
-//! extensive testing used in this crate means it's relatively safe to use,
-//! provided the underlying algorithms remain safe. Arguably, this crate is
-//! _incredibly_ safe (as far as cryptography libraries go) thanks to the
-//! features provided by the API of this crate, and those provided by the Rust
-//! language itself.
+//! dryoc has not undergone a third-party security audit. Its compatibility
+//! tests, Rust types, and limited use of unsafe code reduce some classes of
+//! defects, but do not guarantee that an application is secure. Applications
+//! must still follow the documented key and nonce rules, protect secret
+//! material, handle errors, and choose primitives appropriate for their
+//! protocol.
 //!
 //! ## Acknowledgements
 //!
-//! Big ups to the authors and contributors of [NaCl](https://nacl.cr.yp.to/) and [libsodium](https://github.com/jedisct1/libsodium) for paving the
-//! way toward better cryptography libraries.
+//! Thanks to the authors and contributors of [NaCl](https://nacl.cr.yp.to/) and
+//! [libsodium](https://github.com/jedisct1/libsodium).
 //!
 //! [^1]: Not actually trademarked.
 //!
@@ -178,13 +154,8 @@
 //! require custom memory allocation, system calls, and pointer arithmetic,
 //! which are unsafe in Rust. Some optional SIMD code, including
 //! dependency-provided SIMD implementations and small internal helpers, may
-//! contain unsafe code. In particular, many SIMD implementations are considered
-//! "unsafe" due to their use of assembly or intrinsics, however without
-//! SIMD-based cryptography you may be exposed to timing attacks. See the unsafe
-//! code section above for the non-test unsafe inventory in this crate.
-//!
-//! [^3]: The Rustaceous API is designed to protect users of this library from
-//! making mistakes, however the Classic API allows one to do as one pleases.
+//! contain unsafe code. See the unsafe code section above for the non-test
+//! unsafe inventory in this crate.
 //!
 //! [^4]: Available on Unix and Windows targets with the `protected` feature
 //! flag enabled. The `protected` feature is enabled by default.
@@ -213,11 +184,9 @@ mod siphash24;
 pub mod classic {
     //! # Classic API
     //!
-    //! The Classic API contains functions designed to match the interface of
-    //! libsodium as closely as possible. It's provided to make it easier to
-    //! switch code from using libsodium directly over to dryoc, and also to
-    //! provide a familiar interface for anyone already comfortable with
-    //! libsodium.
+    //! The Classic API follows libsodium's interface closely. Use it to port
+    //! libsodium code or when fixed-size byte arrays and byte slices are a
+    //! better fit than the Rustaceous types.
     mod crypto_auth_hmac_impl;
     mod crypto_box_impl;
     mod crypto_secretbox_impl;

--- a/src/onetimeauth.rs
+++ b/src/onetimeauth.rs
@@ -5,15 +5,14 @@
 //!
 //! Use [`OnetimeAuth`] to authenticate messages when:
 //!
-//! * you want to exchange many small messages, such as in an online protocol
-//! * you can generate a unique key for each message you're authenticating,
-//!   i.e., using a key and a nonce
+//! * you need to authenticate a message with a one-time Poly1305 key
+//! * your protocol derives a unique key for every distinct message
 //!
-//! Do not reuse the same key for difference messages with [`OnetimeAuth`], as
-//! it provides an opportunity for an attacker to discover the key.
+//! Never use the same key to authenticate two different messages. Poly1305 key
+//! reuse can let an attacker forge authentication codes. Reusing the key to
+//! verify the authentication code for the same message is safe.
 //!
-//!
-//! # Rustaceous API example, one-time interface
+//! # Rustaceous API example, single-part interface
 //!
 //! ```
 //! use dryoc::onetimeauth::*;
@@ -22,12 +21,10 @@
 //! // Generate a random key
 //! let key = Key::generate();
 //!
-//! // Compute the mac in one shot. Here we clone the key for the purpose of this
-//! // example, but normally you would not do this as you never want to re-use a
-//! // key.
+//! // Compute the MAC. Keep a copy only to verify this same message.
 //! let mac = OnetimeAuth::compute_to_vec(key.clone(), b"Data to authenticate");
 //!
-//! // Verify the mac
+//! // Verify the MAC
 //! OnetimeAuth::compute_and_verify(&mac, key, b"Data to authenticate").expect("verify failed");
 //! ```
 //!
@@ -40,24 +37,26 @@
 //! // Generate a random key
 //! let key = Key::generate();
 //!
-//! // Initialize the MAC, clone the key (don't do this)
+//! // Initialize the MAC. Keep a copy only to verify this same message.
 //! let mut mac = OnetimeAuth::new(key.clone());
 //! mac.update(b"Multi-part");
 //! mac.update(b"data");
 //! let mac = mac.finalize_to_vec();
 //!
-//! // Verify it's correct, clone the key (don't do this)
+//! // Verify the MAC for the same message
 //! let mut verify_mac = OnetimeAuth::new(key.clone());
 //! verify_mac.update(b"Multi-part");
 //! verify_mac.update(b"data");
 //! verify_mac.verify(&mac).expect("verify failed");
 //!
-//! // Check that invalid data fails, consume the key
+//! // Check that a modified MAC fails for the same message
+//! let mut modified_mac = mac.clone();
+//! modified_mac[0] ^= 1;
 //! let mut verify_mac = OnetimeAuth::new(key);
 //! verify_mac.update(b"Multi-part");
-//! verify_mac.update(b"bad data");
+//! verify_mac.update(b"data");
 //! verify_mac
-//!     .verify(&mac)
+//!     .verify(&modified_mac)
 //!     .expect_err("verify should have failed");
 //! ```
 
@@ -79,11 +78,9 @@ pub type Mac = StackByteArray<CRYPTO_ONETIMEAUTH_BYTES>;
 #[cfg(any(all(feature = "protected", any(unix, windows)), all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "protected")))]
 pub mod protected {
-    //! #  Protected memory type aliases for [`OnetimeAuth`]
+    //! # Protected memory type aliases for [`OnetimeAuth`]
     //!
-    //! This mod provides re-exports of type aliases for protected memory usage
-    //! with [`OnetimeAuth`]. These type aliases are provided for
-    //! convenience.
+    //! Protected-memory aliases for one-time authentication keys and codes.
     //!
     //! ## Example
     //!
@@ -101,11 +98,11 @@ pub mod protected {
     use super::*;
     pub use crate::protected::*;
 
-    /// Heap-allocated, page-aligned secret key for the generic hash algorithm,
-    /// for use with protected memory.
+    /// Heap-allocated, page-aligned key for one-time authentication with
+    /// protected memory.
     pub type Key = HeapByteArray<CRYPTO_ONETIMEAUTH_KEYBYTES>;
-    /// Heap-allocated, page-aligned hash output for the generic hash algorithm,
-    /// for use with protected memory.
+    /// Heap-allocated, page-aligned one-time authentication code for use with
+    /// protected memory.
     pub type Mac = HeapByteArray<CRYPTO_ONETIMEAUTH_BYTES>;
 }
 
@@ -116,9 +113,10 @@ pub struct OnetimeAuth {
 }
 
 impl OnetimeAuth {
-    /// Single-part interface for [`OnetimeAuth`]. Computes (and returns) the
-    /// message authentication code for `input` using `key`. The `key` is
-    /// consumed to prevent accidental re-use of the same key.
+    /// Computes the message authentication code for `input` using `key`.
+    ///
+    /// The key must not be used to authenticate any other message. It may be
+    /// retained to verify the authentication code for this same message.
     pub fn compute<
         Key: ByteArray<CRYPTO_ONETIMEAUTH_KEYBYTES>,
         Input: Bytes,
@@ -132,9 +130,9 @@ impl OnetimeAuth {
         output
     }
 
-    /// Convience wrapper around [`OnetimeAuth::compute`]. Returns the message
-    /// authentication code as a [`Vec`]. The `key` is
-    /// consumed to prevent accidental re-use of the same key.
+    /// Computes the message authentication code and returns it as a [`Vec`].
+    ///
+    /// This is a convenience wrapper around [`OnetimeAuth::compute`].
     pub fn compute_to_vec<Key: ByteArray<CRYPTO_ONETIMEAUTH_KEYBYTES>, Input: Bytes>(
         key: Key,
         input: &Input,
@@ -142,9 +140,12 @@ impl OnetimeAuth {
         Self::compute(key, input)
     }
 
-    /// Verifies the message authentication code `other_mac` matches the
-    /// expected code for `key` and `input`. The `key` is
-    /// consumed to prevent accidental re-use of the same key.
+    /// Verifies that `other_mac` authenticates `input` under `key`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `other_mac` does not match the authentication code
+    /// computed from `key` and `input`.
     pub fn compute_and_verify<
         OtherMac: ByteArray<CRYPTO_ONETIMEAUTH_BYTES>,
         Key: ByteArray<CRYPTO_ONETIMEAUTH_KEYBYTES>,
@@ -157,8 +158,10 @@ impl OnetimeAuth {
         crypto_onetimeauth_verify(other_mac.as_array(), input.as_slice(), key.as_array())
     }
 
-    /// Returns a new one-time authenticator for `key`. The `key` is
-    /// consumed to prevent accidental re-use of the same key.
+    /// Returns a new incremental one-time authenticator for `key`.
+    ///
+    /// The key must not be used to authenticate any other message. It may be
+    /// retained to verify the authentication code for this same message.
     pub fn new<Key: ByteArray<CRYPTO_ONETIMEAUTH_KEYBYTES>>(key: Key) -> Self {
         Self {
             state: crypto_onetimeauth_init(key.as_array()),
@@ -187,6 +190,11 @@ impl OnetimeAuth {
 
     /// Finalizes this authenticator, and verifies that the computed code
     /// matches `other_mac` using a constant-time comparison.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `other_mac` does not match the authentication code
+    /// computed from the data passed to [`OnetimeAuth::update`].
     pub fn verify<OtherMac: ByteArray<CRYPTO_ONETIMEAUTH_BYTES>>(
         self,
         other_mac: &OtherMac,

--- a/src/precalc.rs
+++ b/src/precalc.rs
@@ -1,8 +1,8 @@
 //! Precalculated secret key for use with `precalc_*` functions in
 //! [`crate::dryocbox::DryocBox`]
 //!
-//! You may want to use `precalc_*` functions if you need to
-//! encrypt/decrypt multiple messages between the same sender and receiver.
+//! Precalculation avoids repeating the public-key operation when encrypting or
+//! decrypting multiple messages between the same sender and receiver.
 use std::fmt;
 
 use subtle::ConstantTimeEq;
@@ -19,10 +19,9 @@ type InnerKey = StackByteArray<CRYPTO_BOX_BEFORENMBYTES>;
 /// Precalculated secret key for use with `precalc_*` functions in
 /// [`crate::dryocbox::DryocBox`].
 ///
-/// You probably want to use `precalc_*` functions if you need to
-/// encrypt/decrypt multiple messages between the same sender and receiver.
-/// These functions save computation time by using [`PrecalcSecretKey`]
-/// instead of computing the shared secret every time.
+/// Use `precalc_*` functions to encrypt or decrypt multiple messages between
+/// the same sender and receiver. They reuse this shared secret instead of
+/// repeating the public-key operation for every message.
 ///
 /// Using precalculated secret keys is compatible with libsodium's
 /// `crypto_box_beforenm`.
@@ -105,6 +104,11 @@ impl PrecalcSecretKey<InnerKey> {
     /// `third_party_public_key` and `secret_key`.
     ///
     /// Compatible with libsodium's `crypto_box_beforenm`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `third_party_public_key` is an unacceptable
+    /// low-order point.
     #[inline]
     pub fn precalculate<
         ThirdPartyPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
@@ -124,7 +128,7 @@ impl PrecalcSecretKey<InnerKey> {
 #[cfg(any(all(feature = "protected", any(unix, windows)), all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "protected")))]
 pub mod protected {
-    //! #  Protected memory for [`PrecalcSecretKey`]
+    //! # Protected memory for [`PrecalcSecretKey`]
     use super::*;
     pub use crate::protected::*;
 
@@ -135,6 +139,16 @@ pub mod protected {
         /// for the given `third_party_public_key` and `secret_key`.
         ///
         /// Compatible with libsodium's `crypto_box_beforenm`.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if `third_party_public_key` is an unacceptable
+        /// low-order point or the protected allocation cannot be locked.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the page-aligned allocation cannot be created or its size
+        /// cannot be represented with guard pages.
         pub fn precalculate_locked<
             ThirdPartyPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
             SecretKey: ByteArray<CRYPTO_BOX_SECRETKEYBYTES>,
@@ -161,6 +175,17 @@ pub mod protected {
         /// `secret_key`.
         ///
         /// Compatible with libsodium's `crypto_box_beforenm`.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if `third_party_public_key` is an unacceptable
+        /// low-order point, the protected allocation cannot be locked, or its
+        /// page permissions cannot be changed to read-only.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the page-aligned allocation cannot be created or its size
+        /// cannot be represented with guard pages.
         pub fn precalculate_readonly_locked<
             ThirdPartyPublicKey: ByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
             SecretKey: ByteArray<CRYPTO_BOX_SECRETKEYBYTES>,

--- a/src/protected.rs
+++ b/src/protected.rs
@@ -204,6 +204,11 @@ pub trait Lockable<A: Zeroize + Bytes> {
     /// Windows. By default, the protect mode is set to ReadWrite (i.e., no
     /// exec) using `mprotect()` on UNIX, or `VirtualProtect()` on Windows.
     /// On Linux, it will also set `MADV_DONTDUMP` using `madvise()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error if the pages cannot be locked. A common cause is
+    /// exceeding the process's locked-memory limit.
     fn mlock(self) -> Result<Protected<A, traits::ReadWrite, traits::Locked>, std::io::Error>;
 }
 
@@ -213,13 +218,22 @@ pub trait Lock<A: Zeroize + Bytes, PM: traits::ProtectMode> {
     /// Windows. By default, the protect mode is set to ReadWrite (i.e., no
     /// exec) using `mprotect()` on UNIX, or `VirtualProtect()` on Windows.
     /// On Linux, it will also set `MADV_DONTDUMP` using `madvise()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error if the pages cannot be locked, for example because
+    /// the process has reached its locked-memory limit.
     fn mlock(self) -> Result<Protected<A, PM, traits::Locked>, std::io::Error>;
 }
 
 /// Protected region of memory that can be locked (i.e., is already locked).
 pub trait Unlock<A: Zeroize + Bytes, PM: traits::ProtectMode> {
     /// Unlocks a region of memory, using `munlock()` on UNIX, or
-    /// `VirtualLock()` on Windows.
+    /// `VirtualUnlock()` on Windows.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error if the pages cannot be unlocked.
     fn munlock(self) -> Result<Protected<A, PM, traits::Unlocked>, std::io::Error>;
 }
 
@@ -227,6 +241,10 @@ pub trait Unlock<A: Zeroize + Bytes, PM: traits::ProtectMode> {
 pub trait ProtectReadOnly<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> {
     /// Protects a region of memory as read-only (and no exec), using
     /// `mprotect()` on UNIX, or `VirtualProtect()` on Windows.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error if the page permissions cannot be changed.
     fn mprotect_readonly(self) -> Result<Protected<A, traits::ReadOnly, LM>, std::io::Error>;
 }
 
@@ -234,6 +252,10 @@ pub trait ProtectReadOnly<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: trait
 pub trait ProtectReadWrite<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> {
     /// Protects a region of memory as read-write (and no exec), using
     /// `mprotect()` on UNIX, or `VirtualProtect()` on Windows.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error if the page permissions cannot be changed.
     fn mprotect_readwrite(self) -> Result<Protected<A, traits::ReadWrite, LM>, std::io::Error>;
 }
 
@@ -241,6 +263,10 @@ pub trait ProtectReadWrite<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: trai
 pub trait ProtectNoAccess<A: Zeroize + Bytes, PM: traits::ProtectMode> {
     /// Protects an unlocked region of memory as no-access (and no exec), using
     /// `mprotect()` on UNIX, or `VirtualProtect()` on Windows.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error if the page permissions cannot be changed.
     fn mprotect_noaccess(
         self,
     ) -> Result<Protected<A, traits::NoAccess, traits::Unlocked>, std::io::Error>;
@@ -249,19 +275,42 @@ pub trait ProtectNoAccess<A: Zeroize + Bytes, PM: traits::ProtectMode> {
 /// Bytes which can be allocated and protected.
 pub trait NewLocked<A: Zeroize + NewBytes + Lockable<A>> {
     /// Returns a new locked byte array.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error if the allocation cannot be locked, commonly
+    /// because the process has reached its locked-memory limit.
     fn new_locked() -> Result<Protected<A, traits::ReadWrite, traits::Locked>, std::io::Error>;
     /// Returns a new locked byte array.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error if the allocation cannot be locked or its page
+    /// permissions cannot be changed to read-only.
     fn new_readonly_locked()
     -> Result<Protected<A, traits::ReadOnly, traits::Locked>, std::io::Error>;
     /// Returns a new locked byte array, filled with random data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error if the allocation cannot be locked.
     fn generate_locked() -> Result<Protected<A, traits::ReadWrite, traits::Locked>, std::io::Error>;
     /// Returns a new read-only, locked byte array, filled with random data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error if the allocation cannot be locked or its page
+    /// permissions cannot be changed to read-only.
     fn generate_readonly_locked()
     -> Result<Protected<A, traits::ReadOnly, traits::Locked>, std::io::Error>;
     /// Returns a new locked byte array, filled with random data.
     ///
     /// Prefer [`generate_locked`](Self::generate_locked). This method is
     /// retained for compatibility.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`generate_locked`](Self::generate_locked).
     #[deprecated(note = "use generate_locked() instead")]
     fn gen_locked() -> Result<Protected<A, traits::ReadWrite, traits::Locked>, std::io::Error> {
         Self::generate_locked()
@@ -270,6 +319,11 @@ pub trait NewLocked<A: Zeroize + NewBytes + Lockable<A>> {
     ///
     /// Prefer [`generate_readonly_locked`](Self::generate_readonly_locked).
     /// This method is retained for compatibility.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as
+    /// [`generate_readonly_locked`](Self::generate_readonly_locked).
     #[deprecated(note = "use generate_readonly_locked() instead")]
     fn gen_readonly_locked()
     -> Result<Protected<A, traits::ReadOnly, traits::Locked>, std::io::Error> {
@@ -280,10 +334,31 @@ pub trait NewLocked<A: Zeroize + NewBytes + Lockable<A>> {
 /// Create a new region of protected memory from a slice.
 pub trait NewLockedFromSlice<A: Zeroize + NewBytes + Lockable<A>> {
     /// Returns a new locked region of memory from `src`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `src` has the wrong length for a fixed-size output
+    /// or the pages cannot be locked.
+    ///
+    /// # Panics
+    ///
+    /// May panic if allocating or resizing the protected storage fails,
+    /// including when the requested size cannot be rounded to whole pages.
     fn from_slice_into_locked(
         src: &[u8],
     ) -> Result<Protected<A, traits::ReadWrite, traits::Locked>, crate::error::Error>;
     /// Returns a new read-only locked region of memory from `src`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `src` has the wrong length for a fixed-size output,
+    /// its pages cannot be locked, or its page permissions cannot be changed
+    /// to read-only.
+    ///
+    /// # Panics
+    ///
+    /// May panic if allocating or resizing the protected storage fails,
+    /// including when the requested size cannot be rounded to whole pages.
     fn from_slice_into_readonly_locked(
         src: &[u8],
     ) -> Result<Protected<A, traits::ReadOnly, traits::Locked>, crate::error::Error>;
@@ -703,6 +778,15 @@ impl<const LENGTH: usize> From<StackByteArray<LENGTH>> for HeapByteArray<LENGTH>
 impl<const LENGTH: usize> StackByteArray<LENGTH> {
     /// Locks a [StackByteArray], consuming it, and returning a [Protected]
     /// wrapper.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error if the pages cannot be locked.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the page-aligned allocation cannot be created or its size
+    /// cannot be represented after page rounding and adding guard pages.
     pub fn mlock(
         self,
     ) -> Result<Protected<HeapByteArray<LENGTH>, traits::ReadWrite, traits::Locked>, std::io::Error>
@@ -716,6 +800,16 @@ impl<const LENGTH: usize> StackByteArray<LENGTH> {
 
 impl<const LENGTH: usize> StackByteArray<LENGTH> {
     /// Returns a readonly protected [StackByteArray].
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error if the page permissions cannot be changed to
+    /// read-only.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the page-aligned allocation cannot be created or its size
+    /// cannot be represented after page rounding and adding guard pages.
     pub fn mprotect_readonly(
         self,
     ) -> Result<Protected<HeapByteArray<LENGTH>, traits::ReadOnly, traits::Unlocked>, std::io::Error>
@@ -1245,8 +1339,7 @@ impl<A: Zeroize + NewBytes + Lockable<A>> NewLocked<A> for A {
 }
 
 impl<A: Zeroize + NewBytes + ResizableBytes + Lockable<A>> NewLockedFromSlice<A> for A {
-    /// Returns a new locked byte array from `other`. Panics if sizes do not
-    /// match.
+    /// Copies `src` into a new locked byte buffer.
     fn from_slice_into_locked(
         src: &[u8],
     ) -> Result<Protected<Self, traits::ReadWrite, traits::Locked>, crate::error::Error> {
@@ -1256,8 +1349,7 @@ impl<A: Zeroize + NewBytes + ResizableBytes + Lockable<A>> NewLockedFromSlice<A>
         Ok(res)
     }
 
-    /// Returns a new locked byte array from `other`. Panics if sizes do not
-    /// match.
+    /// Copies `src` into a new read-only, locked byte buffer.
     fn from_slice_into_readonly_locked(
         src: &[u8],
     ) -> Result<Protected<Self, traits::ReadOnly, traits::Locked>, crate::error::Error> {
@@ -1267,8 +1359,7 @@ impl<A: Zeroize + NewBytes + ResizableBytes + Lockable<A>> NewLockedFromSlice<A>
 }
 
 impl<const LENGTH: usize> NewLockedFromSlice<HeapByteArray<LENGTH>> for HeapByteArray<LENGTH> {
-    /// Returns a new locked byte array from `other`. Panics if sizes do not
-    /// match.
+    /// Copies `other` into a new fixed-size locked byte array.
     fn from_slice_into_locked(
         other: &[u8],
     ) -> Result<Protected<Self, traits::ReadWrite, traits::Locked>, crate::error::Error> {

--- a/src/pwhash.rs
+++ b/src/pwhash.rs
@@ -3,16 +3,20 @@
 //! [`PwHash`] implements libsodium's password hashing functions, based on
 //! Argon2.
 //!
-//! Argon2 provides a configurable memory-hard arbitrary-length hashing function
-//! that is well suited for password hashing. You may tune the function
-//! according to your preferences to either provide stronger collision
-//! resistance, or shorter computation times.
+//! Argon2 is a memory-hard password hashing function. Its work and memory
+//! settings make each password guess more expensive, which slows offline
+//! guessing if a password database is stolen. These settings do not compensate
+//! for weak passwords, so applications should still encourage long, unique
+//! passwords.
 //!
 //! You should use [`PwHash`] when you want to:
 //!
 //! * authenticate with passwords, and store their salted hashes in a database
 //! * derive secret keys based on passphrases
-//! * hash arbitrary data in a manner that's strongly resistant to collisions
+//!
+//! Use a general-purpose hash such as [`crate::generichash`] or
+//! [`crate::sha256`] for arbitrary data. Password hashing is deliberately much
+//! more expensive.
 //!
 //! If the `serde` feature is enabled, the [`serde::Deserialize`] and
 //! [`serde::Serialize`] traits will be implemented for [`PwHash`].
@@ -48,13 +52,18 @@
 //! let password = b"What's in a name? That which we call a rose\n
 //!                  By any other word would smell as sweet...";
 //!
-//! // With customized configuration parameters, return type must be explicit
-//! let pwhash: VecPwHash = PwHash::hash_with_salt(
-//!     password,
-//!     salt,
-//!     Config::interactive().with_opslimit(1).with_memlimit(8192),
-//! )
-//! .expect("unable to hash password with salt and custom config");
+//! // Start with a preset, then increase its work factor if your deployment can
+//! // tolerate the extra time. Benchmark the result on the slowest target.
+//! let config = Config::interactive()
+//!     .with_opslimit(dryoc::constants::CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE + 1);
+//! # // Keep this doctest fast; these minimums are not a production recommendation.
+//! # let config = Config::interactive()
+//! #     .with_opslimit(dryoc::constants::CRYPTO_PWHASH_OPSLIMIT_MIN)
+//! #     .with_memlimit(dryoc::constants::CRYPTO_PWHASH_MEMLIMIT_MIN);
+//!
+//! // With customized configuration parameters, the return type must be explicit.
+//! let pwhash: VecPwHash = PwHash::hash_with_salt(password, salt, config)
+//!     .expect("unable to hash password with salt and custom config");
 //!
 //! pwhash.verify(password).expect("verification failed");
 //! pwhash
@@ -106,13 +115,16 @@ use crate::keypair;
 use crate::rng::copy_randombytes;
 use crate::types::*;
 
-/// Heap-allocated salt type alias for password hashing with [`PwHash`]. Salts
-/// can be of arbitrary length, but they should be at least
-/// [`CRYPTO_PWHASH_SALTBYTES_MIN`] bytes.
+/// Heap-allocated salt type alias for password hashing with [`PwHash`].
+///
+/// Salts must contain at least [`CRYPTO_PWHASH_SALTBYTES_MIN`] bytes. Prefer
+/// [`CRYPTO_PWHASH_SALTBYTES`] bytes unless interoperability requires another
+/// length. Each stored password hash needs a unique, unpredictable salt;
+/// [`PwHash::hash`] generates one automatically.
 pub type Salt = Vec<u8>;
-/// Heap-allocated hash type alias for password hashing with [`PwHash`]. Hashes
-/// can be of arbitrary length, but they should be at least
-/// [`CRYPTO_PWHASH_BYTES_MIN`] bytes.
+/// Heap-allocated hash type alias for password hashing with [`PwHash`].
+///
+/// Hashes must contain at least [`CRYPTO_PWHASH_BYTES_MIN`] bytes.
 pub type Hash = Vec<u8>;
 
 #[cfg_attr(
@@ -120,9 +132,13 @@ pub type Hash = Vec<u8>;
     derive(Zeroize, Clone, Debug, Serialize, Deserialize)
 )]
 #[cfg_attr(not(feature = "serde"), derive(Zeroize, Clone, Debug))]
-/// Password hash configuration parameters. Provides reasonable default
-/// values with [`Config::default()`], [`Config::interactive()`],
-/// [`Config::moderate()`], and [`Config::sensitive()`].
+/// Password hash configuration parameters.
+///
+/// [`Config::interactive`] is the default and is suitable for online
+/// authentication. [`Config::moderate`] and [`Config::sensitive`] spend more
+/// time and memory per password guess. Benchmark the chosen preset on the
+/// slowest supported system, and account for the number of concurrent hashes
+/// when setting memory limits.
 pub struct Config {
     algorithm: crypto_pwhash::PasswordHashAlgorithm,
     hash_length: usize,
@@ -132,7 +148,11 @@ pub struct Config {
 }
 
 impl Config {
-    /// Returns this config with `salt_length`.
+    /// Sets the generated salt length in bytes.
+    ///
+    /// The length must be between [`CRYPTO_PWHASH_SALTBYTES_MIN`] and
+    /// [`CRYPTO_PWHASH_SALTBYTES_MAX`], inclusive. Invalid values are reported
+    /// when the config is used to hash a password.
     #[must_use]
     pub fn with_salt_length(self, salt_length: usize) -> Self {
         Self {
@@ -141,7 +161,11 @@ impl Config {
         }
     }
 
-    /// Returns this config with `hash_length`.
+    /// Sets the hash output length in bytes.
+    ///
+    /// The length must be between [`CRYPTO_PWHASH_BYTES_MIN`] and
+    /// [`CRYPTO_PWHASH_BYTES_MAX`], inclusive. Invalid values are reported when
+    /// the config is used to hash a password.
     #[must_use]
     pub fn with_hash_length(self, hash_length: usize) -> Self {
         Self {
@@ -150,19 +174,31 @@ impl Config {
         }
     }
 
-    /// Returns this config with `memlimit`.
+    /// Sets the approximate memory cost in bytes.
+    ///
+    /// More memory makes parallel guessing more expensive, but every
+    /// concurrent hash also consumes that memory. The value must be between
+    /// [`CRYPTO_PWHASH_MEMLIMIT_MIN`] and [`CRYPTO_PWHASH_MEMLIMIT_MAX`],
+    /// inclusive.
     #[must_use]
     pub fn with_memlimit(self, memlimit: usize) -> Self {
         Self { memlimit, ..self }
     }
 
-    /// Returns this config with `opslimit`.
+    /// Sets the computation cost.
+    ///
+    /// Larger values take longer and make each password guess more expensive.
+    /// The value must be between [`CRYPTO_PWHASH_OPSLIMIT_MIN`] and
+    /// [`CRYPTO_PWHASH_OPSLIMIT_MAX`], inclusive.
     #[must_use]
     pub fn with_opslimit(self, opslimit: u64) -> Self {
         Self { opslimit, ..self }
     }
 
-    /// Provides a password hash configuration for interactive hashing.
+    /// Returns libsodium's interactive password hashing configuration.
+    ///
+    /// This is the default preset for online operations where users wait for
+    /// the result.
     pub fn interactive() -> Self {
         Self {
             algorithm: crypto_pwhash::PasswordHashAlgorithm::Argon2id13,
@@ -173,7 +209,9 @@ impl Config {
         }
     }
 
-    /// Provides a password hash configuration for moderate hashing.
+    /// Returns libsodium's moderate password hashing configuration.
+    ///
+    /// This preset uses more time and memory than [`Config::interactive`].
     pub fn moderate() -> Self {
         Self {
             algorithm: crypto_pwhash::PasswordHashAlgorithm::Argon2id13,
@@ -184,7 +222,10 @@ impl Config {
         }
     }
 
-    /// Provides a password hash configuration for sensitive hashing.
+    /// Returns libsodium's sensitive password hashing configuration.
+    ///
+    /// This preset has the highest resource requirements. Use it only when the
+    /// deployment can tolerate its latency and memory use.
     pub fn sensitive() -> Self {
         Self {
             algorithm: crypto_pwhash::PasswordHashAlgorithm::Argon2id13,
@@ -221,11 +262,9 @@ pub type VecPwHash = PwHash<Hash, Salt>;
 #[cfg(any(all(feature = "protected", any(unix, windows)), all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "protected")))]
 pub mod protected {
-    //! #  Protected memory type aliases for [`PwHash`]
+    //! # Protected memory type aliases for [`PwHash`]
     //!
-    //! This mod provides re-exports of type aliases for protected memory usage
-    //! with [`PwHash`]. These type aliases are provided for
-    //! convenience.
+    //! Protected-memory aliases for password hashes and salts.
     //!
     //! ## Example
     //!
@@ -265,6 +304,12 @@ impl<Hash: NewBytes + ResizableBytes + Zeroize, Salt: NewBytes + ResizableBytes 
 {
     /// Hashes `password` with a random salt and `config`, returning
     /// the hash, salt, and config upon success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a work limit, memory limit, hash length, salt
+    /// length, or password length is outside the supported range, or if the
+    /// underlying Argon2 operation fails.
     pub fn hash<Password: Bytes>(password: &Password, config: Config) -> Result<Self, Error> {
         let mut hash = Hash::new_bytes();
         let mut salt = Salt::new_bytes();
@@ -289,6 +334,10 @@ impl<Hash: NewBytes + ResizableBytes + Zeroize, Salt: NewBytes + ResizableBytes 
     /// Hashes `password` with a random salt and a default configuration
     /// suitable for interactive hashing, returning the hash, salt, and config
     /// upon success.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`PwHash::hash`].
     pub fn hash_interactive<Password: Bytes>(password: &Password) -> Result<Self, Error> {
         Self::hash(password, Config::interactive())
     }
@@ -296,6 +345,10 @@ impl<Hash: NewBytes + ResizableBytes + Zeroize, Salt: NewBytes + ResizableBytes 
     /// Hashes `password` with a random salt and a default configuration
     /// suitable for moderate hashing, returning the hash, salt, and config upon
     /// success.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`PwHash::hash`].
     pub fn hash_moderate<Password: Bytes>(password: &Password) -> Result<Self, Error> {
         Self::hash(password, Config::moderate())
     }
@@ -303,15 +356,16 @@ impl<Hash: NewBytes + ResizableBytes + Zeroize, Salt: NewBytes + ResizableBytes 
     /// Hashes `password` with a random salt and a default configuration
     /// suitable for sensitive hashing, returning the hash, salt, and config
     /// upon success.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`PwHash::hash`].
     pub fn hash_sensitive<Password: Bytes>(password: &Password) -> Result<Self, Error> {
         Self::hash(password, Config::sensitive())
     }
 
     /// Returns a string-encoded representation of this hash, salt, and config,
     /// suitable for storage in a database.
-    ///
-    /// It's recommended that you use the Serde support instead of this
-    /// function, however this function is provided for compatiblity reasons.
     ///
     /// The string returned is compatible with libsodium's `crypto_pwhash_str`,
     /// `crypto_pwhash_str_verify`, and `crypto_pwhash_str_needs_rehash`
@@ -349,7 +403,12 @@ impl<Hash: NewBytes + ResizableBytes + Zeroize, Salt: NewBytes + ResizableBytes 
 }
 
 impl<Hash: NewBytes + ResizableBytes + Zeroize, Salt: Bytes + Clone + Zeroize> PwHash<Hash, Salt> {
-    /// Verifies that this hash, salt, and config is valid for `password`.
+    /// Verifies `password` against this hash using its salt and configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the password does not match, if the stored salt or
+    /// configuration is invalid, or if the underlying Argon2 operation fails.
     pub fn verify<Password: Bytes>(&self, password: &Password) -> Result<(), Error> {
         let computed = Self::hash_with_salt(password, self.salt.clone(), self.config.clone())?;
 
@@ -368,6 +427,15 @@ impl<Hash: NewBytes + ResizableBytes + Zeroize, Salt: Bytes + Clone + Zeroize> P
 
     /// Hashes `password` with `salt` and `config`, returning
     /// the hash, salt, and config upon success.
+    ///
+    /// The caller must provide a unique, unpredictable salt for each password.
+    /// Prefer [`PwHash::hash`] unless an existing salt must be reused.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a work limit, memory limit, hash length, salt
+    /// length, or password length is outside the supported range, or if the
+    /// underlying Argon2 operation fails.
     pub fn hash_with_salt<Password: Bytes>(
         password: &Password,
         salt: Salt,
@@ -399,20 +467,39 @@ impl<Hash: Bytes + From<Vec<u8>> + Zeroize, Salt: Bytes + From<Vec<u8>> + Zeroiz
     /// Compatible with libsodium's `crypto_pwhash_str*` functions, and supports
     /// variable-length encoding for the hash and salt.
     ///
-    /// It's recommended that you use the Serde support instead of this
-    /// function, however this function is provided for compatiblity reasons.
+    /// # Errors
+    ///
+    /// Returns an error if the string is malformed, uses an unsupported
+    /// algorithm or version, omits a required field, or contains an invalid
+    /// encoded value.
     pub fn from_string(hashed_password: &str) -> Result<Self, Error> {
         let parsed_pwhash = crypto_pwhash::Pwhash::parse_encoded_pwhash(hashed_password)?;
 
-        let opslimit = parsed_pwhash.t_cost.unwrap() as u64;
-        let memlimit = 1024 * (parsed_pwhash.m_cost.unwrap() as usize);
-        let hash_length = parsed_pwhash.pwhash.as_ref().unwrap().len();
-        let salt_length = parsed_pwhash.salt.as_ref().unwrap().len();
-        let algorithm = parsed_pwhash.type_.unwrap();
+        let opslimit = parsed_pwhash
+            .t_cost
+            .ok_or_else(|| dryoc_error!("encoded password hash has no computation cost"))?
+            as u64;
+        let encoded_memlimit = parsed_pwhash
+            .m_cost
+            .ok_or_else(|| dryoc_error!("encoded password hash has no memory cost"))?;
+        let memlimit = 1024usize
+            .checked_mul(encoded_memlimit as usize)
+            .ok_or_else(|| dryoc_error!("encoded memory cost is too large"))?;
+        let hash = parsed_pwhash
+            .pwhash
+            .ok_or_else(|| dryoc_error!("encoded password hash has no hash value"))?;
+        let salt = parsed_pwhash
+            .salt
+            .ok_or_else(|| dryoc_error!("encoded password hash has no salt"))?;
+        let algorithm = parsed_pwhash
+            .type_
+            .ok_or_else(|| dryoc_error!("encoded password hash has no algorithm"))?;
+        let hash_length = hash.len();
+        let salt_length = salt.len();
 
         Ok(Self {
-            hash: parsed_pwhash.pwhash.unwrap().into(),
-            salt: parsed_pwhash.salt.unwrap().into(),
+            hash: hash.into(),
+            salt: salt.into(),
             config: Config {
                 algorithm,
                 hash_length,
@@ -427,6 +514,9 @@ impl<Hash: Bytes + From<Vec<u8>> + Zeroize, Salt: Bytes + From<Vec<u8>> + Zeroiz
 impl<Hash: Bytes + Zeroize, Salt: Bytes + Zeroize> PwHash<Hash, Salt> {
     /// Constructs a new instance from `hash`, `salt`, and `config`, consuming
     /// them.
+    ///
+    /// This function does not validate the parts. Invalid values are reported
+    /// when [`PwHash::verify`] uses them.
     pub fn from_parts(hash: Hash, salt: Salt, config: Config) -> Self {
         Self { hash, salt, config }
     }
@@ -440,6 +530,15 @@ impl<Hash: Bytes + Zeroize, Salt: Bytes + Zeroize> PwHash<Hash, Salt> {
 
 impl<Salt: Bytes + Zeroize> PwHash<Hash, Salt> {
     /// Derives a keypair from `password` and `salt`, using `config`.
+    ///
+    /// The same password and salt derive the same keypair. Store the salt, keep
+    /// it unique per derived key, and do not treat it as secret.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a work limit, memory limit, salt length, or password
+    /// length is outside the supported range, or if the underlying Argon2
+    /// operation fails.
     pub fn derive_keypair<
         Password: Bytes + Zeroize,
         PublicKey: NewByteArray<CRYPTO_BOX_PUBLICKEYBYTES> + Zeroize,
@@ -472,6 +571,11 @@ impl PwHash<Hash, Salt> {
     ///
     /// This function provides reasonable defaults, and is provided for
     /// convenience.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the password length is unsupported or the
+    /// underlying Argon2 operation fails.
     pub fn hash_with_defaults<Password: Bytes>(password: &Password) -> Result<Self, Error> {
         Self::hash_interactive(password)
     }
@@ -480,6 +584,12 @@ impl PwHash<Hash, Salt> {
     #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "base64")))]
     /// Parses the `hashed_password` string, returning a new hash instance upon
     /// success. Wraps [`PwHash::from_string`], provided for convenience.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the string is malformed, uses an unsupported
+    /// algorithm or version, omits a required field, or contains an invalid
+    /// encoded value.
     pub fn from_string_with_defaults(hashed_password: &str) -> Result<Self, Error> {
         Self::from_string(hashed_password)
     }

--- a/src/pwhash.rs
+++ b/src/pwhash.rs
@@ -54,10 +54,10 @@
 //!
 //! // Start with a preset, then increase its work factor if your deployment can
 //! // tolerate the extra time. Benchmark the result on the slowest target.
-//! let config = Config::interactive()
+//! let mut config = Config::interactive()
 //!     .with_opslimit(dryoc::constants::CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE + 1);
 //! # // Keep this doctest fast; these minimums are not a production recommendation.
-//! # let config = Config::interactive()
+//! # config = config
 //! #     .with_opslimit(dryoc::constants::CRYPTO_PWHASH_OPSLIMIT_MIN)
 //! #     .with_memlimit(dryoc::constants::CRYPTO_PWHASH_MEMLIMIT_MIN);
 //!

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,4 +1,8 @@
 /// Provides random data up to `len` from the OS's random number generator.
+///
+/// # Panics
+///
+/// Panics if the operating system's random number generator fails.
 pub fn randombytes_buf(len: usize) -> Vec<u8> {
     use rand::TryRng;
     use rand::rngs::SysRng;
@@ -13,6 +17,10 @@ pub fn randombytes_buf(len: usize) -> Vec<u8> {
 
 /// Provides random data up to length of `data` from the OS's random number
 /// generator.
+///
+/// # Panics
+///
+/// Panics if the operating system's random number generator fails.
 pub fn copy_randombytes(dest: &mut [u8]) {
     use rand::TryRng;
     use rand::rngs::SysRng;

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -16,10 +16,10 @@ use sha2::{Digest as DigestImpl, Sha512 as Sha512Impl};
 use crate::constants::CRYPTO_HASH_SHA512_BYTES;
 use crate::types::*;
 
-/// Type alias for SHA512 digest, provided for convience.
+/// Type alias for a SHA-512 digest.
 pub type Digest = StackByteArray<CRYPTO_HASH_SHA512_BYTES>;
 
-/// SHA-512 wrapper, provided for convience.
+/// SHA-512 wrapper.
 pub struct Sha512 {
     hasher: Sha512Impl,
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -14,7 +14,7 @@
 //! The single-part and multi-part variants use slightly different algorithms,
 //! and thus they are not compatible with each other.
 //!
-//! You should use a this module when you want to:
+//! Use this module when you want to:
 //!
 //! * share a message with other parties, and provide a proof that the message
 //!   is authentic
@@ -23,9 +23,9 @@
 //!
 //! The public key of the signer must be known to the verifier.
 //!
-//! One should take note that keys used for signing and encryption should remain
-//! separate. While it's possible to convert Ed25519 keys to X25519 keys (or
-//! derive them from the same seed), one is cautioned against doing so.
+//! Keep signing and encryption keys separate. Although Ed25519 keys can be
+//! converted to X25519 keys or derived from the same seed, doing so couples two
+//! distinct security roles.
 //!
 //! Signing secret keys include both the seed and public key. Use
 //! [`secret_key_to_seed`], [`secret_key_to_public_key`],
@@ -287,6 +287,10 @@ impl<
 {
     /// Constructs a new signing keypair from key slices, consuming them. Does
     /// not check validity or authenticity of keypair.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either slice has the wrong length for its key type.
     pub fn from_slices(public_key: &'a [u8], secret_key: &'a [u8]) -> Result<Self, Error> {
         Ok(Self {
             public_key: PublicKey::try_from(public_key)
@@ -300,7 +304,7 @@ impl<
 #[cfg(any(all(feature = "protected", any(unix, windows)), all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "protected")))]
 pub mod protected {
-    //! #  Protected memory for [`SigningKeyPair`] and [`SignedMessage`].
+    //! # Protected memory for [`SigningKeyPair`] and [`SignedMessage`]
     //!
     //! ## Example
     //! ```
@@ -355,6 +359,15 @@ pub mod protected {
         >
     {
         /// Returns a new locked signing keypair.
+        ///
+        /// # Errors
+        ///
+        /// Returns an OS error if either allocation cannot be locked.
+        ///
+        /// # Panics
+        ///
+        /// Panics if either page-aligned allocation cannot be created or its
+        /// size cannot be represented with guard pages.
         pub fn new_locked_keypair() -> Result<Self, std::io::Error> {
             Ok(Self {
                 public_key: HeapByteArray::<CRYPTO_SIGN_PUBLICKEYBYTES>::new_locked()?,
@@ -363,6 +376,16 @@ pub mod protected {
         }
 
         /// Returns a new randomly generated locked signing keypair.
+        ///
+        /// # Errors
+        ///
+        /// Returns an OS error if either allocation cannot be locked.
+        ///
+        /// # Panics
+        ///
+        /// Panics if either page-aligned allocation cannot be created, its
+        /// size cannot be represented with guard pages, or the operating
+        /// system's random number generator fails.
         pub fn generate_locked_keypair() -> Result<Self, std::io::Error> {
             let mut res = Self::new_locked_keypair()?;
 
@@ -378,6 +401,16 @@ pub mod protected {
         ///
         /// Prefer [`generate_locked_keypair`](Self::generate_locked_keypair).
         /// This method is retained for compatibility.
+        ///
+        /// # Errors
+        ///
+        /// Returns the same errors as
+        /// [`generate_locked_keypair`](Self::generate_locked_keypair).
+        ///
+        /// # Panics
+        ///
+        /// Panics under the same conditions as
+        /// [`generate_locked_keypair`](Self::generate_locked_keypair).
         #[deprecated(note = "use generate_locked_keypair() instead")]
         pub fn gen_locked_keypair() -> Result<Self, std::io::Error> {
             Self::generate_locked_keypair()
@@ -391,6 +424,17 @@ pub mod protected {
         >
     {
         /// Returns a new randomly generated locked, read-only signing keypair.
+        ///
+        /// # Errors
+        ///
+        /// Returns an OS error if either allocation cannot be locked or its
+        /// page permissions cannot be changed to read-only.
+        ///
+        /// # Panics
+        ///
+        /// Panics if either page-aligned allocation cannot be created, its
+        /// size cannot be represented with guard pages, or the operating
+        /// system's random number generator fails.
         pub fn generate_readonly_locked_keypair() -> Result<Self, std::io::Error> {
             let mut public_key = HeapByteArray::<CRYPTO_SIGN_PUBLICKEYBYTES>::new_locked()?;
             let mut secret_key = HeapByteArray::<CRYPTO_SIGN_SECRETKEYBYTES>::new_locked()?;
@@ -411,6 +455,16 @@ pub mod protected {
         /// Prefer
         /// [`generate_readonly_locked_keypair`](Self::generate_readonly_locked_keypair).
         /// This method is retained for compatibility.
+        ///
+        /// # Errors
+        ///
+        /// Returns the same errors as
+        /// [`generate_readonly_locked_keypair`](Self::generate_readonly_locked_keypair).
+        ///
+        /// # Panics
+        ///
+        /// Panics under the same conditions as
+        /// [`generate_readonly_locked_keypair`](Self::generate_readonly_locked_keypair).
         #[deprecated(note = "use generate_readonly_locked_keypair() instead")]
         pub fn gen_readonly_locked_keypair() -> Result<Self, std::io::Error> {
             Self::generate_readonly_locked_keypair()
@@ -443,6 +497,13 @@ impl<
     /// Signs `message` using this keypair, consuming the message, and returning
     /// a new [`SignedMessage`]. The type of `message` should match that of the
     /// target signed message.
+    ///
+    /// # Errors
+    ///
+    /// The fixed-size signature and secret-key types satisfy the current
+    /// implementation's requirements, so this function does not return an
+    /// error for valid type implementations. The [`Result`] is retained for
+    /// compatibility with the underlying signing API.
     pub fn sign<Signature: NewByteArray<CRYPTO_SIGN_BYTES> + Zeroize, Message: Bytes + Zeroize>(
         &self,
         message: Message,
@@ -459,6 +520,12 @@ impl<
 
     /// Signs `message`, putting the result into a [`Vec`]. Convenience wrapper
     /// for [`SigningKeyPair::sign`].
+    ///
+    /// # Errors
+    ///
+    /// The default fixed-size types satisfy the current implementation's
+    /// requirements, so this function does not return an error in normal use.
+    /// The [`Result`] is retained for API compatibility.
     pub fn sign_with_defaults<Message: Bytes>(
         &self,
         message: Message,
@@ -493,6 +560,13 @@ impl IncrementalSigner {
 
     /// Finalizes this incremental signer, returning the signature upon
     /// success.
+    ///
+    /// # Errors
+    ///
+    /// The fixed-size signature and secret-key types satisfy the current
+    /// implementation's requirements, so this function does not return an
+    /// error for valid type implementations. The [`Result`] is retained for
+    /// compatibility with the underlying signing API.
     pub fn finalize<
         Signature: NewByteArray<CRYPTO_SIGN_BYTES>,
         SecretKey: ByteArray<CRYPTO_SIGN_SECRETKEYBYTES>,
@@ -508,6 +582,11 @@ impl IncrementalSigner {
     }
 
     /// Verifies `signature` as a valid signature for this signer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `signature` is not valid for the accumulated
+    /// message and `public_key`.
     pub fn verify<
         Signature: ByteArray<CRYPTO_SIGN_BYTES>,
         PublicKey: ByteArray<CRYPTO_SIGN_PUBLICKEYBYTES>,
@@ -532,6 +611,11 @@ impl<Signature: ByteArray<CRYPTO_SIGN_BYTES> + Zeroize, Message: Bytes + Zeroize
     SignedMessage<Signature, Message>
 {
     /// Verifies that this signed message is valid for `public_key`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the signature is not valid for the message and
+    /// `public_key`.
     pub fn verify<PublicKey: ByteArray<CRYPTO_SIGN_PUBLICKEYBYTES>>(
         &self,
         public_key: &PublicKey,
@@ -553,6 +637,11 @@ impl<
     /// Initializes a [`SignedMessage`] from a slice. Expects the first
     /// [`CRYPTO_SIGN_BYTES`] bytes to contain the message signature,
     /// with the remaining bytes containing the message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `bytes` is shorter than a signature or the
+    /// signature cannot be converted to the requested output type.
     pub fn from_bytes(bytes: &'a [u8]) -> Result<Self, Error> {
         if bytes.len() < CRYPTO_SIGN_BYTES {
             Err(dryoc_error!(format!(


### PR DESCRIPTION
## Summary

Audit and overhaul dryoc's README and public API documentation for correctness, clarity, and completeness.

The changes align Classic and Rustaceous guidance with the implemented behavior, add actionable error and panic contracts, and remove filler and unsupported security claims.

## User Impact

Users now get accurate guidance for key and nonce reuse, sealed-box anonymity, shared-key authentication, password hashing, keyed BLAKE2b, and SHA-2/SHA-3 compatibility. Fallible APIs explain whether failures come from malformed inputs, invalid lengths, authentication, low-order keys, protected-memory operations, or stream state.

Examples and overview pages are shorter, safer to copy, and easier to navigate.

## Root Cause

Documentation evolved incrementally across two API surfaces. This left several concepts conflated, including HMAC versus one-time authentication and keyed BLAKE2b versus HMAC. Many `Result`-returning APIs also described success without documenting concrete failure conditions.

The audit additionally exposed parser unwraps and redundant fixed-size assertions that made the documented panic behavior worse than necessary.

## Fix

- rewrite the README and crate overview around concrete capabilities and limitations
- correct HMAC, Poly1305, Argon2, generic hashing, sealed-box, secretbox, nonce, and stream guidance
- distinguish libsodium-compatible operations from dryoc extensions
- add `# Errors` and `# Panics` sections across Classic and Rustaceous public APIs
- document protected-memory allocation, locking, and protection failures
- make password-hashing examples use production-appropriate visible settings
- return errors for missing password-hash fields instead of unwrapping them
- remove redundant HChaCha20 length assertions enforced by fixed-size types
- fix terminology, grammar, local links, and the libsodium SHA-2 link

## Validation

- `cargo test`
- `cargo test --features serde`
- `cargo test --features wincode`
- `cargo test --no-default-features`
- `cargo test --doc`
- `cargo clippy --features default -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
- `cargo +nightly fmt --all -- --check`
- `RUSTDOCFLAGS='-D warnings' cargo +nightly doc --no-deps --features nightly,serde,base64,wincode`
- local Markdown target and external documentation link checks
