### PR TITLE
feat!: add structured error types

### DIFF
--- a/src/argon2/mod.rs
+++ b/src/argon2/mod.rs
@@ -223,35 +223,60 @@ impl<'a> Argon2Context<'a> {
         parallelism: u32,
     ) -> Result<Self, Error> {
         // validate the inputs
-        validate!(ARGON2_MIN_OUTLEN, ARGON2_MAX_OUTLEN, output.len(), "output");
-        validate!(
+        validate_length!(
+            ARGON2_MIN_OUTLEN,
+            ARGON2_MAX_OUTLEN,
+            output.len(),
+            crate::ErrorContext::Output
+        );
+        validate_length!(
             ARGON2_MIN_PWD_LENGTH,
             ARGON2_MAX_PWD_LENGTH,
             password.len(),
-            "password"
+            crate::ErrorContext::Password
         );
-        validate!(
+        validate_length!(
             ARGON2_MIN_SALT_LENGTH,
             ARGON2_MAX_SALT_LENGTH,
             salt.len(),
-            "salt"
+            crate::ErrorContext::PasswordHashSalt
         );
 
         if let Some(secret) = secret {
-            validate!(ARGON2_MIN_SECRET, ARGON2_MAX_SECRET, secret.len(), "secret");
+            validate_length!(
+                ARGON2_MIN_SECRET,
+                ARGON2_MAX_SECRET,
+                secret.len(),
+                crate::ErrorContext::Secret
+            );
         }
         if let Some(ad) = ad {
-            validate!(ARGON2_MIN_AD_LENGTH, ARGON2_MAX_AD_LENGTH, ad.len(), "ad");
+            validate_length!(
+                ARGON2_MIN_AD_LENGTH,
+                ARGON2_MAX_AD_LENGTH,
+                ad.len(),
+                crate::ErrorContext::AssociatedData
+            );
         }
 
         validate!(
             ARGON2_MIN_LANES,
             ARGON2_MAX_LANES,
             parallelism,
-            "parallelism"
+            crate::ErrorContext::Parallelism
         );
-        validate!(ARGON2_MIN_MEMORY, ARGON2_MAX_MEMORY, m_cost, "m_cost");
-        validate!(ARGON2_MIN_TIME, ARGON2_MAX_TIME, t_cost, "t_cost");
+        validate!(
+            ARGON2_MIN_MEMORY,
+            ARGON2_MAX_MEMORY,
+            m_cost,
+            crate::ErrorContext::MemoryCost
+        );
+        validate!(
+            ARGON2_MIN_TIME,
+            ARGON2_MAX_TIME,
+            t_cost,
+            crate::ErrorContext::TimeCost
+        );
 
         Ok(Self {
             output,

--- a/src/argon2/mod.rs
+++ b/src/argon2/mod.rs
@@ -259,19 +259,19 @@ impl<'a> Argon2Context<'a> {
             );
         }
 
-        validate!(
+        validate_value!(
             ARGON2_MIN_LANES,
             ARGON2_MAX_LANES,
             parallelism,
             crate::ErrorContext::Parallelism
         );
-        validate!(
+        validate_value!(
             ARGON2_MIN_MEMORY,
             ARGON2_MAX_MEMORY,
             m_cost,
             crate::ErrorContext::MemoryCost
         );
-        validate!(
+        validate_value!(
             ARGON2_MIN_TIME,
             ARGON2_MAX_TIME,
             t_cost,
@@ -685,6 +685,72 @@ mod tests {
     fn secret_working_types_zeroize_on_drop() {
         assert!(std::mem::needs_drop::<Block>());
         assert!(std::mem::needs_drop::<Argon2Instance>());
+    }
+
+    #[test]
+    fn context_rejects_invalid_parameters_with_specific_errors() {
+        fn context_error(
+            output_len: usize,
+            salt_len: usize,
+            t_cost: u32,
+            m_cost: u32,
+            parallelism: u32,
+        ) -> Error {
+            let mut output = vec![0u8; output_len];
+            let salt = vec![0u8; salt_len];
+            match Argon2Context::new(
+                &mut output,
+                b"password",
+                &salt,
+                None,
+                None,
+                t_cost,
+                m_cost,
+                parallelism,
+            ) {
+                Ok(_) => panic!("invalid Argon2 parameters should fail"),
+                Err(error) => error,
+            }
+        }
+
+        let cases = [
+            (
+                context_error(ARGON2_MIN_OUTLEN - 1, ARGON2_MIN_SALT_LENGTH, 1, 8, 1),
+                crate::ErrorContext::Output,
+            ),
+            (
+                context_error(ARGON2_MIN_OUTLEN, ARGON2_MIN_SALT_LENGTH - 1, 1, 8, 1),
+                crate::ErrorContext::PasswordHashSalt,
+            ),
+            (
+                context_error(ARGON2_MIN_OUTLEN, ARGON2_MIN_SALT_LENGTH, 1, 8, 0),
+                crate::ErrorContext::Parallelism,
+            ),
+            (
+                context_error(
+                    ARGON2_MIN_OUTLEN,
+                    ARGON2_MIN_SALT_LENGTH,
+                    1,
+                    ARGON2_MIN_MEMORY - 1,
+                    1,
+                ),
+                crate::ErrorContext::MemoryCost,
+            ),
+            (
+                context_error(ARGON2_MIN_OUTLEN, ARGON2_MIN_SALT_LENGTH, 0, 8, 1),
+                crate::ErrorContext::TimeCost,
+            ),
+        ];
+
+        for (error, expected_context) in cases {
+            let context = match error {
+                Error::InvalidLength { context, .. } | Error::InvalidValue { context, .. } => {
+                    context
+                }
+                other => panic!("unexpected Argon2 error: {other:?}"),
+            };
+            assert_eq!(context, expected_context);
+        }
     }
 
     #[cfg(feature = "nightly")]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -197,7 +197,7 @@ impl Auth {
         {
             Ok(())
         } else {
-            Err(dryoc_error!("authentication codes do not match"))
+            Err(Error::AuthenticationFailed)
         }
     }
 }

--- a/src/blake2b/blake2b_simd.rs
+++ b/src/blake2b/blake2b_simd.rs
@@ -469,20 +469,17 @@ impl State {
         personal: Option<&[u8; PERSONALBYTES]>,
     ) -> Result<State, Error> {
         if outlen == 0 || outlen as usize > OUTBYTES {
-            return Err(dryoc_error!(format!("invalid blake2b outlen: {}", outlen)));
+            return Err(
+                length_error!(crate::ErrorContext::Blake2bOutput, outlen as usize, range 1, OUTBYTES),
+            );
         }
 
-        let key_length: u8 = match key {
-            Some(key) => key.len() as u8,
-            None => 0,
-        };
+        let key_length = key.map_or(0, <[u8]>::len);
 
-        if key_length > KEYBYTES as u8 {
-            return Err(dryoc_error!(format!(
-                "invalid blake2b key length: {} max: {}",
-                key_length, KEYBYTES
-            )));
+        if key_length > KEYBYTES {
+            return Err(length_error!(crate::ErrorContext::Blake2bKey, key_length, max KEYBYTES));
         }
+        let key_length = key_length as u8;
 
         let salt = match salt {
             Some(salt) => *salt,
@@ -551,15 +548,15 @@ impl State {
 
     pub(crate) fn finalize(mut self, output: &mut [u8]) -> Result<(), Error> {
         if output.is_empty() || output.len() > OUTBYTES {
-            return Err(dryoc_error!(format!(
-                "invalid output length {}, should be <= {}",
-                output.len(),
-                OUTBYTES
-            )));
+            return Err(
+                length_error!(crate::ErrorContext::Blake2bOutput, output.len(), range 1, OUTBYTES),
+            );
         }
 
         if self.is_lastblock() {
-            return Err(dryoc_error!("already on last block"));
+            return Err(Error::InvalidState {
+                context: crate::ErrorContext::Blake2b,
+            });
         }
 
         increment_counter(&mut self.t, self.buflen);
@@ -604,11 +601,7 @@ impl State {
 
 pub fn hash(output: &mut [u8], input: &[u8], key: Option<&[u8]>) -> Result<(), Error> {
     if output.len() > OUTBYTES {
-        return Err(dryoc_error!(format!(
-            "output length {} greater than max {}",
-            output.len(),
-            OUTBYTES
-        )));
+        return Err(length_error!(crate::ErrorContext::Blake2bOutput, output.len(), max OUTBYTES));
     }
 
     let mut state = State::init(output.len() as u8, key, None, None)?;
@@ -726,6 +719,21 @@ mod tests {
 
             assert_eq!(vector.out, hex::encode(output));
         }
+    }
+
+    #[test]
+    fn rejects_key_lengths_that_do_not_fit_in_u8() {
+        let key = [0u8; 256];
+        let error = State::init(64, Some(&key), None, None).expect_err("key should be rejected");
+
+        assert!(matches!(
+            error,
+            Error::InvalidLength {
+                context: crate::ErrorContext::Blake2bKey,
+                actual: 256,
+                constraint: crate::LengthConstraint::AtMost(KEYBYTES),
+            }
+        ));
     }
 
     #[cfg(feature = "nightly")]

--- a/src/blake2b/blake2b_simd.rs
+++ b/src/blake2b/blake2b_simd.rs
@@ -554,9 +554,7 @@ impl State {
         }
 
         if self.is_lastblock() {
-            return Err(Error::InvalidState {
-                context: crate::ErrorContext::Blake2b,
-            });
+            return Err(Error::invalid_state(crate::ErrorContext::Blake2b));
         }
 
         increment_counter(&mut self.t, self.buflen);

--- a/src/blake2b/blake2b_soft.rs
+++ b/src/blake2b/blake2b_soft.rs
@@ -174,20 +174,17 @@ impl State {
         personal: Option<&[u8; PERSONALBYTES]>,
     ) -> Result<State, Error> {
         if outlen == 0 || outlen as usize > OUTBYTES {
-            return Err(dryoc_error!(format!("invalid blake2b outlen: {}", outlen)));
+            return Err(
+                length_error!(crate::ErrorContext::Blake2bOutput, outlen as usize, range 1, OUTBYTES),
+            );
         }
 
-        let key_length: u8 = match key {
-            Some(key) => key.len() as u8,
-            None => 0,
-        };
+        let key_length = key.map_or(0, <[u8]>::len);
 
-        if key_length > KEYBYTES as u8 {
-            return Err(dryoc_error!(format!(
-                "invalid blake2b key length: {} max: {}",
-                key_length, KEYBYTES
-            )));
+        if key_length > KEYBYTES {
+            return Err(length_error!(crate::ErrorContext::Blake2bKey, key_length, max KEYBYTES));
         }
+        let key_length = key_length as u8;
 
         let salt = match salt {
             Some(salt) => *salt,
@@ -265,15 +262,15 @@ impl State {
 
     pub(crate) fn finalize(mut self, output: &mut [u8]) -> Result<(), Error> {
         if output.is_empty() || output.len() > OUTBYTES {
-            return Err(dryoc_error!(format!(
-                "invalid output length {}, should be <= {}",
-                output.len(),
-                OUTBYTES
-            )));
+            return Err(
+                length_error!(crate::ErrorContext::Blake2bOutput, output.len(), range 1, OUTBYTES),
+            );
         }
 
         if self.is_lastblock() {
-            return Err(dryoc_error!("already on last block"));
+            return Err(Error::InvalidState {
+                context: crate::ErrorContext::Blake2b,
+            });
         }
 
         if self.buf.len() > BLOCKBYTES {
@@ -333,11 +330,7 @@ impl State {
 
 pub fn hash(output: &mut [u8], input: &[u8], key: Option<&[u8]>) -> Result<(), Error> {
     if output.len() > OUTBYTES {
-        return Err(dryoc_error!(format!(
-            "output length {} greater than max {}",
-            output.len(),
-            OUTBYTES
-        )));
+        return Err(length_error!(crate::ErrorContext::Blake2bOutput, output.len(), max OUTBYTES));
     }
 
     let mut state = State::init(output.len() as u8, key, None, None)?;
@@ -433,6 +426,21 @@ mod tests {
 
             assert_eq!(vector.out, hex::encode(output));
         }
+    }
+
+    #[test]
+    fn rejects_key_lengths_that_do_not_fit_in_u8() {
+        let key = [0u8; 256];
+        let error = State::init(64, Some(&key), None, None).expect_err("key should be rejected");
+
+        assert!(matches!(
+            error,
+            Error::InvalidLength {
+                context: crate::ErrorContext::Blake2bKey,
+                actual: 256,
+                constraint: crate::LengthConstraint::AtMost(KEYBYTES),
+            }
+        ));
     }
 
     #[cfg(feature = "nightly")]

--- a/src/blake2b/blake2b_soft.rs
+++ b/src/blake2b/blake2b_soft.rs
@@ -268,9 +268,7 @@ impl State {
         }
 
         if self.is_lastblock() {
-            return Err(Error::InvalidState {
-                context: crate::ErrorContext::Blake2b,
-            });
+            return Err(Error::invalid_state(crate::ErrorContext::Blake2b));
         }
 
         if self.buf.len() > BLOCKBYTES {

--- a/src/bytes_serde.rs
+++ b/src/bytes_serde.rs
@@ -176,8 +176,7 @@ mod protected {
                 where
                     A: SeqAccess<'de>,
                 {
-                    let mut arr =
-                        HeapBytes::generate_locked().expect("couldn't create locked bytes");
+                    let mut arr = HeapBytes::new_locked().map_err(A::Error::custom)?;
                     let mut idx: usize = 0;
                     let size_hint = seq.size_hint().unwrap_or(1);
                     arr.resize(size_hint, 0);
@@ -197,8 +196,7 @@ mod protected {
                 where
                     E: Error,
                 {
-                    Ok(HeapBytes::from_slice_into_locked(v)
-                        .expect("couldn't copy slice into locked bytes"))
+                    HeapBytes::from_slice_into_locked(v).map_err(E::custom)
                 }
             }
 
@@ -224,8 +222,8 @@ mod protected {
                 where
                     A: SeqAccess<'de>,
                 {
-                    let mut arr = HeapByteArray::<LENGTH>::generate_locked()
-                        .expect("couldn't create locked bytes");
+                    let mut arr =
+                        HeapByteArray::<LENGTH>::new_locked().map_err(A::Error::custom)?;
                     let mut idx: usize = 0;
                     while let Some(elem) = seq.next_element()? {
                         if idx >= LENGTH {
@@ -249,8 +247,7 @@ mod protected {
                     if v.len() != LENGTH {
                         Err(Error::invalid_length(v.len(), &stringify!(LENGTH)))
                     } else {
-                        Ok(HeapByteArray::<LENGTH>::from_slice_into_locked(v)
-                            .expect("couldn't copy slice into locked bytes"))
+                        HeapByteArray::<LENGTH>::from_slice_into_locked(v).map_err(E::custom)
                     }
                 }
             }

--- a/src/classic/crypto_aead_xchacha20poly1305_ietf.rs
+++ b/src/classic/crypto_aead_xchacha20poly1305_ietf.rs
@@ -95,11 +95,7 @@ fn validate_output_len(
     context: crate::ErrorContext,
 ) -> Result<(), Error> {
     if output_len != expected_len {
-        Err(Error::InvalidLength {
-            context,
-            actual: output_len,
-            constraint: crate::error::LengthConstraint::Exact(expected_len),
-        })
+        Err(length_error!(context, output_len, exact expected_len))
     } else {
         Ok(())
     }
@@ -110,13 +106,7 @@ fn message_len_from_combined_len(
     context: crate::ErrorContext,
 ) -> Result<usize, Error> {
     if combined_len < CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES {
-        Err(Error::InvalidLength {
-            context,
-            actual: combined_len,
-            constraint: crate::error::LengthConstraint::AtLeast(
-                CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES,
-            ),
-        })
+        Err(length_error!(context, combined_len, min CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES))
     } else {
         let message_len = combined_len - CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES;
         validate_message_len(message_len)?;

--- a/src/classic/crypto_aead_xchacha20poly1305_ietf.rs
+++ b/src/classic/crypto_aead_xchacha20poly1305_ietf.rs
@@ -79,32 +79,44 @@ pub fn crypto_aead_xchacha20poly1305_ietf_keygen() -> Key {
 
 fn validate_message_len(message_len: usize) -> Result<(), Error> {
     if message_len > CRYPTO_AEAD_XCHACHA20POLY1305_IETF_MESSAGEBYTES_MAX {
-        Err(dryoc_error!(format!(
-            "message length {} exceeds max message length {}",
-            message_len, CRYPTO_AEAD_XCHACHA20POLY1305_IETF_MESSAGEBYTES_MAX
-        )))
+        Err(length_error!(
+            crate::ErrorContext::Message,
+            message_len,
+            max CRYPTO_AEAD_XCHACHA20POLY1305_IETF_MESSAGEBYTES_MAX
+        ))
     } else {
         Ok(())
     }
 }
 
-fn validate_output_len(output_len: usize, expected_len: usize, name: &str) -> Result<(), Error> {
+fn validate_output_len(
+    output_len: usize,
+    expected_len: usize,
+    context: crate::ErrorContext,
+) -> Result<(), Error> {
     if output_len != expected_len {
-        Err(dryoc_error!(format!(
-            "{} length invalid ({} != {})",
-            name, output_len, expected_len
-        )))
+        Err(Error::InvalidLength {
+            context,
+            actual: output_len,
+            constraint: crate::error::LengthConstraint::Exact(expected_len),
+        })
     } else {
         Ok(())
     }
 }
 
-fn message_len_from_combined_len(combined_len: usize, name: &str) -> Result<usize, Error> {
+fn message_len_from_combined_len(
+    combined_len: usize,
+    context: crate::ErrorContext,
+) -> Result<usize, Error> {
     if combined_len < CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES {
-        Err(dryoc_error!(format!(
-            "{} length {} less than minimum {}",
-            name, combined_len, CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES
-        )))
+        Err(Error::InvalidLength {
+            context,
+            actual: combined_len,
+            constraint: crate::error::LengthConstraint::AtLeast(
+                CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES,
+            ),
+        })
     } else {
         let message_len = combined_len - CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES;
         validate_message_len(message_len)?;
@@ -168,7 +180,7 @@ fn verify_mac(mac: &Mac, computed_mac: &Mac) -> Result<(), Error> {
     if mac.ct_eq(computed_mac).unwrap_u8() == 1 {
         Ok(())
     } else {
-        Err(dryoc_error!("decryption error (authentication failure)"))
+        Err(Error::AuthenticationFailed)
     }
 }
 
@@ -185,7 +197,11 @@ pub fn crypto_aead_xchacha20poly1305_ietf_encrypt_detached(
     key: &Key,
 ) -> Result<(), Error> {
     validate_message_len(message.len())?;
-    validate_output_len(ciphertext.len(), message.len(), "ciphertext")?;
+    validate_output_len(
+        ciphertext.len(),
+        message.len(),
+        crate::ErrorContext::Ciphertext,
+    )?;
 
     let associated_data = associated_data.unwrap_or(&[]);
     let mut cipher = chacha20_xietf_ext(nonce, key);
@@ -234,7 +250,11 @@ pub fn crypto_aead_xchacha20poly1305_ietf_decrypt_detached(
     key: &Key,
 ) -> Result<(), Error> {
     validate_message_len(ciphertext.len())?;
-    validate_output_len(message.len(), ciphertext.len(), "message")?;
+    validate_output_len(
+        message.len(),
+        ciphertext.len(),
+        crate::ErrorContext::Message,
+    )?;
 
     let associated_data = associated_data.unwrap_or(&[]);
     let mut cipher = chacha20_xietf_ext(nonce, key);
@@ -284,7 +304,7 @@ pub fn crypto_aead_xchacha20poly1305_ietf_encrypt(
     validate_output_len(
         ciphertext.len(),
         message.len() + CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES,
-        "ciphertext",
+        crate::ErrorContext::Ciphertext,
     )?;
 
     let (ciphertext, mac) = ciphertext.split_at_mut(message.len());
@@ -309,8 +329,9 @@ pub fn crypto_aead_xchacha20poly1305_ietf_decrypt(
     nonce: &Nonce,
     key: &Key,
 ) -> Result<(), Error> {
-    let message_len = message_len_from_combined_len(ciphertext.len(), "ciphertext")?;
-    validate_output_len(message.len(), message_len, "message")?;
+    let message_len =
+        message_len_from_combined_len(ciphertext.len(), crate::ErrorContext::Ciphertext)?;
+    validate_output_len(message.len(), message_len, crate::ErrorContext::Message)?;
 
     let (ciphertext, mac) = ciphertext.split_at(message_len);
     let mac = ByteArray::as_array(mac);
@@ -334,7 +355,7 @@ pub fn crypto_aead_xchacha20poly1305_ietf_encrypt_inplace(
     nonce: &Nonce,
     key: &Key,
 ) -> Result<(), Error> {
-    let message_len = message_len_from_combined_len(data.len(), "data")?;
+    let message_len = message_len_from_combined_len(data.len(), crate::ErrorContext::Data)?;
     let (data, mac) = data.split_at_mut(message_len);
     let mac = MutByteArray::as_mut_array(mac);
     crypto_aead_xchacha20poly1305_ietf_encrypt_detached_inplace(
@@ -356,7 +377,7 @@ pub fn crypto_aead_xchacha20poly1305_ietf_decrypt_inplace(
     nonce: &Nonce,
     key: &Key,
 ) -> Result<(), Error> {
-    let message_len = message_len_from_combined_len(data.len(), "data")?;
+    let message_len = message_len_from_combined_len(data.len(), crate::ErrorContext::Data)?;
     let (data, mac) = data.split_at_mut(message_len);
     let mac = ByteArray::as_array(mac);
     crypto_aead_xchacha20poly1305_ietf_decrypt_detached_inplace(

--- a/src/classic/crypto_auth_hmac_impl.rs
+++ b/src/classic/crypto_auth_hmac_impl.rs
@@ -133,7 +133,7 @@ where
     if valid == 1 {
         Ok(())
     } else {
-        Err(dryoc_error!("authentication codes do not match"))
+        Err(Error::AuthenticationFailed)
     }
 }
 

--- a/src/classic/crypto_auth_hmacsha512256.rs
+++ b/src/classic/crypto_auth_hmacsha512256.rs
@@ -78,7 +78,7 @@ pub fn crypto_auth_hmacsha512256_verify(mac: &Mac, input: &[u8], key: &Key) -> R
     if valid == 1 {
         Ok(())
     } else {
-        Err(dryoc_error!("authentication codes do not match"))
+        Err(Error::AuthenticationFailed)
     }
 }
 

--- a/src/classic/crypto_box.rs
+++ b/src/classic/crypto_box.rs
@@ -582,6 +582,53 @@ mod tests {
     }
 
     #[test]
+    fn test_crypto_box_seal_rejects_mismatched_buffers() {
+        let (recipient_public_key, recipient_secret_key) = crypto_box_keypair();
+        let message = b"sealed box buffer validation";
+
+        let mut short_ciphertext = vec![0u8; message.len() + CRYPTO_BOX_SEALBYTES - 1];
+        assert!(matches!(
+            crypto_box_seal(&mut short_ciphertext, message, &recipient_public_key),
+            Err(Error::InvalidLength {
+                context: crate::ErrorContext::Ciphertext,
+                actual,
+                constraint: crate::LengthConstraint::Exact(expected),
+            }) if actual == short_ciphertext.len()
+                && expected == message.len() + CRYPTO_BOX_SEALBYTES
+        ));
+
+        let short_sealed_box = vec![0u8; CRYPTO_BOX_SEALBYTES - 1];
+        assert!(matches!(
+            crypto_box_seal_open(
+                &mut [],
+                &short_sealed_box,
+                &recipient_public_key,
+                &recipient_secret_key,
+            ),
+            Err(Error::InvalidLength {
+                context: crate::ErrorContext::Ciphertext,
+                actual,
+                constraint: crate::LengthConstraint::AtLeast(CRYPTO_BOX_SEALBYTES),
+            }) if actual == short_sealed_box.len()
+        ));
+
+        let sealed_box = vec![0u8; CRYPTO_BOX_SEALBYTES + 1];
+        assert!(matches!(
+            crypto_box_seal_open(
+                &mut [],
+                &sealed_box,
+                &recipient_public_key,
+                &recipient_secret_key,
+            ),
+            Err(Error::InvalidLength {
+                context: crate::ErrorContext::Message,
+                actual: 0,
+                constraint: crate::LengthConstraint::Exact(1),
+            })
+        ));
+    }
+
+    #[test]
     fn test_crypto_box_rejects_low_order_public_keys() {
         let (_, secret_key) = crypto_box_keypair();
         let nonce = Nonce::default();

--- a/src/classic/crypto_box.rs
+++ b/src/classic/crypto_box.rs
@@ -175,17 +175,15 @@ pub fn crypto_box_easy(
     sender_secret_key: &SecretKey,
 ) -> Result<(), Error> {
     if message.len() > CRYPTO_BOX_MESSAGEBYTES_MAX {
-        Err(dryoc_error!(format!(
-            "message length {} exceeds max message length {}",
-            message.len(),
-            CRYPTO_BOX_MESSAGEBYTES_MAX
-        )))
+        Err(
+            length_error!(crate::ErrorContext::Message, message.len(), max CRYPTO_BOX_MESSAGEBYTES_MAX),
+        )
     } else if ciphertext.len() != message.len() + CRYPTO_BOX_MACBYTES {
-        Err(dryoc_error!(format!(
-            "ciphertext length invalid ({} != {})",
+        Err(length_error!(
+            crate::ErrorContext::Ciphertext,
             ciphertext.len(),
-            message.len() + CRYPTO_BOX_MACBYTES
-        )))
+            exact message.len() + CRYPTO_BOX_MACBYTES
+        ))
     } else {
         let (mac, ciphertext) = ciphertext.split_at_mut(CRYPTO_BOX_MACBYTES);
         let mac = MutByteArray::as_mut_array(mac);
@@ -223,11 +221,11 @@ pub fn crypto_box_seal(
     recipient_public_key: &PublicKey,
 ) -> Result<(), Error> {
     if ciphertext.len() != message.len() + CRYPTO_BOX_SEALBYTES {
-        Err(dryoc_error!(format!(
-            "ciphertext length invalid ({} != {})",
+        Err(length_error!(
+            crate::ErrorContext::Ciphertext,
             ciphertext.len(),
-            message.len() + CRYPTO_BOX_SEALBYTES,
-        )))
+            exact message.len() + CRYPTO_BOX_SEALBYTES
+        ))
     } else {
         let mut nonce = Nonce::new_byte_array();
         let (mut epk, esk) = crypto_box_keypair();
@@ -271,17 +269,9 @@ pub fn crypto_box_easy_inplace(
     sender_secret_key: &SecretKey,
 ) -> Result<(), Error> {
     if data.len() < CRYPTO_BOX_MACBYTES {
-        Err(dryoc_error!(format!(
-            "Message length {} less than {}, impossibly small",
-            data.len(),
-            CRYPTO_BOX_MACBYTES
-        )))
+        Err(length_error!(crate::ErrorContext::Data, data.len(), min CRYPTO_BOX_MACBYTES))
     } else if data.len() > CRYPTO_BOX_MESSAGEBYTES_MAX {
-        Err(dryoc_error!(format!(
-            "Message length {} exceeds max message length {}",
-            data.len(),
-            CRYPTO_BOX_MESSAGEBYTES_MAX
-        )))
+        Err(length_error!(crate::ErrorContext::Data, data.len(), max CRYPTO_BOX_MESSAGEBYTES_MAX))
     } else {
         data.rotate_right(CRYPTO_BOX_MACBYTES);
 
@@ -368,17 +358,15 @@ pub fn crypto_box_open_easy(
     recipient_secret_key: &SecretKey,
 ) -> Result<(), Error> {
     if ciphertext.len() < CRYPTO_BOX_MACBYTES {
-        Err(dryoc_error!(format!(
-            "Impossibly small box ({} < {}",
-            ciphertext.len(),
-            CRYPTO_BOX_MACBYTES
-        )))
+        Err(
+            length_error!(crate::ErrorContext::Ciphertext, ciphertext.len(), min CRYPTO_BOX_MACBYTES),
+        )
     } else if message.len() != ciphertext.len() - CRYPTO_BOX_MACBYTES {
-        Err(dryoc_error!(format!(
-            "message length invalid ({} != {})",
+        Err(length_error!(
+            crate::ErrorContext::Message,
             message.len(),
-            ciphertext.len() - CRYPTO_BOX_MACBYTES
-        )))
+            exact ciphertext.len() - CRYPTO_BOX_MACBYTES
+        ))
     } else {
         let (mac, ciphertext) = ciphertext.split_at(CRYPTO_BOX_MACBYTES);
         let mac = ByteArray::as_array(mac);
@@ -410,17 +398,15 @@ pub fn crypto_box_seal_open(
     recipient_secret_key: &SecretKey,
 ) -> Result<(), Error> {
     if ciphertext.len() < CRYPTO_BOX_SEALBYTES {
-        Err(dryoc_error!(format!(
-            "Impossibly small box ({} < {}",
-            ciphertext.len(),
-            CRYPTO_BOX_SEALBYTES,
-        )))
+        Err(
+            length_error!(crate::ErrorContext::Ciphertext, ciphertext.len(), min CRYPTO_BOX_SEALBYTES),
+        )
     } else if message.len() != ciphertext.len() - CRYPTO_BOX_SEALBYTES {
-        Err(dryoc_error!(format!(
-            "message length invalid ({} != {}",
+        Err(length_error!(
+            crate::ErrorContext::Message,
             message.len(),
-            ciphertext.len() - CRYPTO_BOX_SEALBYTES,
-        )))
+            exact ciphertext.len() - CRYPTO_BOX_SEALBYTES
+        ))
     } else {
         let mut nonce = Nonce::new_byte_array();
         let mut epk = PublicKey::new_byte_array();
@@ -457,11 +443,7 @@ pub fn crypto_box_open_easy_inplace(
     recipient_secret_key: &SecretKey,
 ) -> Result<(), Error> {
     if data.len() < CRYPTO_BOX_MACBYTES {
-        Err(dryoc_error!(format!(
-            "Impossibly small box ({} < {}",
-            data.len(),
-            CRYPTO_BOX_MACBYTES
-        )))
+        Err(length_error!(crate::ErrorContext::Data, data.len(), min CRYPTO_BOX_MACBYTES))
     } else {
         let (mac, d) = data.split_at_mut(CRYPTO_BOX_MACBYTES);
         let mac = ByteArray::as_array(mac);

--- a/src/classic/crypto_core.rs
+++ b/src/classic/crypto_core.rs
@@ -56,9 +56,7 @@ pub fn crypto_scalarmult(
     crypto_scalarmult_curve25519(q, n, p);
 
     if q.ct_eq(&[0u8; CRYPTO_SCALARMULT_BYTES]).into() {
-        Err(Error::InvalidKey {
-            context: crate::ErrorContext::Curve25519PublicKey,
-        })
+        Err(Error::invalid_key(crate::ErrorContext::Curve25519PublicKey))
     } else {
         Ok(())
     }

--- a/src/classic/crypto_core.rs
+++ b/src/classic/crypto_core.rs
@@ -54,7 +54,9 @@ pub fn crypto_scalarmult(
     crypto_scalarmult_curve25519(q, n, p);
 
     if q.ct_eq(&[0u8; CRYPTO_SCALARMULT_BYTES]).into() {
-        Err(dryoc_error!("unacceptable Curve25519 public key"))
+        Err(Error::InvalidKey {
+            context: crate::ErrorContext::Curve25519PublicKey,
+        })
     } else {
         Ok(())
     }

--- a/src/classic/crypto_kdf.rs
+++ b/src/classic/crypto_kdf.rs
@@ -133,12 +133,12 @@ pub fn crypto_kdf_derive_from_key(
     main_key: &Key,
 ) -> Result<(), Error> {
     if subkey.len() < CRYPTO_KDF_BLAKE2B_BYTES_MIN || subkey.len() > CRYPTO_KDF_BLAKE2B_BYTES_MAX {
-        Err(dryoc_error!(format!(
-            "invalid subkey length {}, should be at least {} and no more than {}",
+        Err(length_error!(
+            crate::ErrorContext::Subkey,
             subkey.len(),
-            CRYPTO_KDF_BLAKE2B_BYTES_MIN,
+            range CRYPTO_KDF_BLAKE2B_BYTES_MIN,
             CRYPTO_KDF_BLAKE2B_BYTES_MAX
-        )))
+        ))
     } else {
         let mut ctx_padded = [0u8; CRYPTO_GENERICHASH_BLAKE2B_PERSONALBYTES];
         let mut salt = [0u8; CRYPTO_GENERICHASH_BLAKE2B_SALTBYTES];
@@ -162,10 +162,7 @@ fn validate_hkdf_output_len(
     max_len: usize,
 ) -> Result<(), Error> {
     if output_len < min_len || output_len > max_len {
-        Err(dryoc_error!(format!(
-            "invalid output length {}, should be at least {} and no more than {}",
-            output_len, min_len, max_len
-        )))
+        Err(length_error!(crate::ErrorContext::Output, output_len, range min_len, max_len))
     } else {
         Ok(())
     }

--- a/src/classic/crypto_kdf.rs
+++ b/src/classic/crypto_kdf.rs
@@ -301,6 +301,30 @@ where
 mod tests {
     use super::*;
 
+    #[test]
+    fn test_crypto_kdf_rejects_invalid_subkey_lengths() {
+        let context = Context::default();
+        let key = Key::default();
+
+        for length in [
+            CRYPTO_KDF_BLAKE2B_BYTES_MIN - 1,
+            CRYPTO_KDF_BLAKE2B_BYTES_MAX + 1,
+        ] {
+            let mut subkey = vec![0u8; length];
+            assert!(matches!(
+                crypto_kdf_derive_from_key(&mut subkey, 0, &context, &key),
+                Err(Error::InvalidLength {
+                    context: crate::ErrorContext::Subkey,
+                    actual,
+                    constraint: crate::LengthConstraint::Between {
+                        min: CRYPTO_KDF_BLAKE2B_BYTES_MIN,
+                        max: CRYPTO_KDF_BLAKE2B_BYTES_MAX,
+                    },
+                }) if actual == length
+            ));
+        }
+    }
+
     fn bytes_in_range(start: u8, end_inclusive: u8) -> Vec<u8> {
         (start..=end_inclusive).collect()
     }

--- a/src/classic/crypto_onetimeauth.rs
+++ b/src/classic/crypto_onetimeauth.rs
@@ -79,7 +79,7 @@ fn crypto_onetimeauth_poly1305_verify(mac: &Mac, input: &[u8], key: &Key) -> Res
     if mac.ct_eq(&computed_mac).unwrap_u8() == 1 {
         Ok(())
     } else {
-        Err(dryoc_error!("authentication codes do not match"))
+        Err(Error::AuthenticationFailed)
     }
 }
 

--- a/src/classic/crypto_pwhash.rs
+++ b/src/classic/crypto_pwhash.rs
@@ -125,13 +125,13 @@ pub fn crypto_pwhash(
     memlimit: usize,
     algorithm: PasswordHashAlgorithm,
 ) -> Result<(), Error> {
-    validate!(
+    validate_value!(
         CRYPTO_PWHASH_OPSLIMIT_MIN,
         CRYPTO_PWHASH_OPSLIMIT_MAX,
         opslimit,
         crate::ErrorContext::OperationsLimit
     );
-    validate!(
+    validate_value!(
         CRYPTO_PWHASH_MEMLIMIT_MIN,
         CRYPTO_PWHASH_MEMLIMIT_MAX,
         memlimit,
@@ -273,13 +273,13 @@ pub(crate) fn convert_costs(opslimit: u64, memlimit: usize) -> (u32, u32) {
 #[cfg(any(feature = "base64", all(doc, not(doctest))))]
 #[cfg_attr(all(feature = "nightly", doc), doc(cfg(feature = "base64")))]
 pub fn crypto_pwhash_str(password: &[u8], opslimit: u64, memlimit: usize) -> Result<String, Error> {
-    validate!(
+    validate_value!(
         CRYPTO_PWHASH_OPSLIMIT_MIN,
         CRYPTO_PWHASH_OPSLIMIT_MAX,
         opslimit,
         crate::ErrorContext::OperationsLimit
     );
-    validate!(
+    validate_value!(
         CRYPTO_PWHASH_MEMLIMIT_MIN,
         CRYPTO_PWHASH_MEMLIMIT_MAX,
         memlimit,
@@ -334,82 +334,70 @@ impl Pwhash {
                     "argon2i" => pwhash.type_ = Some(PasswordHashAlgorithm::Argon2i13),
                     "argon2id" => pwhash.type_ = Some(PasswordHashAlgorithm::Argon2id13),
                     _ => {
-                        return Err(Error::InvalidEncoding {
-                            context: crate::ErrorContext::PasswordHashAlgorithm,
-                        });
+                        return Err(Error::invalid_encoding(
+                            crate::ErrorContext::PasswordHashAlgorithm,
+                        ));
                     }
                 }
             } else if let Some(stripped) = s.strip_prefix("v=") {
-                pwhash.version =
-                    Some(
-                        stripped
-                            .parse::<u32>()
-                            .map_err(|_| Error::InvalidEncoding {
-                                context: crate::ErrorContext::PasswordHashVersion,
-                            })?,
-                    );
+                pwhash.version = Some(stripped.parse::<u32>().map_err(|_| {
+                    Error::invalid_encoding(crate::ErrorContext::PasswordHashVersion)
+                })?);
             } else if s.contains("m=") && s.contains("t=") && s.contains("p=") {
                 for p in s.split(',') {
                     if let Some(m_cost) = p.strip_prefix("m=") {
-                        pwhash.m_cost =
-                            Some(m_cost.parse::<u32>().map_err(|_| Error::InvalidEncoding {
-                                context: crate::ErrorContext::PasswordHashMemoryCost,
-                            })?);
+                        pwhash.m_cost = Some(m_cost.parse::<u32>().map_err(|_| {
+                            Error::invalid_encoding(crate::ErrorContext::PasswordHashMemoryCost)
+                        })?);
                     } else if let Some(t_cost) = p.strip_prefix("t=") {
-                        pwhash.t_cost =
-                            Some(t_cost.parse::<u32>().map_err(|_| Error::InvalidEncoding {
-                                context: crate::ErrorContext::PasswordHashTimeCost,
-                            })?);
+                        pwhash.t_cost = Some(t_cost.parse::<u32>().map_err(|_| {
+                            Error::invalid_encoding(crate::ErrorContext::PasswordHashTimeCost)
+                        })?);
                     } else if let Some(parallelism) = p.strip_prefix("p=") {
                         pwhash.parallelism = Some(parallelism.parse::<u32>().map_err(|_| {
-                            Error::InvalidEncoding {
-                                context: crate::ErrorContext::PasswordHashParallelism,
-                            }
+                            Error::invalid_encoding(crate::ErrorContext::PasswordHashParallelism)
                         })?);
                     }
                 }
             } else if pwhash.salt.is_none() {
-                pwhash.salt = Some(base64_no_pad_decode(s).ok_or(Error::InvalidEncoding {
-                    context: crate::ErrorContext::PasswordHashSalt,
-                })?);
+                pwhash.salt = Some(base64_no_pad_decode(s).ok_or(Error::invalid_encoding(
+                    crate::ErrorContext::PasswordHashSalt,
+                ))?);
             } else if pwhash.pwhash.is_none() {
-                pwhash.pwhash = Some(base64_no_pad_decode(s).ok_or(Error::InvalidEncoding {
-                    context: crate::ErrorContext::PasswordHash,
-                })?);
+                pwhash.pwhash = Some(
+                    base64_no_pad_decode(s)
+                        .ok_or(Error::invalid_encoding(crate::ErrorContext::PasswordHash))?,
+                );
             }
         }
 
         // Check if version is supported
         if pwhash.version.is_none() || pwhash.version.unwrap() != ARGON2_VERSION_NUMBER {
-            Err(Error::InvalidEncoding {
-                context: crate::ErrorContext::PasswordHashVersion,
-            })
+            Err(Error::invalid_encoding(
+                crate::ErrorContext::PasswordHashVersion,
+            ))
         // Verify the parallelism value
         } else if pwhash.parallelism.is_none() || pwhash.parallelism.unwrap() != 1 {
-            Err(Error::InvalidEncoding {
-                context: crate::ErrorContext::PasswordHashParallelism,
-            })
+            Err(Error::invalid_encoding(
+                crate::ErrorContext::PasswordHashParallelism,
+            ))
         // Check for missing fields
         } else if pwhash.pwhash.is_none() || pwhash.pwhash.as_ref().unwrap().is_empty() {
-            Err(Error::MissingData {
-                context: crate::ErrorContext::PasswordHash,
-            })
+            Err(Error::missing_data(crate::ErrorContext::PasswordHash))
         } else if pwhash.salt.is_none() || pwhash.salt.as_ref().unwrap().is_empty() {
-            Err(Error::MissingData {
-                context: crate::ErrorContext::PasswordHashSalt,
-            })
+            Err(Error::missing_data(crate::ErrorContext::PasswordHashSalt))
         } else if pwhash.type_.is_none() {
-            Err(Error::MissingData {
-                context: crate::ErrorContext::PasswordHashAlgorithm,
-            })
+            Err(Error::missing_data(
+                crate::ErrorContext::PasswordHashAlgorithm,
+            ))
         } else if pwhash.m_cost.is_none() {
-            Err(Error::MissingData {
-                context: crate::ErrorContext::PasswordHashMemoryCost,
-            })
+            Err(Error::missing_data(
+                crate::ErrorContext::PasswordHashMemoryCost,
+            ))
         } else if pwhash.t_cost.is_none() {
-            Err(Error::MissingData {
-                context: crate::ErrorContext::PasswordHashTimeCost,
-            })
+            Err(Error::missing_data(
+                crate::ErrorContext::PasswordHashTimeCost,
+            ))
         } else {
             Ok(pwhash)
         }
@@ -431,24 +419,24 @@ pub fn crypto_pwhash_str_verify(hashed_password: &str, password: &[u8]) -> Resul
     let mut hash = [0u8; STR_HASHBYTES];
 
     let pwhash = Pwhash::parse_encoded_pwhash(hashed_password)?;
-    let t_cost = pwhash.t_cost.ok_or(Error::MissingData {
-        context: crate::ErrorContext::PasswordHashTimeCost,
-    })?;
-    let m_cost = pwhash.m_cost.ok_or(Error::MissingData {
-        context: crate::ErrorContext::PasswordHashMemoryCost,
-    })?;
-    let parallelism = pwhash.parallelism.ok_or(Error::MissingData {
-        context: crate::ErrorContext::PasswordHashParallelism,
-    })?;
-    let salt = pwhash.salt.ok_or(Error::MissingData {
-        context: crate::ErrorContext::PasswordHashSalt,
-    })?;
-    let algorithm = pwhash.type_.ok_or(Error::MissingData {
-        context: crate::ErrorContext::PasswordHashAlgorithm,
-    })?;
-    let expected_hash = pwhash.pwhash.ok_or(Error::MissingData {
-        context: crate::ErrorContext::PasswordHash,
-    })?;
+    let t_cost = pwhash.t_cost.ok_or(Error::missing_data(
+        crate::ErrorContext::PasswordHashTimeCost,
+    ))?;
+    let m_cost = pwhash.m_cost.ok_or(Error::missing_data(
+        crate::ErrorContext::PasswordHashMemoryCost,
+    ))?;
+    let parallelism = pwhash.parallelism.ok_or(Error::missing_data(
+        crate::ErrorContext::PasswordHashParallelism,
+    ))?;
+    let salt = pwhash
+        .salt
+        .ok_or(Error::missing_data(crate::ErrorContext::PasswordHashSalt))?;
+    let algorithm = pwhash.type_.ok_or(Error::missing_data(
+        crate::ErrorContext::PasswordHashAlgorithm,
+    ))?;
+    let expected_hash = pwhash
+        .pwhash
+        .ok_or(Error::missing_data(crate::ErrorContext::PasswordHash))?;
 
     argon2_hash(
         t_cost,
@@ -487,12 +475,12 @@ pub fn crypto_pwhash_str_needs_rehash(
     memlimit: usize,
 ) -> Result<bool, Error> {
     let pwhash = Pwhash::parse_encoded_pwhash(hashed_password)?;
-    let parsed_t_cost = pwhash.t_cost.ok_or(Error::MissingData {
-        context: crate::ErrorContext::PasswordHashTimeCost,
-    })?;
-    let parsed_m_cost = pwhash.m_cost.ok_or(Error::MissingData {
-        context: crate::ErrorContext::PasswordHashMemoryCost,
-    })?;
+    let parsed_t_cost = pwhash.t_cost.ok_or(Error::missing_data(
+        crate::ErrorContext::PasswordHashTimeCost,
+    ))?;
+    let parsed_m_cost = pwhash.m_cost.ok_or(Error::missing_data(
+        crate::ErrorContext::PasswordHashMemoryCost,
+    ))?;
 
     let (t_cost, m_cost) = convert_costs(opslimit, memlimit);
 
@@ -568,19 +556,114 @@ mod tests {
     #[cfg(feature = "base64")]
     #[test]
     fn malformed_password_hash_fields_have_structured_errors() {
-        let error = match Pwhash::parse_encoded_pwhash(
-            "$argon2id$v=19$m=65536,t=2,p=1$A$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-        ) {
-            Ok(_) => panic!("invalid salt encoding should fail"),
-            Err(error) => error,
-        };
+        const SALT: &str = "AAAAAAAAAAA";
+        const HASH: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let cases = [
+            (
+                format!("$argon2wat$v=19$m=65536,t=2,p=1${SALT}${HASH}"),
+                crate::ErrorContext::PasswordHashAlgorithm,
+            ),
+            (
+                format!("$argon2id$v=nope$m=65536,t=2,p=1${SALT}${HASH}"),
+                crate::ErrorContext::PasswordHashVersion,
+            ),
+            (
+                format!("$argon2id$v=19$m=nope,t=2,p=1${SALT}${HASH}"),
+                crate::ErrorContext::PasswordHashMemoryCost,
+            ),
+            (
+                format!("$argon2id$v=19$m=65536,t=nope,p=1${SALT}${HASH}"),
+                crate::ErrorContext::PasswordHashTimeCost,
+            ),
+            (
+                format!("$argon2id$v=19$m=65536,t=2,p=nope${SALT}${HASH}"),
+                crate::ErrorContext::PasswordHashParallelism,
+            ),
+            (
+                format!("$argon2id$v=19$m=65536,t=2,p=1$A${HASH}"),
+                crate::ErrorContext::PasswordHashSalt,
+            ),
+            (
+                format!("$argon2id$v=19$m=65536,t=2,p=1${SALT}$A"),
+                crate::ErrorContext::PasswordHash,
+            ),
+            (
+                format!("$argon2id$v=18$m=65536,t=2,p=1${SALT}${HASH}"),
+                crate::ErrorContext::PasswordHashVersion,
+            ),
+            (
+                format!("$argon2id$v=19$m=65536,t=2,p=2${SALT}${HASH}"),
+                crate::ErrorContext::PasswordHashParallelism,
+            ),
+        ];
 
+        for (encoded, expected_context) in cases {
+            let error = match Pwhash::parse_encoded_pwhash(&encoded) {
+                Ok(_) => panic!("the malformed field should be rejected"),
+                Err(error) => error,
+            };
+            assert!(matches!(
+                error,
+                Error::InvalidEncoding { context } if context == expected_context
+            ));
+        }
+
+        let missing_hash = format!("$argon2id$v=19$m=65536,t=2,p=1${SALT}");
         assert!(matches!(
-            error,
-            Error::InvalidEncoding {
-                context: crate::ErrorContext::PasswordHashSalt,
-            }
+            Pwhash::parse_encoded_pwhash(&missing_hash),
+            Err(Error::MissingData {
+                context: crate::ErrorContext::PasswordHash,
+            })
         ));
+
+        let missing_algorithm = format!("$v=19$m=65536,t=2,p=1${SALT}${HASH}");
+        assert!(matches!(
+            Pwhash::parse_encoded_pwhash(&missing_algorithm),
+            Err(Error::MissingData {
+                context: crate::ErrorContext::PasswordHashAlgorithm,
+            })
+        ));
+    }
+
+    #[test]
+    fn password_hashing_reports_invalid_resource_limits() {
+        let mut output = [0u8; CRYPTO_PWHASH_BYTES_MIN];
+        let salt = [0u8; CRYPTO_PWHASH_SALTBYTES];
+        let password = b"password";
+
+        for (opslimit, memlimit, expected_context) in [
+            (
+                CRYPTO_PWHASH_OPSLIMIT_MIN - 1,
+                CRYPTO_PWHASH_MEMLIMIT_MIN,
+                crate::ErrorContext::OperationsLimit,
+            ),
+            (
+                CRYPTO_PWHASH_OPSLIMIT_MIN,
+                CRYPTO_PWHASH_MEMLIMIT_MIN - 1,
+                crate::ErrorContext::MemoryLimit,
+            ),
+        ] {
+            let error = crypto_pwhash(
+                &mut output,
+                password,
+                &salt,
+                opslimit,
+                memlimit,
+                PasswordHashAlgorithm::Argon2id13,
+            )
+            .expect_err("invalid resource limits should fail");
+            assert!(matches!(
+                error,
+                Error::InvalidValue { context, .. } if context == expected_context
+            ));
+
+            let error = crypto_pwhash_str(password, opslimit, memlimit)
+                .expect_err("invalid resource limits should fail");
+            assert!(matches!(
+                error,
+                Error::InvalidValue { context, .. } if context == expected_context
+            ));
+        }
     }
 
     #[cfg(feature = "base64")]

--- a/src/classic/crypto_pwhash.rs
+++ b/src/classic/crypto_pwhash.rs
@@ -124,13 +124,13 @@ pub fn crypto_pwhash(
         CRYPTO_PWHASH_OPSLIMIT_MIN,
         CRYPTO_PWHASH_OPSLIMIT_MAX,
         opslimit,
-        "opslimit"
+        crate::ErrorContext::OperationsLimit
     );
     validate!(
         CRYPTO_PWHASH_MEMLIMIT_MIN,
         CRYPTO_PWHASH_MEMLIMIT_MAX,
         memlimit,
-        "memlimit"
+        crate::ErrorContext::MemoryLimit
     );
 
     let (t_cost, m_cost) = convert_costs(opslimit, memlimit);
@@ -263,13 +263,13 @@ pub fn crypto_pwhash_str(password: &[u8], opslimit: u64, memlimit: usize) -> Res
         CRYPTO_PWHASH_OPSLIMIT_MIN,
         CRYPTO_PWHASH_OPSLIMIT_MAX,
         opslimit,
-        "opslimit"
+        crate::ErrorContext::OperationsLimit
     );
     validate!(
         CRYPTO_PWHASH_MEMLIMIT_MIN,
         CRYPTO_PWHASH_MEMLIMIT_MAX,
         memlimit,
-        "memlimit"
+        crate::ErrorContext::MemoryLimit
     );
 
     let mut salt = [0u8; CRYPTO_PWHASH_SALTBYTES];
@@ -319,54 +319,83 @@ impl Pwhash {
                 match s {
                     "argon2i" => pwhash.type_ = Some(PasswordHashAlgorithm::Argon2i13),
                     "argon2id" => pwhash.type_ = Some(PasswordHashAlgorithm::Argon2id13),
-                    _ => return Err(dryoc_error!(format!("invalid type: {}", s))),
+                    _ => {
+                        return Err(Error::InvalidEncoding {
+                            context: crate::ErrorContext::PasswordHashAlgorithm,
+                        });
+                    }
                 }
             } else if let Some(stripped) = s.strip_prefix("v=") {
-                pwhash.version = Some(
-                    stripped
-                        .parse::<u32>()
-                        .map_err(|_| dryoc_error!("unable to decode password hash version"))?,
-                );
+                pwhash.version =
+                    Some(
+                        stripped
+                            .parse::<u32>()
+                            .map_err(|_| Error::InvalidEncoding {
+                                context: crate::ErrorContext::PasswordHashVersion,
+                            })?,
+                    );
             } else if s.contains("m=") && s.contains("t=") && s.contains("p=") {
                 for p in s.split(',') {
                     if let Some(m_cost) = p.strip_prefix("m=") {
-                        pwhash.m_cost = Some(m_cost.parse::<u32>().map_err(|_| {
-                            dryoc_error!("unable to decode password hash parameter m_cost")
-                        })?);
+                        pwhash.m_cost =
+                            Some(m_cost.parse::<u32>().map_err(|_| Error::InvalidEncoding {
+                                context: crate::ErrorContext::PasswordHashMemoryCost,
+                            })?);
                     } else if let Some(t_cost) = p.strip_prefix("t=") {
-                        pwhash.t_cost = Some(t_cost.parse::<u32>().map_err(|_| {
-                            dryoc_error!("unable to decode password hash parameter t_cost")
-                        })?);
+                        pwhash.t_cost =
+                            Some(t_cost.parse::<u32>().map_err(|_| Error::InvalidEncoding {
+                                context: crate::ErrorContext::PasswordHashTimeCost,
+                            })?);
                     } else if let Some(parallelism) = p.strip_prefix("p=") {
                         pwhash.parallelism = Some(parallelism.parse::<u32>().map_err(|_| {
-                            dryoc_error!("unable to decode password hash parameter t_cost")
+                            Error::InvalidEncoding {
+                                context: crate::ErrorContext::PasswordHashParallelism,
+                            }
                         })?);
                     }
                 }
             } else if pwhash.salt.is_none() {
-                pwhash.salt = base64_no_pad_decode(s);
+                pwhash.salt = Some(base64_no_pad_decode(s).ok_or(Error::InvalidEncoding {
+                    context: crate::ErrorContext::PasswordHashSalt,
+                })?);
             } else if pwhash.pwhash.is_none() {
-                pwhash.pwhash = base64_no_pad_decode(s);
+                pwhash.pwhash = Some(base64_no_pad_decode(s).ok_or(Error::InvalidEncoding {
+                    context: crate::ErrorContext::PasswordHash,
+                })?);
             }
         }
 
         // Check if version is supported
         if pwhash.version.is_none() || pwhash.version.unwrap() != ARGON2_VERSION_NUMBER {
-            Err(dryoc_error!("unsupported password hash"))
+            Err(Error::InvalidEncoding {
+                context: crate::ErrorContext::PasswordHashVersion,
+            })
         // Verify correct value for parallism
         } else if pwhash.parallelism.is_none() || pwhash.parallelism.unwrap() != 1 {
-            Err(dryoc_error!("parallelism missing or invalid"))
+            Err(Error::InvalidEncoding {
+                context: crate::ErrorContext::PasswordHashParallelism,
+            })
         // Check for missing fields
         } else if pwhash.pwhash.is_none() || pwhash.pwhash.as_ref().unwrap().is_empty() {
-            Err(dryoc_error!("password hash missing"))
+            Err(Error::MissingData {
+                context: crate::ErrorContext::PasswordHash,
+            })
         } else if pwhash.salt.is_none() || pwhash.salt.as_ref().unwrap().is_empty() {
-            Err(dryoc_error!("password salt missing"))
+            Err(Error::MissingData {
+                context: crate::ErrorContext::PasswordHashSalt,
+            })
         } else if pwhash.type_.is_none() {
-            Err(dryoc_error!("algorithm type missing"))
+            Err(Error::MissingData {
+                context: crate::ErrorContext::PasswordHashAlgorithm,
+            })
         } else if pwhash.m_cost.is_none() {
-            Err(dryoc_error!("m_cost missing"))
+            Err(Error::MissingData {
+                context: crate::ErrorContext::PasswordHashMemoryCost,
+            })
         } else if pwhash.t_cost.is_none() {
-            Err(dryoc_error!("t_cost missing"))
+            Err(Error::MissingData {
+                context: crate::ErrorContext::PasswordHashTimeCost,
+            })
         } else {
             Ok(pwhash)
         }
@@ -399,7 +428,7 @@ pub fn crypto_pwhash_str_verify(hashed_password: &str, password: &[u8]) -> Resul
     if hash.ct_eq(pwhash.pwhash.unwrap().as_ref()).unwrap_u8() == 1 {
         Ok(())
     } else {
-        Err(dryoc_error!("password hashes do not match"))
+        Err(Error::AuthenticationFailed)
     }
 }
 
@@ -486,6 +515,24 @@ mod tests {
         assert_eq!(base64_no_pad_decode("AA="), None);
         assert_eq!(base64_no_pad_decode("A/"), None);
         assert_eq!(base64_no_pad_decode("AA/"), None);
+    }
+
+    #[cfg(feature = "base64")]
+    #[test]
+    fn malformed_password_hash_fields_have_structured_errors() {
+        let error = match Pwhash::parse_encoded_pwhash(
+            "$argon2id$v=19$m=65536,t=2,p=1$A$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        ) {
+            Ok(_) => panic!("invalid salt encoding should fail"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error,
+            Error::InvalidEncoding {
+                context: crate::ErrorContext::PasswordHashSalt,
+            }
+        ));
     }
 
     #[cfg(feature = "base64")]

--- a/src/classic/crypto_secretbox.rs
+++ b/src/classic/crypto_secretbox.rs
@@ -118,13 +118,10 @@ pub fn crypto_secretbox_easy(
     nonce: &Nonce,
     key: &Key,
 ) -> Result<(), Error> {
-    let expected_len =
-        message
-            .len()
-            .checked_add(CRYPTO_SECRETBOX_MACBYTES)
-            .ok_or(Error::ArithmeticOverflow {
-                context: crate::ErrorContext::Ciphertext,
-            })?;
+    let expected_len = message
+        .len()
+        .checked_add(CRYPTO_SECRETBOX_MACBYTES)
+        .ok_or(Error::arithmetic_overflow(crate::ErrorContext::Ciphertext))?;
     if ciphertext.len() != expected_len {
         return Err(
             length_error!(crate::ErrorContext::Ciphertext, ciphertext.len(), exact expected_len),

--- a/src/classic/crypto_secretbox.rs
+++ b/src/classic/crypto_secretbox.rs
@@ -69,11 +69,9 @@ pub fn crypto_secretbox_detached(
     key: &Key,
 ) -> Result<(), Error> {
     if ciphertext.len() < message.len() {
-        return Err(dryoc_error!(format!(
-            "ciphertext length {} less than message length {}",
-            ciphertext.len(),
-            message.len()
-        )));
+        return Err(
+            length_error!(crate::ErrorContext::Ciphertext, ciphertext.len(), min message.len()),
+        );
     }
 
     crypto_secretbox_detached_b2b(&mut ciphertext[..message.len()], mac, message, nonce, key);
@@ -93,11 +91,7 @@ pub fn crypto_secretbox_open_detached(
 ) -> Result<(), Error> {
     let c_len = ciphertext.len();
     if message.len() < c_len {
-        return Err(dryoc_error!(format!(
-            "message length {} less than ciphertext length {}",
-            message.len(),
-            c_len
-        )));
+        return Err(length_error!(crate::ErrorContext::Message, message.len(), min c_len));
     }
 
     crypto_secretbox_open_detached_b2b(&mut message[..c_len], mac, ciphertext, nonce, key)
@@ -112,16 +106,17 @@ pub fn crypto_secretbox_easy(
     nonce: &Nonce,
     key: &Key,
 ) -> Result<(), Error> {
-    let expected_len = message
-        .len()
-        .checked_add(CRYPTO_SECRETBOX_MACBYTES)
-        .ok_or_else(|| dryoc_error!("ciphertext length overflow"))?;
+    let expected_len =
+        message
+            .len()
+            .checked_add(CRYPTO_SECRETBOX_MACBYTES)
+            .ok_or(Error::ArithmeticOverflow {
+                context: crate::ErrorContext::Ciphertext,
+            })?;
     if ciphertext.len() != expected_len {
-        return Err(dryoc_error!(format!(
-            "ciphertext length invalid ({} != {})",
-            ciphertext.len(),
-            expected_len
-        )));
+        return Err(
+            length_error!(crate::ErrorContext::Ciphertext, ciphertext.len(), exact expected_len),
+        );
     }
 
     let mut mac = Mac::default();
@@ -148,17 +143,15 @@ pub fn crypto_secretbox_open_easy(
     key: &Key,
 ) -> Result<(), Error> {
     if ciphertext.len() < CRYPTO_SECRETBOX_MACBYTES {
-        Err(dryoc_error!(format!(
-            "Impossibly small box ({} < {}",
-            ciphertext.len(),
-            CRYPTO_SECRETBOX_MACBYTES
-        )))
+        Err(
+            length_error!(crate::ErrorContext::Ciphertext, ciphertext.len(), min CRYPTO_SECRETBOX_MACBYTES),
+        )
     } else if message.len() != ciphertext.len() - CRYPTO_SECRETBOX_MACBYTES {
-        Err(dryoc_error!(format!(
-            "message length invalid ({} != {})",
+        Err(length_error!(
+            crate::ErrorContext::Message,
             message.len(),
-            ciphertext.len() - CRYPTO_SECRETBOX_MACBYTES
-        )))
+            exact ciphertext.len() - CRYPTO_SECRETBOX_MACBYTES
+        ))
     } else {
         let (mac, ciphertext) = ciphertext.split_at(CRYPTO_SECRETBOX_MACBYTES);
         let mac = ByteArray::as_array(mac);
@@ -174,11 +167,9 @@ pub fn crypto_secretbox_easy_inplace(
     key: &Key,
 ) -> Result<(), Error> {
     if data.len() < CRYPTO_SECRETBOX_MACBYTES {
-        return Err(dryoc_error!(format!(
-            "data length {} less than minimum {}",
-            data.len(),
-            CRYPTO_SECRETBOX_MACBYTES
-        )));
+        return Err(
+            length_error!(crate::ErrorContext::Data, data.len(), min CRYPTO_SECRETBOX_MACBYTES),
+        );
     }
     data.rotate_right(CRYPTO_SECRETBOX_MACBYTES);
     let (mac, data) = data.split_at_mut(CRYPTO_SECRETBOX_MACBYTES);
@@ -197,11 +188,9 @@ pub fn crypto_secretbox_open_easy_inplace(
     key: &Key,
 ) -> Result<(), Error> {
     if ciphertext.len() < CRYPTO_SECRETBOX_MACBYTES {
-        Err(dryoc_error!(format!(
-            "Impossibly small box ({} < {}",
-            ciphertext.len(),
-            CRYPTO_SECRETBOX_MACBYTES
-        )))
+        Err(
+            length_error!(crate::ErrorContext::Ciphertext, ciphertext.len(), min CRYPTO_SECRETBOX_MACBYTES),
+        )
     } else {
         let (mac, data) = ciphertext.split_at_mut(CRYPTO_SECRETBOX_MACBYTES);
         let mac = ByteArray::as_array(mac);

--- a/src/classic/crypto_secretbox_impl.rs
+++ b/src/classic/crypto_secretbox_impl.rs
@@ -116,7 +116,7 @@ pub(crate) fn crypto_secretbox_open_detached_b2b(
         cipher.xor_b2b(message, ciphertext);
         Ok(())
     } else {
-        Err(dryoc_error!("decryption error (authentication failure)"))
+        Err(Error::AuthenticationFailed)
     }
 }
 
@@ -160,6 +160,6 @@ pub(crate) fn crypto_secretbox_open_detached_inplace(
         cipher.xor(data);
         Ok(())
     } else {
-        Err(dryoc_error!("decryption error (authentication failure)"))
+        Err(Error::AuthenticationFailed)
     }
 }

--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -266,19 +266,19 @@ pub fn crypto_secretstream_xchacha20poly1305_push(
     let _pad0 = [0u8; 16];
 
     if ciphertext.len() != message.len() + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES {
-        return Err(dryoc_error!(format!(
-            "Ciphertext length was {}, should be {}",
+        return Err(length_error!(
+            crate::ErrorContext::Ciphertext,
             ciphertext.len(),
-            message.len() + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES
-        )));
+            exact message.len() + CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES
+        ));
     }
 
     if message.len() > CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_MESSAGEBYTES_MAX {
-        return Err(dryoc_error!(format!(
-            "Message length {} exceeds max length {}",
+        return Err(length_error!(
+            crate::ErrorContext::Message,
             message.len(),
-            CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_MESSAGEBYTES_MAX
-        )));
+            max CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_MESSAGEBYTES_MAX
+        ));
     }
 
     let associated_data = associated_data.unwrap_or(&[]);
@@ -371,27 +371,27 @@ pub fn crypto_secretstream_xchacha20poly1305_pull(
     let _pad0 = [0u8; 16];
 
     if ciphertext.len() < CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES {
-        return Err(dryoc_error!(format!(
-            "Ciphertext length was {}, should be at least {}",
+        return Err(length_error!(
+            crate::ErrorContext::Ciphertext,
             ciphertext.len(),
-            CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES
-        )));
+            min CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES
+        ));
     }
 
     if message.len() < ciphertext.len() - CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES {
-        return Err(dryoc_error!(format!(
-            "Message length was {}, should be at least {}",
+        return Err(length_error!(
+            crate::ErrorContext::Message,
             message.len(),
-            ciphertext.len() - CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES
-        )));
+            min ciphertext.len() - CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES
+        ));
     }
 
     if ciphertext.len() > CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_MESSAGEBYTES_MAX {
-        return Err(dryoc_error!(format!(
-            "Message length {} exceeds max length {}",
+        return Err(length_error!(
+            crate::ErrorContext::Ciphertext,
             ciphertext.len(),
-            CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_MESSAGEBYTES_MAX
-        )));
+            max CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_MESSAGEBYTES_MAX
+        ));
     }
 
     let associated_data = associated_data.unwrap_or(&[]);
@@ -440,7 +440,7 @@ pub fn crypto_secretstream_xchacha20poly1305_pull(
     cipher.apply_keystream(&mut message[..mlen]);
 
     if ciphertext[1 + mlen..].ct_eq(&mac).unwrap_u8() == 0 {
-        return Err(dryoc_error!("Message authentication mismatch"));
+        return Err(Error::AuthenticationFailed);
     }
 
     let inonce = state_inonce(&mut state.nonce);

--- a/src/classic/crypto_secretstream_xchacha20poly1305.rs
+++ b/src/classic/crypto_secretstream_xchacha20poly1305.rs
@@ -478,6 +478,62 @@ mod tests {
     use crate::dryocstream::Tag;
 
     #[test]
+    fn push_and_pull_reject_invalid_buffer_lengths() {
+        let mut state = State::new();
+        let mut tag = 0;
+
+        let error = crypto_secretstream_xchacha20poly1305_push(
+            &mut state,
+            &mut [],
+            b"message",
+            None,
+            Tag::MESSAGE.bits(),
+        )
+        .expect_err("ciphertext must include secretstream overhead");
+        assert!(matches!(
+            error,
+            Error::InvalidLength {
+                context: crate::ErrorContext::Ciphertext,
+                ..
+            }
+        ));
+
+        let short_ciphertext = [0u8; CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES - 1];
+        let error = crypto_secretstream_xchacha20poly1305_pull(
+            &mut state,
+            &mut [],
+            &mut tag,
+            &short_ciphertext,
+            None,
+        )
+        .expect_err("ciphertext must include secretstream overhead");
+        assert!(matches!(
+            error,
+            Error::InvalidLength {
+                context: crate::ErrorContext::Ciphertext,
+                ..
+            }
+        ));
+
+        let ciphertext = [0u8; CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES + 1];
+        let error = crypto_secretstream_xchacha20poly1305_pull(
+            &mut state,
+            &mut [],
+            &mut tag,
+            &ciphertext,
+            None,
+        )
+        .expect_err("the message buffer must hold the plaintext");
+        assert!(matches!(
+            error,
+            Error::InvalidLength {
+                context: crate::ErrorContext::Message,
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn test_sizes() {
         use crate::constants::*;
 

--- a/src/classic/crypto_sign.rs
+++ b/src/classic/crypto_sign.rs
@@ -98,11 +98,11 @@ pub fn crypto_sign(
     secret_key: &SecretKey,
 ) -> Result<(), Error> {
     if signed_message.len() != message.len() + CRYPTO_SIGN_BYTES {
-        Err(dryoc_error!(format!(
-            "signed_message length incorrect (expect {}, got {})",
-            message.len() + CRYPTO_SIGN_BYTES,
-            signed_message.len()
-        )))
+        Err(length_error!(
+            crate::ErrorContext::SignedMessage,
+            signed_message.len(),
+            exact message.len() + CRYPTO_SIGN_BYTES
+        ))
     } else {
         crypto_sign_ed25519(signed_message, message, secret_key)
     }
@@ -120,17 +120,15 @@ pub fn crypto_sign_open(
     public_key: &PublicKey,
 ) -> Result<(), Error> {
     if signed_message.len() < CRYPTO_SIGN_BYTES {
-        Err(dryoc_error!(format!(
-            "signed_message length invalid ({} < {})",
-            signed_message.len(),
-            CRYPTO_SIGN_BYTES,
-        )))
+        Err(
+            length_error!(crate::ErrorContext::SignedMessage, signed_message.len(), min CRYPTO_SIGN_BYTES),
+        )
     } else if message.len() != signed_message.len() - CRYPTO_SIGN_BYTES {
-        Err(dryoc_error!(format!(
-            "message length incorrect (expect {}, got {})",
-            signed_message.len() - CRYPTO_SIGN_BYTES,
-            message.len()
-        )))
+        Err(length_error!(
+            crate::ErrorContext::Message,
+            message.len(),
+            exact signed_message.len() - CRYPTO_SIGN_BYTES
+        ))
     } else {
         crypto_sign_ed25519_open(message, signed_message, public_key)
     }

--- a/src/classic/crypto_sign.rs
+++ b/src/classic/crypto_sign.rs
@@ -232,6 +232,74 @@ pub fn crypto_sign_final_verify(
 #[cfg(all(test, dryoc_native_tests))]
 mod tests {
     use super::*;
+    use crate::constants::CRYPTO_SIGN_PUBLICKEYBYTES;
+
+    #[test]
+    fn combined_signing_rejects_invalid_buffer_lengths() {
+        let (public_key, secret_key) = crypto_sign_keypair();
+
+        let mut short_signed_message = [0u8; CRYPTO_SIGN_BYTES];
+        let error = crypto_sign(&mut short_signed_message, b"x", &secret_key)
+            .expect_err("the signed-message buffer should include the message");
+        assert!(matches!(
+            error,
+            Error::InvalidLength {
+                context: crate::ErrorContext::SignedMessage,
+                ..
+            }
+        ));
+
+        let mut message = [];
+        let short_input = [0u8; CRYPTO_SIGN_BYTES - 1];
+        let error = crypto_sign_open(&mut message, &short_input, &public_key)
+            .expect_err("a signed message must contain a full signature");
+        assert!(matches!(
+            error,
+            Error::InvalidLength {
+                context: crate::ErrorContext::SignedMessage,
+                ..
+            }
+        ));
+
+        let mut oversized_message = [0u8; 1];
+        let signature_only = [0u8; CRYPTO_SIGN_BYTES];
+        let error = crypto_sign_open(&mut oversized_message, &signature_only, &public_key)
+            .expect_err("the output length should match the embedded message");
+        assert!(matches!(
+            error,
+            Error::InvalidLength {
+                context: crate::ErrorContext::Message,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn verification_classifies_invalid_signatures_and_public_keys() {
+        let (public_key, secret_key) = crypto_sign_keypair();
+        let message = b"important message";
+        let mut signature = [0u8; CRYPTO_SIGN_BYTES];
+        crypto_sign_detached(&mut signature, message, &secret_key).expect("signing should succeed");
+
+        let mut tampered_signature = signature;
+        tampered_signature[CRYPTO_SIGN_BYTES - 1] ^= 1;
+        assert!(matches!(
+            crypto_sign_verify_detached(&tampered_signature, message, &public_key),
+            Err(Error::AuthenticationFailed)
+        ));
+
+        assert!(matches!(
+            crypto_sign_verify_detached(&[0u8; CRYPTO_SIGN_BYTES], message, &public_key),
+            Err(Error::AuthenticationFailed)
+        ));
+
+        assert!(matches!(
+            crypto_sign_verify_detached(&signature, message, &[0u8; CRYPTO_SIGN_PUBLICKEYBYTES],),
+            Err(Error::InvalidKey {
+                context: crate::ErrorContext::Ed25519PublicKey,
+            })
+        ));
+    }
 
     #[test]
     fn test_crypto_sign() {

--- a/src/classic/crypto_sign_ed25519.rs
+++ b/src/classic/crypto_sign_ed25519.rs
@@ -137,9 +137,7 @@ pub fn crypto_sign_ed25519_pk_to_curve25519(
 ) -> Result<(), Error> {
     let ep = CompressedEdwardsY(*ed25519_public_key)
         .decompress()
-        .ok_or(Error::InvalidKey {
-            context: crate::ErrorContext::Ed25519PublicKey,
-        })?;
+        .ok_or(Error::invalid_key(crate::ErrorContext::Ed25519PublicKey))?;
     x25519_public_key.copy_from_slice(ep.to_montgomery().as_bytes());
 
     Ok(())
@@ -292,17 +290,11 @@ fn crypto_sign_ed25519_verify_detached_impl(
         return Err(Error::AuthenticationFailed);
     }
     let pk = CompressedEdwardsY::from_slice(public_key)
-        .map_err(|_| Error::InvalidKey {
-            context: crate::ErrorContext::Ed25519PublicKey,
-        })?
+        .map_err(|_| Error::invalid_key(crate::ErrorContext::Ed25519PublicKey))?
         .decompress()
-        .ok_or(Error::InvalidKey {
-            context: crate::ErrorContext::Ed25519PublicKey,
-        })?;
+        .ok_or(Error::invalid_key(crate::ErrorContext::Ed25519PublicKey))?;
     if pk.is_small_order() {
-        return Err(Error::InvalidKey {
-            context: crate::ErrorContext::Ed25519PublicKey,
-        });
+        return Err(Error::invalid_key(crate::ErrorContext::Ed25519PublicKey));
     }
 
     let mut hasher = Sha512::new();

--- a/src/classic/crypto_sign_ed25519.rs
+++ b/src/classic/crypto_sign_ed25519.rs
@@ -132,7 +132,9 @@ pub fn crypto_sign_ed25519_pk_to_curve25519(
 ) -> Result<(), Error> {
     let ep = CompressedEdwardsY(*ed25519_public_key)
         .decompress()
-        .ok_or_else(|| dryoc_error!("failed to convert to Edwards point"))?;
+        .ok_or(Error::InvalidKey {
+            context: crate::ErrorContext::Ed25519PublicKey,
+        })?;
     x25519_public_key.copy_from_slice(ep.to_montgomery().as_bytes());
 
     Ok(())
@@ -178,11 +180,11 @@ pub(crate) fn crypto_sign_ed25519(
     secret_key: &SecretKey,
 ) -> Result<(), Error> {
     if signed_message.len() != message.len() + CRYPTO_SIGN_ED25519_BYTES {
-        Err(dryoc_error!(format!(
-            "signed_message length incorrect (expect {}, got {})",
-            message.len() + CRYPTO_SIGN_ED25519_BYTES,
-            signed_message.len()
-        )))
+        Err(length_error!(
+            crate::ErrorContext::SignedMessage,
+            signed_message.len(),
+            exact message.len() + CRYPTO_SIGN_ED25519_BYTES
+        ))
     } else {
         let (sig, sm) = signed_message.split_at_mut(CRYPTO_SIGN_ED25519_BYTES);
         let sig: &mut [u8; CRYPTO_SIGN_ED25519_BYTES] =
@@ -208,11 +210,11 @@ fn crypto_sign_ed25519_detached_impl(
     prehashed: bool,
 ) -> Result<(), Error> {
     if signature.len() != CRYPTO_SIGN_ED25519_BYTES {
-        Err(dryoc_error!(format!(
-            "signature length incorrect (expect {}, got {})",
-            CRYPTO_SIGN_ED25519_BYTES,
-            signature.len()
-        )))
+        Err(length_error!(
+            crate::ErrorContext::Signature,
+            signature.len(),
+            exact CRYPTO_SIGN_ED25519_BYTES
+        ))
     } else {
         let mut az: [u8; CRYPTO_HASH_SHA512_BYTES] = Sha512::compute(&secret_key[..32]);
 
@@ -275,19 +277,27 @@ fn crypto_sign_ed25519_verify_detached_impl(
 ) -> Result<(), Error> {
     let s = Scalar::from_bytes_mod_order(
         *<&[u8; CRYPTO_SCALARMULT_CURVE25519_SCALARBYTES]>::try_from(&signature[32..])
-            .map_err(|_| dryoc_error!("bad signature"))?,
+            .map_err(|_| Error::AuthenticationFailed)?,
     );
-    let big_r = CompressedEdwardsY::from_slice(&signature[..32])?
+    let big_r = CompressedEdwardsY::from_slice(&signature[..32])
+        .map_err(|_| Error::AuthenticationFailed)?
         .decompress()
-        .ok_or_else(|| dryoc_error!("bad signature"))?;
+        .ok_or(Error::AuthenticationFailed)?;
     if big_r.is_small_order() {
-        return Err(dryoc_error!("bad signature"));
+        return Err(Error::AuthenticationFailed);
     }
-    let pk = CompressedEdwardsY::from_slice(public_key)?
+    let pk = CompressedEdwardsY::from_slice(public_key)
+        .map_err(|_| Error::InvalidKey {
+            context: crate::ErrorContext::Ed25519PublicKey,
+        })?
         .decompress()
-        .ok_or_else(|| dryoc_error!("bad public key"))?;
+        .ok_or(Error::InvalidKey {
+            context: crate::ErrorContext::Ed25519PublicKey,
+        })?;
     if pk.is_small_order() {
-        return Err(dryoc_error!("bad public key"));
+        return Err(Error::InvalidKey {
+            context: crate::ErrorContext::Ed25519PublicKey,
+        });
     }
 
     let mut hasher = Sha512::new();
@@ -306,7 +316,7 @@ fn crypto_sign_ed25519_verify_detached_impl(
     if sig_r == big_r {
         Ok(())
     } else {
-        Err(dryoc_error!("bad signature"))
+        Err(Error::AuthenticationFailed)
     }
 }
 
@@ -316,17 +326,17 @@ pub(crate) fn crypto_sign_ed25519_open(
     public_key: &PublicKey,
 ) -> Result<(), Error> {
     if signed_message.len() < CRYPTO_SIGN_ED25519_BYTES {
-        Err(dryoc_error!(format!(
-            "signed_message length invalid ({} < {})",
+        Err(length_error!(
+            crate::ErrorContext::SignedMessage,
             signed_message.len(),
-            CRYPTO_SIGN_ED25519_BYTES,
-        )))
+            min CRYPTO_SIGN_ED25519_BYTES
+        ))
     } else if message.len() != signed_message.len() - CRYPTO_SIGN_ED25519_BYTES {
-        Err(dryoc_error!(format!(
-            "message length incorrect (expect {}, got {})",
-            signed_message.len() - CRYPTO_SIGN_ED25519_BYTES,
-            message.len()
-        )))
+        Err(length_error!(
+            crate::ErrorContext::Message,
+            message.len(),
+            exact signed_message.len() - CRYPTO_SIGN_ED25519_BYTES
+        ))
     } else {
         let (sig, sm) = signed_message.split_at(CRYPTO_SIGN_ED25519_BYTES);
         let sig: &[u8; CRYPTO_SIGN_ED25519_BYTES] =

--- a/src/classic/generichash_blake2b.rs
+++ b/src/classic/generichash_blake2b.rs
@@ -13,12 +13,12 @@ pub(crate) fn crypto_generichash_blake2b_validate_key(key: Option<&[u8]>) -> Res
             if key.len() < CRYPTO_GENERICHASH_BLAKE2B_KEYBYTES_MIN
                 || key.len() > CRYPTO_GENERICHASH_BLAKE2B_KEYBYTES_MAX
             {
-                return Err(dryoc_error!(format!(
-                    "key length is {}, should be at least {} and less than {} bytes",
+                return Err(length_error!(
+                    crate::ErrorContext::Blake2bKey,
                     key.len(),
-                    CRYPTO_GENERICHASH_BLAKE2B_KEYBYTES_MIN,
+                    range CRYPTO_GENERICHASH_BLAKE2B_KEYBYTES_MIN,
                     CRYPTO_GENERICHASH_BLAKE2B_KEYBYTES_MAX
-                )));
+                ));
             }
             Ok(())
         }
@@ -31,10 +31,12 @@ pub(crate) fn crypto_generichash_blake2b_validate_outlen(outlen: usize) -> Resul
     if !(CRYPTO_GENERICHASH_BLAKE2B_BYTES_MIN..=CRYPTO_GENERICHASH_BLAKE2B_BYTES_MAX)
         .contains(&outlen)
     {
-        return Err(dryoc_error!(format!(
-            "output length is {}, expected at least {} and less than {} bytes",
-            outlen, CRYPTO_GENERICHASH_BLAKE2B_BYTES_MIN, CRYPTO_GENERICHASH_BLAKE2B_BYTES_MAX
-        )));
+        return Err(length_error!(
+            crate::ErrorContext::Output,
+            outlen,
+            range CRYPTO_GENERICHASH_BLAKE2B_BYTES_MIN,
+            CRYPTO_GENERICHASH_BLAKE2B_BYTES_MAX
+        ));
     }
     Ok(())
 }

--- a/src/classic/generichash_blake2b.rs
+++ b/src/classic/generichash_blake2b.rs
@@ -78,3 +78,49 @@ pub(crate) fn crypto_generichash_blake2b_final(
 ) -> Result<(), Error> {
     state.finalize(output)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ErrorContext, LengthConstraint};
+
+    #[test]
+    fn validation_reports_key_and_output_bounds() {
+        assert!(crypto_generichash_blake2b_validate_key(None).is_ok());
+        assert!(
+            crypto_generichash_blake2b_validate_key(Some(
+                &[0u8; CRYPTO_GENERICHASH_BLAKE2B_KEYBYTES_MIN]
+            ))
+            .is_ok()
+        );
+
+        for key_len in [
+            CRYPTO_GENERICHASH_BLAKE2B_KEYBYTES_MIN - 1,
+            CRYPTO_GENERICHASH_BLAKE2B_KEYBYTES_MAX + 1,
+        ] {
+            let key = vec![0u8; key_len];
+            assert!(matches!(
+                crypto_generichash_blake2b_validate_key(Some(&key)),
+                Err(Error::InvalidLength {
+                    context: ErrorContext::Blake2bKey,
+                    actual,
+                    constraint: LengthConstraint::Between { .. },
+                }) if actual == key_len
+            ));
+        }
+
+        for output_len in [
+            CRYPTO_GENERICHASH_BLAKE2B_BYTES_MIN - 1,
+            CRYPTO_GENERICHASH_BLAKE2B_BYTES_MAX + 1,
+        ] {
+            assert!(matches!(
+                crypto_generichash_blake2b_validate_outlen(output_len),
+                Err(Error::InvalidLength {
+                    context: ErrorContext::Output,
+                    actual,
+                    constraint: LengthConstraint::Between { .. },
+                }) if actual == output_len
+            ));
+        }
+    }
+}

--- a/src/dryocaead.rs
+++ b/src/dryocaead.rs
@@ -13,10 +13,10 @@
 //! key. [`DryocAeadEnvelope`] generates and stores a nonce for each message;
 //! callers using [`DryocAead`] must manage this uniqueness themselves.
 //!
-//! If the `serde` feature is enabled, `serde::Deserialize` and
-//! `serde::Serialize` are implemented for [`AeadBox`] and [`AeadEnvelope`].
+//! If the `serde` feature is enabled, [`serde::Deserialize`] and
+//! [`serde::Serialize`] are implemented for [`AeadBox`] and [`AeadEnvelope`].
 //! If the `wincode` feature is enabled,
-//! `wincode::SchemaRead` and `wincode::SchemaWrite`
+//! [`wincode::SchemaRead`] and [`wincode::SchemaWrite`]
 //! are implemented for [`VecBox`] and [`VecEnvelope`].
 //!
 //! ## Rustaceous API example
@@ -423,13 +423,8 @@ impl<
                 bytes.split_at(bytes.len() - CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES);
             Ok(Self {
                 algorithm: PhantomData,
-                tag: Mac::try_from(tag).map_err(|_| {
-                    length_error!(
-                        crate::ErrorContext::AuthenticationTag,
-                        tag.len(),
-                        exact CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES
-                    )
-                })?,
+                tag: Mac::try_from(tag)
+                    .map_err(|_| Error::invalid_encoding(crate::ErrorContext::AuthenticationTag))?,
                 data: Data::from(data),
             })
         }
@@ -464,20 +459,10 @@ impl<
             let (data, tag) = rest.split_at(rest.len() - CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES);
             Ok(Self {
                 algorithm: PhantomData,
-                nonce: Nonce::try_from(nonce).map_err(|_| {
-                    length_error!(
-                        crate::ErrorContext::Nonce,
-                        nonce.len(),
-                        exact CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES
-                    )
-                })?,
-                tag: Mac::try_from(tag).map_err(|_| {
-                    length_error!(
-                        crate::ErrorContext::AuthenticationTag,
-                        tag.len(),
-                        exact CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES
-                    )
-                })?,
+                nonce: Nonce::try_from(nonce)
+                    .map_err(|_| Error::invalid_encoding(crate::ErrorContext::Nonce))?,
+                tag: Mac::try_from(tag)
+                    .map_err(|_| Error::invalid_encoding(crate::ErrorContext::AuthenticationTag))?,
                 data: Data::from(data),
             })
         }

--- a/src/dryocaead.rs
+++ b/src/dryocaead.rs
@@ -9,10 +9,10 @@
 //! dryoc to generate a random XChaCha nonce and store it with the ciphertext as
 //! `nonce || ciphertext || tag`.
 //!
-//! If the `serde` feature is enabled, [`serde::Deserialize`] and
-//! [`serde::Serialize`] are implemented for [`AeadBox`] and [`AeadEnvelope`].
+//! If the `serde` feature is enabled, `serde::Deserialize` and
+//! `serde::Serialize` are implemented for [`AeadBox`] and [`AeadEnvelope`].
 //! If the `wincode` feature is enabled,
-//! [`wincode::SchemaRead`] and [`wincode::SchemaWrite`]
+//! `wincode::SchemaRead` and `wincode::SchemaWrite`
 //! are implemented for [`VecBox`] and [`VecEnvelope`].
 //!
 //! ## Rustaceous API example
@@ -390,17 +390,23 @@ impl<
     /// Initializes an [`AeadBox`] from `ciphertext || tag`.
     pub fn from_bytes(bytes: &'a [u8]) -> Result<Self, Error> {
         if bytes.len() < CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES {
-            Err(dryoc_error!(format!(
-                "bytes of len {} less than expected minimum of {}",
+            Err(length_error!(
+                crate::ErrorContext::AeadCiphertext,
                 bytes.len(),
-                CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES
-            )))
+                min CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES
+            ))
         } else {
             let (data, tag) =
                 bytes.split_at(bytes.len() - CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES);
             Ok(Self {
                 algorithm: PhantomData,
-                tag: Mac::try_from(tag).map_err(|_e| dryoc_error!("invalid tag"))?,
+                tag: Mac::try_from(tag).map_err(|_| {
+                    length_error!(
+                        crate::ErrorContext::AuthenticationTag,
+                        tag.len(),
+                        exact CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES
+                    )
+                })?,
                 data: Data::from(data),
             })
         }
@@ -423,18 +429,26 @@ impl<
         let minimum_len = CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES
             + CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES;
         if bytes.len() < minimum_len {
-            Err(dryoc_error!(format!(
-                "bytes of len {} less than expected minimum of {}",
-                bytes.len(),
-                minimum_len
-            )))
+            Err(length_error!(crate::ErrorContext::AeadEnvelope, bytes.len(), min minimum_len))
         } else {
             let (nonce, rest) = bytes.split_at(CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES);
             let (data, tag) = rest.split_at(rest.len() - CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES);
             Ok(Self {
                 algorithm: PhantomData,
-                nonce: Nonce::try_from(nonce).map_err(|_e| dryoc_error!("invalid nonce"))?,
-                tag: Mac::try_from(tag).map_err(|_e| dryoc_error!("invalid tag"))?,
+                nonce: Nonce::try_from(nonce).map_err(|_| {
+                    length_error!(
+                        crate::ErrorContext::Nonce,
+                        nonce.len(),
+                        exact CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES
+                    )
+                })?,
+                tag: Mac::try_from(tag).map_err(|_| {
+                    length_error!(
+                        crate::ErrorContext::AuthenticationTag,
+                        tag.len(),
+                        exact CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES
+                    )
+                })?,
                 data: Data::from(data),
             })
         }

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -17,10 +17,10 @@
 //! this, by generating an ephemeral secret key, deriving a nonce, and including
 //! the sender's public key in the box.
 //!
-//! If the `serde` feature is enabled, the [`serde::Deserialize`] and
-//! [`serde::Serialize`] traits will be implemented for [`DryocBox`]. If the
+//! If the `serde` feature is enabled, the `serde::Deserialize` and
+//! `serde::Serialize` traits will be implemented for [`DryocBox`]. If the
 //! `wincode` feature is enabled, the
-//! [`wincode::SchemaRead`] and [`wincode::SchemaWrite`] traits will be
+//! `wincode::SchemaRead` and `wincode::SchemaWrite` traits will be
 //! implemented.
 //!
 //! ## Rustaceous API example
@@ -404,16 +404,14 @@ impl<
     /// with the remaining bytes containing the encrypted message.
     pub fn from_bytes(bytes: &'a [u8]) -> Result<Self, Error> {
         if bytes.len() < CRYPTO_BOX_MACBYTES {
-            Err(dryoc_error!(format!(
-                "bytes of len {} less than expected minimum of {}",
-                bytes.len(),
-                CRYPTO_BOX_MACBYTES
-            )))
+            Err(length_error!(crate::ErrorContext::Box, bytes.len(), min CRYPTO_BOX_MACBYTES))
         } else {
             let (tag, data) = bytes.split_at(CRYPTO_BOX_MACBYTES);
             Ok(Self {
                 ephemeral_pk: None,
-                tag: Mac::try_from(tag).map_err(|_e| dryoc_error!("invalid tag"))?,
+                tag: Mac::try_from(tag).map_err(
+                    |_| length_error!(crate::ErrorContext::AuthenticationTag, tag.len(), exact CRYPTO_BOX_MACBYTES),
+                )?,
                 data: Data::from(data),
             })
         }
@@ -425,20 +423,21 @@ impl<
     /// tag, with the remaining bytes containing the encrypted message.
     pub fn from_sealed_bytes(bytes: &'a [u8]) -> Result<Self, Error> {
         if bytes.len() < CRYPTO_BOX_SEALBYTES {
-            Err(dryoc_error!(format!(
-                "bytes of len {} less than expected minimum of {}",
-                bytes.len(),
-                CRYPTO_BOX_SEALBYTES
-            )))
+            Err(
+                length_error!(crate::ErrorContext::SealedBox, bytes.len(), min CRYPTO_BOX_SEALBYTES),
+            )
         } else {
             let (seal, data) = bytes.split_at(CRYPTO_BOX_SEALBYTES);
             let (epk, tag) = seal.split_at(CRYPTO_BOX_PUBLICKEYBYTES);
             Ok(Self {
                 ephemeral_pk: Some(
-                    EphemeralPublicKey::try_from(epk)
-                        .map_err(|_e| dryoc_error!("invalid ephemeral public key"))?,
+                    EphemeralPublicKey::try_from(epk).map_err(|_| {
+                        length_error!(crate::ErrorContext::EphemeralPublicKey, epk.len(), exact CRYPTO_BOX_PUBLICKEYBYTES)
+                    })?,
                 ),
-                tag: Mac::try_from(tag).map_err(|_e| dryoc_error!("invalid tag"))?,
+                tag: Mac::try_from(tag).map_err(|_| {
+                    length_error!(crate::ErrorContext::AuthenticationTag, tag.len(), exact CRYPTO_BOX_MACBYTES)
+                })?,
                 data: Data::from(data),
             })
         }
@@ -564,9 +563,9 @@ impl<
 
                 Ok(message)
             }
-            None => Err(dryoc_error!(
-                "ephemeral public key is missing, cannot unseal"
-            )),
+            None => Err(Error::MissingData {
+                context: crate::ErrorContext::EphemeralPublicKey,
+            }),
         }
     }
 

--- a/src/dryocbox.rs
+++ b/src/dryocbox.rs
@@ -24,9 +24,9 @@
 //! derives its nonce from a newly generated ephemeral public key and the
 //! recipient public key.
 //!
-//! With the `serde` feature, `serde::Deserialize` and `serde::Serialize` are
-//! implemented for [`DryocBox`]. With `wincode`, `wincode::SchemaRead` and
-//! `wincode::SchemaWrite` are implemented.
+//! With the `serde` feature, [`serde::Deserialize`] and [`serde::Serialize`]
+//! are implemented for [`DryocBox`]. With `wincode`, [`wincode::SchemaRead`]
+//! and [`wincode::SchemaWrite`] are implemented.
 //!
 //! ## Rustaceous API example
 //!
@@ -438,9 +438,8 @@ impl<
             let (tag, data) = bytes.split_at(CRYPTO_BOX_MACBYTES);
             Ok(Self {
                 ephemeral_pk: None,
-                tag: Mac::try_from(tag).map_err(
-                    |_| length_error!(crate::ErrorContext::AuthenticationTag, tag.len(), exact CRYPTO_BOX_MACBYTES),
-                )?,
+                tag: Mac::try_from(tag)
+                    .map_err(|_| Error::invalid_encoding(crate::ErrorContext::AuthenticationTag))?,
                 data: Data::from(data),
             })
         }
@@ -466,13 +465,11 @@ impl<
             let (epk, tag) = seal.split_at(CRYPTO_BOX_PUBLICKEYBYTES);
             Ok(Self {
                 ephemeral_pk: Some(
-                    EphemeralPublicKey::try_from(epk).map_err(|_| {
-                        length_error!(crate::ErrorContext::EphemeralPublicKey, epk.len(), exact CRYPTO_BOX_PUBLICKEYBYTES)
-                    })?,
+                    EphemeralPublicKey::try_from(epk)
+                        .map_err(|_| Error::invalid_key(crate::ErrorContext::EphemeralPublicKey))?,
                 ),
-                tag: Mac::try_from(tag).map_err(|_| {
-                    length_error!(crate::ErrorContext::AuthenticationTag, tag.len(), exact CRYPTO_BOX_MACBYTES)
-                })?,
+                tag: Mac::try_from(tag)
+                    .map_err(|_| Error::invalid_encoding(crate::ErrorContext::AuthenticationTag))?,
                 data: Data::from(data),
             })
         }
@@ -616,9 +613,7 @@ impl<
 
                 Ok(message)
             }
-            None => Err(Error::MissingData {
-                context: crate::ErrorContext::EphemeralPublicKey,
-            }),
+            None => Err(Error::missing_data(crate::ErrorContext::EphemeralPublicKey)),
         }
     }
 
@@ -825,6 +820,23 @@ impl<
 mod tests {
     use super::*;
     use crate::precalc::PrecalcSecretKey;
+
+    #[test]
+    fn unseal_requires_an_ephemeral_public_key() {
+        let box_without_ephemeral_key =
+            VecBox::from_bytes(&[0u8; CRYPTO_BOX_MACBYTES]).expect("a regular box should parse");
+        let recipient_keypair = KeyPair::generate();
+
+        let error = box_without_ephemeral_key
+            .unseal::<_, _, Vec<u8>>(&recipient_keypair)
+            .expect_err("a regular box cannot be unsealed");
+        assert!(matches!(
+            error,
+            Error::MissingData {
+                context: crate::ErrorContext::EphemeralPublicKey,
+            }
+        ));
+    }
 
     #[test]
     fn test_decrypt_failure_empty() {

--- a/src/dryocsecretbox.rs
+++ b/src/dryocsecretbox.rs
@@ -14,10 +14,10 @@
 //!   * a passphrase with a strong password hashing function, such as
 //!     [`crypto_pwhash`](crate::classic::crypto_pwhash)
 //!
-//! If the `serde` feature is enabled, the [`serde::Deserialize`] and
-//! [`serde::Serialize`] traits will be implemented for [`DryocSecretBox`]. If
+//! If the `serde` feature is enabled, the `serde::Deserialize` and
+//! `serde::Serialize` traits will be implemented for [`DryocSecretBox`]. If
 //! the `wincode` feature is enabled, the
-//! [`wincode::SchemaRead`] and [`wincode::SchemaWrite`] traits will be
+//! `wincode::SchemaRead` and `wincode::SchemaWrite` traits will be
 //! implemented.
 //!
 //! ## Rustaceous API example
@@ -241,15 +241,15 @@ impl<
     /// encrypted message.
     pub fn from_bytes(bytes: &'a [u8]) -> Result<Self, Error> {
         if bytes.len() < CRYPTO_SECRETBOX_MACBYTES {
-            Err(dryoc_error!(format!(
-                "bytes of len {} less than expected minimum of {}",
-                bytes.len(),
-                CRYPTO_SECRETBOX_MACBYTES
-            )))
+            Err(
+                length_error!(crate::ErrorContext::SecretBox, bytes.len(), min CRYPTO_SECRETBOX_MACBYTES),
+            )
         } else {
             let (tag, data) = bytes.split_at(CRYPTO_SECRETBOX_MACBYTES);
             Ok(Self {
-                tag: Mac::try_from(tag).map_err(|_e| dryoc_error!("invalid tag"))?,
+                tag: Mac::try_from(tag).map_err(|_| {
+                    length_error!(crate::ErrorContext::AuthenticationTag, tag.len(), exact CRYPTO_SECRETBOX_MACBYTES)
+                })?,
                 data: Data::from(data),
             })
         }

--- a/src/dryocsecretbox.rs
+++ b/src/dryocsecretbox.rs
@@ -22,9 +22,9 @@
 //! key. Store each nonce with its ciphertext or use a counter that cannot
 //! repeat for that key.
 //!
-//! With the `serde` feature, `serde::Deserialize` and `serde::Serialize` are
-//! implemented for [`DryocSecretBox`]. With `wincode`, `wincode::SchemaRead`
-//! and `wincode::SchemaWrite` are implemented.
+//! With the `serde` feature, [`serde::Deserialize`] and [`serde::Serialize`]
+//! are implemented for [`DryocSecretBox`]. With `wincode`,
+//! [`wincode::SchemaRead`] and [`wincode::SchemaWrite`] are implemented.
 //!
 //! ## Rustaceous API example
 //!
@@ -261,9 +261,8 @@ impl<
         } else {
             let (tag, data) = bytes.split_at(CRYPTO_SECRETBOX_MACBYTES);
             Ok(Self {
-                tag: Mac::try_from(tag).map_err(|_| {
-                    length_error!(crate::ErrorContext::AuthenticationTag, tag.len(), exact CRYPTO_SECRETBOX_MACBYTES)
-                })?,
+                tag: Mac::try_from(tag)
+                    .map_err(|_| Error::invalid_encoding(crate::ErrorContext::AuthenticationTag))?,
                 data: Data::from(data),
             })
         }

--- a/src/dryocstream.rs
+++ b/src/dryocstream.rs
@@ -291,11 +291,11 @@ impl DryocStream<Pull> {
     ) -> Result<(Output, Tag), Error> {
         use crate::constants::CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES;
         if ciphertext.as_slice().len() < CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES {
-            return Err(dryoc_error!(format!(
-                "Ciphertext length was {}, should be at least {}",
+            return Err(length_error!(
+                crate::ErrorContext::Ciphertext,
                 ciphertext.as_slice().len(),
-                CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES
-            )));
+                min CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_ABYTES
+            ));
         }
 
         let mut message = Output::default();
@@ -312,7 +312,7 @@ impl DryocStream<Pull> {
             associated_data.map(|aad| aad.as_slice()),
         )?;
 
-        Ok((message, Tag::from_bits(tag).expect("invalid tag")))
+        Ok((message, Tag::try_from(tag)?))
     }
 
     /// Decrypts `ciphertext` for this stream with `associated_data`, returning

--- a/src/dryocstream/tag.rs
+++ b/src/dryocstream/tag.rs
@@ -349,9 +349,17 @@ impl IntoIterator for Tag {
     }
 }
 
-impl From<u8> for Tag {
-    fn from(other: u8) -> Self {
-        Self::from_bits(other).expect("Unable to parse tag")
+impl TryFrom<u8> for Tag {
+    type Error = crate::Error;
+
+    fn try_from(other: u8) -> Result<Self, Self::Error> {
+        Self::from_bits(other).ok_or(crate::Error::InvalidValue {
+            context: crate::ErrorContext::Tag,
+            actual: other as u64,
+            constraint: crate::ValueConstraint::AllowedBits {
+                mask: Self::KNOWN_BITS as u64,
+            },
+        })
     }
 }
 
@@ -436,7 +444,10 @@ mod tests {
             assert_eq!(Tag::from_bits(bits), expected);
         }
 
-        assert_eq!(Tag::from(Tag::FINAL.bits()), Tag::FINAL);
+        assert_eq!(
+            Tag::try_from(Tag::FINAL.bits()).expect("known tag bits should be accepted"),
+            Tag::FINAL
+        );
         assert_eq!(Tag::from_name("MESSAGE"), Some(Tag::MESSAGE));
         assert_eq!(Tag::from_name("PUSH"), Some(Tag::PUSH));
         assert_eq!(Tag::from_name("REKEY"), Some(Tag::REKEY));
@@ -445,9 +456,17 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Unable to parse tag")]
     fn tag_from_u8_rejects_unknown_bits() {
-        let _ = Tag::from(0x80);
+        let error = Tag::try_from(0x80).expect_err("unknown tag bits should be rejected");
+
+        assert!(matches!(
+            error,
+            crate::Error::InvalidValue {
+                context: crate::ErrorContext::Tag,
+                actual: 0x80,
+                constraint: crate::ValueConstraint::AllowedBits { .. },
+            }
+        ));
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -243,6 +243,28 @@ pub enum Error {
     Io(std::io::Error),
 }
 
+impl Error {
+    pub(crate) const fn invalid_encoding(context: ErrorContext) -> Self {
+        Self::InvalidEncoding { context }
+    }
+
+    pub(crate) const fn invalid_key(context: ErrorContext) -> Self {
+        Self::InvalidKey { context }
+    }
+
+    pub(crate) const fn missing_data(context: ErrorContext) -> Self {
+        Self::MissingData { context }
+    }
+
+    pub(crate) const fn invalid_state(context: ErrorContext) -> Self {
+        Self::InvalidState { context }
+    }
+
+    pub(crate) const fn arithmetic_overflow(context: ErrorContext) -> Self {
+        Self::ArithmeticOverflow { context }
+    }
+}
+
 impl From<std::io::Error> for Error {
     fn from(error: std::io::Error) -> Self {
         Self::Io(error)
@@ -324,7 +346,7 @@ macro_rules! length_error {
     };
 }
 
-macro_rules! validate {
+macro_rules! validate_value {
     ($min:expr_2021, $max:expr_2021, $value:expr_2021, $context:expr_2021) => {
         if !($min..=$max).contains(&$value) {
             return Err(crate::error::Error::InvalidValue {
@@ -340,6 +362,11 @@ macro_rules! validate {
 }
 
 macro_rules! validate_length {
+    (exact $expected:expr_2021, $value:expr_2021, $context:expr_2021) => {
+        if $value != $expected {
+            return Err(length_error!($context, $value, exact $expected));
+        }
+    };
     ($min:expr_2021, $max:expr_2021, $value:expr_2021, $context:expr_2021) => {
         if !($min..=$max).contains(&$value) {
             return Err(length_error!($context, $value, range $min, $max));
@@ -350,6 +377,98 @@ macro_rules! validate_length {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn contexts_have_clear_human_readable_names() {
+        let cases = [
+            (ErrorContext::AssociatedData, "associated data"),
+            (ErrorContext::AeadCiphertext, "AEAD ciphertext"),
+            (ErrorContext::AeadEnvelope, "AEAD envelope"),
+            (ErrorContext::AuthenticationTag, "authentication tag"),
+            (ErrorContext::Blake2bKey, "BLAKE2b key"),
+            (ErrorContext::Blake2bOutput, "BLAKE2b output"),
+            (ErrorContext::Blake2b, "BLAKE2b"),
+            (ErrorContext::Box, "box"),
+            (ErrorContext::Ciphertext, "ciphertext"),
+            (ErrorContext::Curve25519PublicKey, "Curve25519 public key"),
+            (ErrorContext::Data, "data"),
+            (ErrorContext::Ed25519PublicKey, "Ed25519 public key"),
+            (ErrorContext::EphemeralPublicKey, "ephemeral public key"),
+            (ErrorContext::MemoryCost, "memory cost"),
+            (ErrorContext::MemoryLimit, "memory limit"),
+            (ErrorContext::Message, "message"),
+            (ErrorContext::Nonce, "nonce"),
+            (ErrorContext::OperationsLimit, "operations limit"),
+            (ErrorContext::Output, "output"),
+            (ErrorContext::Parallelism, "parallelism"),
+            (ErrorContext::Password, "password"),
+            (ErrorContext::PasswordHash, "password hash"),
+            (
+                ErrorContext::PasswordHashAlgorithm,
+                "password hash algorithm",
+            ),
+            (
+                ErrorContext::PasswordHashMemoryCost,
+                "password hash memory cost",
+            ),
+            (
+                ErrorContext::PasswordHashParallelism,
+                "password hash parallelism",
+            ),
+            (ErrorContext::PasswordHashSalt, "password hash salt"),
+            (
+                ErrorContext::PasswordHashTimeCost,
+                "password hash time cost",
+            ),
+            (ErrorContext::PasswordHashVersion, "password hash version"),
+            (ErrorContext::ProtectedMemory, "protected memory"),
+            (ErrorContext::PublicKey, "public key"),
+            (ErrorContext::SealedBox, "sealed box"),
+            (ErrorContext::Secret, "secret"),
+            (ErrorContext::SecretBox, "secretbox"),
+            (ErrorContext::SecretKey, "secret key"),
+            (ErrorContext::Signature, "signature"),
+            (ErrorContext::SignedMessage, "signed message"),
+            (ErrorContext::Slice, "slice"),
+            (ErrorContext::Subkey, "subkey"),
+            (ErrorContext::Tag, "tag"),
+            (ErrorContext::TimeCost, "time cost"),
+        ];
+
+        for (context, expected) in cases {
+            assert_eq!(context.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn constraints_describe_their_requirements() {
+        let length_cases = [
+            (LengthConstraint::Exact(4), "exactly 4"),
+            (LengthConstraint::AtLeast(4), "at least 4"),
+            (LengthConstraint::AtMost(4), "at most 4"),
+            (
+                LengthConstraint::Between { min: 2, max: 4 },
+                "between 2 and 4 (inclusive)",
+            ),
+        ];
+        for (constraint, expected) in length_cases {
+            assert_eq!(constraint.to_string(), expected);
+        }
+
+        let value_cases = [
+            (
+                ValueConstraint::Between { min: 2, max: 4 },
+                "between 2 and 4 (inclusive)",
+            ),
+            (
+                ValueConstraint::AllowedBits { mask: 0x3 },
+                "a value containing only bits from mask 0x3",
+            ),
+        ];
+        for (constraint, expected) in value_cases {
+            assert_eq!(constraint.to_string(), expected);
+        }
+    }
 
     #[test]
     fn display_is_human_readable_without_source_locations() {
@@ -452,5 +571,6 @@ mod tests {
         assert!(debug.contains("PermissionDenied"));
         assert!(debug.contains("access denied"));
         assert!(error.source().is_some());
+        assert!(Error::AuthenticationFailed.source().is_none());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,51 +1,282 @@
 use std::fmt::{Display, Formatter};
 
+/// The input, output, or operation associated with an [`Error`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ErrorContext {
+    /// Associated data supplied to an authenticated operation.
+    AssociatedData,
+    /// An authenticated-encryption ciphertext.
+    AeadCiphertext,
+    /// An authenticated-encryption envelope.
+    AeadEnvelope,
+    /// A message authentication tag.
+    AuthenticationTag,
+    /// A BLAKE2b key.
+    Blake2bKey,
+    /// BLAKE2b output.
+    Blake2bOutput,
+    /// A BLAKE2b operation or state.
+    Blake2b,
+    /// An authenticated public-key box.
+    Box,
+    /// Ciphertext input or output.
+    Ciphertext,
+    /// A Curve25519 public key.
+    Curve25519PublicKey,
+    /// An in-place data buffer.
+    Data,
+    /// An Ed25519 public key.
+    Ed25519PublicKey,
+    /// An ephemeral public key.
+    EphemeralPublicKey,
+    /// An Argon2 memory-cost parameter.
+    MemoryCost,
+    /// A password-hashing memory limit.
+    MemoryLimit,
+    /// Plaintext message input or output.
+    Message,
+    /// A nonce.
+    Nonce,
+    /// A password-hashing operations limit.
+    OperationsLimit,
+    /// A generic output buffer.
+    Output,
+    /// An Argon2 parallelism parameter.
+    Parallelism,
+    /// A password.
+    Password,
+    /// An encoded password hash or its hash field.
+    PasswordHash,
+    /// A password-hash algorithm field.
+    PasswordHashAlgorithm,
+    /// A password-hash memory-cost field.
+    PasswordHashMemoryCost,
+    /// A password-hash parallelism field.
+    PasswordHashParallelism,
+    /// A password-hash salt field.
+    PasswordHashSalt,
+    /// A password-hash time-cost field.
+    PasswordHashTimeCost,
+    /// A password-hash version field.
+    PasswordHashVersion,
+    /// A protected-memory value or operation.
+    ProtectedMemory,
+    /// A public key.
+    PublicKey,
+    /// A sealed public-key box.
+    SealedBox,
+    /// An Argon2 secret input.
+    Secret,
+    /// An authenticated secret-key box.
+    SecretBox,
+    /// A secret key.
+    SecretKey,
+    /// A signature.
+    Signature,
+    /// A signed message.
+    SignedMessage,
+    /// A byte slice.
+    Slice,
+    /// A derived subkey.
+    Subkey,
+    /// A secretstream message tag.
+    Tag,
+    /// An Argon2 time-cost parameter.
+    TimeCost,
+}
+
+impl Display for ErrorContext {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::AssociatedData => "associated data",
+            Self::AeadCiphertext => "AEAD ciphertext",
+            Self::AeadEnvelope => "AEAD envelope",
+            Self::AuthenticationTag => "authentication tag",
+            Self::Blake2bKey => "BLAKE2b key",
+            Self::Blake2bOutput => "BLAKE2b output",
+            Self::Blake2b => "BLAKE2b",
+            Self::Box => "box",
+            Self::Ciphertext => "ciphertext",
+            Self::Curve25519PublicKey => "Curve25519 public key",
+            Self::Data => "data",
+            Self::Ed25519PublicKey => "Ed25519 public key",
+            Self::EphemeralPublicKey => "ephemeral public key",
+            Self::MemoryCost => "memory cost",
+            Self::MemoryLimit => "memory limit",
+            Self::Message => "message",
+            Self::Nonce => "nonce",
+            Self::OperationsLimit => "operations limit",
+            Self::Output => "output",
+            Self::Parallelism => "parallelism",
+            Self::Password => "password",
+            Self::PasswordHash => "password hash",
+            Self::PasswordHashAlgorithm => "password hash algorithm",
+            Self::PasswordHashMemoryCost => "password hash memory cost",
+            Self::PasswordHashParallelism => "password hash parallelism",
+            Self::PasswordHashSalt => "password hash salt",
+            Self::PasswordHashTimeCost => "password hash time cost",
+            Self::PasswordHashVersion => "password hash version",
+            Self::ProtectedMemory => "protected memory",
+            Self::PublicKey => "public key",
+            Self::SealedBox => "sealed box",
+            Self::Secret => "secret",
+            Self::SecretBox => "secretbox",
+            Self::SecretKey => "secret key",
+            Self::Signature => "signature",
+            Self::SignedMessage => "signed message",
+            Self::Slice => "slice",
+            Self::Subkey => "subkey",
+            Self::Tag => "tag",
+            Self::TimeCost => "time cost",
+        })
+    }
+}
+
+/// A constraint on a byte or buffer length.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum LengthConstraint {
+    /// The length must equal this value.
+    Exact(usize),
+    /// The length must be at least this value.
+    AtLeast(usize),
+    /// The length must be at most this value.
+    AtMost(usize),
+    /// The length must be within this inclusive range.
+    Between { min: usize, max: usize },
+}
+
+impl Display for LengthConstraint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Exact(expected) => write!(f, "exactly {expected}"),
+            Self::AtLeast(min) => write!(f, "at least {min}"),
+            Self::AtMost(max) => write!(f, "at most {max}"),
+            Self::Between { min, max } => write!(f, "between {min} and {max} (inclusive)"),
+        }
+    }
+}
+
+/// A constraint on a numeric parameter.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ValueConstraint {
+    /// The value must be within this inclusive range.
+    Between { min: u64, max: u64 },
+    /// Only bits present in this mask may be set.
+    AllowedBits { mask: u64 },
+}
+
+impl Display for ValueConstraint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Between { min, max } => write!(f, "between {min} and {max} (inclusive)"),
+            Self::AllowedBits { mask } => {
+                write!(f, "a value containing only bits from mask 0x{mask:x}")
+            }
+        }
+    }
+}
+
 /// Errors generated by Dryoc.
 ///
-/// Most errors just contain a message as to what went wrong.
-/// I/O errors are forwarded through.
+/// Variants are structured so callers can handle failures without parsing the
+/// human-readable message. Display text is not part of the API contract.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
-    /// An internal Dryoc error.
-    Message(String),
+    /// Authentication or signature verification failed.
+    AuthenticationFailed,
 
-    /// Some I/O problem occurred.
+    /// A byte string or buffer had an invalid length.
+    InvalidLength {
+        /// The input or output whose length was invalid.
+        context: ErrorContext,
+        /// The supplied length.
+        actual: usize,
+        /// The required length constraint.
+        constraint: LengthConstraint,
+    },
+
+    /// A numeric parameter was outside its supported range.
+    InvalidValue {
+        /// The parameter whose value was invalid.
+        context: ErrorContext,
+        /// The supplied value.
+        actual: u64,
+        /// The required value constraint.
+        constraint: ValueConstraint,
+    },
+
+    /// Encoded data was malformed or unsupported.
+    InvalidEncoding {
+        /// The encoded field or format that was invalid.
+        context: ErrorContext,
+    },
+
+    /// A cryptographic key was invalid or unsafe to use.
+    InvalidKey {
+        /// The key whose value was invalid.
+        context: ErrorContext,
+    },
+
+    /// Required data was absent.
+    MissingData {
+        /// The missing field or value.
+        context: ErrorContext,
+    },
+
+    /// The requested operation was invalid for the current state.
+    InvalidState {
+        /// The state or operation that was invalid.
+        context: ErrorContext,
+    },
+
+    /// An arithmetic operation overflowed.
+    ArithmeticOverflow {
+        /// The value being calculated.
+        context: ErrorContext,
+    },
+
+    /// An operating-system I/O operation failed.
     Io(std::io::Error),
-
-    /// Unable to convert data from slice.
-    FromSlice(core::array::TryFromSliceError),
-}
-
-impl From<String> for Error {
-    fn from(message: String) -> Self {
-        Error::Message(message)
-    }
-}
-
-impl From<&str> for Error {
-    fn from(message: &str) -> Self {
-        Error::Message(message.into())
-    }
 }
 
 impl From<std::io::Error> for Error {
     fn from(error: std::io::Error) -> Self {
-        Error::Io(error)
-    }
-}
-
-impl From<core::array::TryFromSliceError> for Error {
-    fn from(error: core::array::TryFromSliceError) -> Self {
-        Error::FromSlice(error)
+        Self::Io(error)
     }
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::Message(message) => f.write_str(message),
-            Error::Io(err) => write!(f, "I/O error: {}", err),
-            Error::FromSlice(err) => write!(f, "From slice error: {}", err),
+            Self::AuthenticationFailed => f.write_str("authentication failed"),
+            Self::InvalidLength {
+                context,
+                actual,
+                constraint,
+            } => write!(
+                f,
+                "invalid {context} length: expected {constraint}, got {actual}"
+            ),
+            Self::InvalidValue {
+                context,
+                actual,
+                constraint,
+            } => write!(
+                f,
+                "invalid {context} value: expected {constraint}, got {actual}"
+            ),
+            Self::InvalidEncoding { context } => write!(f, "invalid {context} encoding"),
+            Self::InvalidKey { context } => write!(f, "invalid {context}"),
+            Self::MissingData { context } => write!(f, "missing {context}"),
+            Self::InvalidState { context } => write!(f, "invalid {context} state"),
+            Self::ArithmeticOverflow { context } => {
+                write!(f, "arithmetic overflow while calculating {context} length")
+            }
+            Self::Io(error) => write!(f, "I/O error: {error}"),
         }
     }
 }
@@ -53,29 +284,173 @@ impl Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::Message(_) => None,
-            Error::Io(err) => Some(err),
-            Error::FromSlice(err) => Some(err),
+            Self::Io(error) => Some(error),
+            _ => None,
         }
     }
 }
 
-macro_rules! dryoc_error {
-    ($msg:expr_2021) => {{ crate::error::Error::from(format!("{}, from {}:{}", $msg, file!(), line!())) }};
+macro_rules! length_error {
+    ($context:expr_2021, $actual:expr_2021,exact $expected:expr_2021) => {
+        crate::error::Error::InvalidLength {
+            context: $context,
+            actual: $actual,
+            constraint: crate::error::LengthConstraint::Exact($expected),
+        }
+    };
+    ($context:expr_2021, $actual:expr_2021,min $min:expr_2021) => {
+        crate::error::Error::InvalidLength {
+            context: $context,
+            actual: $actual,
+            constraint: crate::error::LengthConstraint::AtLeast($min),
+        }
+    };
+    ($context:expr_2021, $actual:expr_2021,max $max:expr_2021) => {
+        crate::error::Error::InvalidLength {
+            context: $context,
+            actual: $actual,
+            constraint: crate::error::LengthConstraint::AtMost($max),
+        }
+    };
+    ($context:expr_2021, $actual:expr_2021,range $min:expr_2021, $max:expr_2021) => {
+        crate::error::Error::InvalidLength {
+            context: $context,
+            actual: $actual,
+            constraint: crate::error::LengthConstraint::Between {
+                min: $min,
+                max: $max,
+            },
+        }
+    };
 }
 
 macro_rules! validate {
-    ($min:expr_2021, $max:expr_2021, $value:expr_2021, $name:literal) => {
-        if $value < $min {
-            return Err(dryoc_error!(format!(
-                "{} value of {} less than minimum {}",
-                $name, $value, $min
-            )));
-        } else if $value > $max {
-            return Err(dryoc_error!(format!(
-                "{} value of {} greater than maximum {}",
-                $name, $value, $max
-            )));
+    ($min:expr_2021, $max:expr_2021, $value:expr_2021, $context:expr_2021) => {
+        if !($min..=$max).contains(&$value) {
+            return Err(crate::error::Error::InvalidValue {
+                context: $context,
+                actual: $value as u64,
+                constraint: crate::error::ValueConstraint::Between {
+                    min: $min as u64,
+                    max: $max as u64,
+                },
+            });
         }
     };
+}
+
+macro_rules! validate_length {
+    ($min:expr_2021, $max:expr_2021, $value:expr_2021, $context:expr_2021) => {
+        if !($min..=$max).contains(&$value) {
+            return Err(length_error!($context, $value, range $min, $max));
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_is_human_readable_without_source_locations() {
+        let cases = [
+            (Error::AuthenticationFailed, "authentication failed"),
+            (
+                Error::InvalidLength {
+                    context: ErrorContext::Nonce,
+                    actual: 12,
+                    constraint: LengthConstraint::Exact(24),
+                },
+                "invalid nonce length: expected exactly 24, got 12",
+            ),
+            (
+                Error::InvalidLength {
+                    context: ErrorContext::Blake2bOutput,
+                    actual: 0,
+                    constraint: LengthConstraint::Between { min: 1, max: 64 },
+                },
+                "invalid BLAKE2b output length: expected between 1 and 64 (inclusive), got 0",
+            ),
+            (
+                Error::InvalidValue {
+                    context: ErrorContext::Parallelism,
+                    actual: 8,
+                    constraint: ValueConstraint::Between { min: 1, max: 4 },
+                },
+                "invalid parallelism value: expected between 1 and 4 (inclusive), got 8",
+            ),
+            (
+                Error::InvalidValue {
+                    context: ErrorContext::Tag,
+                    actual: 128,
+                    constraint: ValueConstraint::AllowedBits { mask: 3 },
+                },
+                "invalid tag value: expected a value containing only bits from mask 0x3, got 128",
+            ),
+            (
+                Error::InvalidEncoding {
+                    context: ErrorContext::PasswordHashSalt,
+                },
+                "invalid password hash salt encoding",
+            ),
+            (
+                Error::InvalidKey {
+                    context: ErrorContext::Ed25519PublicKey,
+                },
+                "invalid Ed25519 public key",
+            ),
+            (
+                Error::MissingData {
+                    context: ErrorContext::EphemeralPublicKey,
+                },
+                "missing ephemeral public key",
+            ),
+            (
+                Error::InvalidState {
+                    context: ErrorContext::Blake2b,
+                },
+                "invalid BLAKE2b state",
+            ),
+            (
+                Error::ArithmeticOverflow {
+                    context: ErrorContext::Ciphertext,
+                },
+                "arithmetic overflow while calculating ciphertext length",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn debug_is_structured_and_does_not_include_internal_source_locations() {
+        let error = Error::InvalidLength {
+            context: ErrorContext::Ciphertext,
+            actual: 7,
+            constraint: LengthConstraint::AtLeast(16),
+        };
+
+        assert_eq!(
+            format!("{error:?}"),
+            "InvalidLength { context: Ciphertext, actual: 7, constraint: AtLeast(16) }"
+        );
+    }
+
+    #[test]
+    fn wrapped_errors_preserve_their_source() {
+        use std::error::Error as _;
+
+        let error = Error::from(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "access denied",
+        ));
+        assert_eq!(error.to_string(), "I/O error: access denied");
+        let debug = format!("{error:?}");
+        assert!(debug.contains("Io"));
+        assert!(debug.contains("PermissionDenied"));
+        assert!(debug.contains("access denied"));
+        assert!(error.source().is_some());
+    }
 }

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -161,12 +161,12 @@ pub trait HkdfVariant<const PRK_LENGTH: usize> {
     /// Validates an output length before allocating output storage.
     fn validate_output_len(output_len: usize) -> Result<(), Error> {
         if output_len < Self::OUTPUT_BYTES_MIN || output_len > Self::OUTPUT_BYTES_MAX {
-            Err(dryoc_error!(format!(
-                "invalid output length {}, should be at least {} and no more than {}",
+            Err(length_error!(
+                crate::ErrorContext::Output,
                 output_len,
-                Self::OUTPUT_BYTES_MIN,
+                range Self::OUTPUT_BYTES_MIN,
                 Self::OUTPUT_BYTES_MAX
-            )))
+            ))
         } else {
             Ok(())
         }

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -370,7 +370,7 @@ where
         if valid == 1 {
             Ok(())
         } else {
-            Err(dryoc_error!("authentication codes do not match"))
+            Err(Error::AuthenticationFailed)
         }
     }
 }

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -156,15 +156,25 @@ impl<
     ///
     /// # Errors
     ///
-    /// Returns an error if either slice does not have the required key length.
+    /// Returns an error if either slice does not have the required key length,
+    /// or if the target key type rejects the key bytes.
     pub fn from_slices(public_key: &'a [u8], secret_key: &'a [u8]) -> Result<Self, Error> {
+        validate_length!(
+            exact CRYPTO_BOX_PUBLICKEYBYTES,
+            public_key.len(),
+            crate::ErrorContext::PublicKey
+        );
+        validate_length!(
+            exact CRYPTO_BOX_SECRETKEYBYTES,
+            secret_key.len(),
+            crate::ErrorContext::SecretKey
+        );
+
         Ok(Self {
-            public_key: PublicKey::try_from(public_key).map_err(
-                |_| length_error!(crate::ErrorContext::PublicKey, public_key.len(), exact CRYPTO_BOX_PUBLICKEYBYTES),
-            )?,
-            secret_key: SecretKey::try_from(secret_key).map_err(
-                |_| length_error!(crate::ErrorContext::SecretKey, secret_key.len(), exact CRYPTO_BOX_SECRETKEYBYTES),
-            )?,
+            public_key: PublicKey::try_from(public_key)
+                .map_err(|_| Error::invalid_key(crate::ErrorContext::PublicKey))?,
+            secret_key: SecretKey::try_from(secret_key)
+                .map_err(|_| Error::invalid_key(crate::ErrorContext::SecretKey))?,
         })
     }
 }

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -156,10 +156,12 @@ impl<
     /// validity or authenticity of keypair.
     pub fn from_slices(public_key: &'a [u8], secret_key: &'a [u8]) -> Result<Self, Error> {
         Ok(Self {
-            public_key: PublicKey::try_from(public_key)
-                .map_err(|_e| dryoc_error!("invalid public key"))?,
-            secret_key: SecretKey::try_from(secret_key)
-                .map_err(|_e| dryoc_error!("invalid secret key"))?,
+            public_key: PublicKey::try_from(public_key).map_err(
+                |_| length_error!(crate::ErrorContext::PublicKey, public_key.len(), exact CRYPTO_BOX_PUBLICKEYBYTES),
+            )?,
+            secret_key: SecretKey::try_from(secret_key).map_err(
+                |_| length_error!(crate::ErrorContext::SecretKey, secret_key.len(), exact CRYPTO_BOX_SECRETKEYBYTES),
+            )?,
         })
     }
 }
@@ -299,7 +301,7 @@ pub mod protected {
         >
     {
         /// Returns a new locked keypair.
-        pub fn new_locked_keypair() -> Result<Self, std::io::Error> {
+        pub fn new_locked_keypair() -> Result<Self, Error> {
             Ok(Self {
                 public_key: HeapByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::new_locked()?,
                 secret_key: HeapByteArray::<CRYPTO_BOX_SECRETKEYBYTES>::new_locked()?,
@@ -307,7 +309,7 @@ pub mod protected {
         }
 
         /// Returns a new randomly generated locked keypair.
-        pub fn generate_locked_keypair() -> Result<Self, std::io::Error> {
+        pub fn generate_locked_keypair() -> Result<Self, Error> {
             let mut res = Self::new_locked_keypair()?;
 
             crypto_box_keypair_inplace(
@@ -323,7 +325,7 @@ pub mod protected {
         /// Prefer [`generate_locked_keypair`](Self::generate_locked_keypair).
         /// This method is retained for compatibility.
         #[deprecated(note = "use generate_locked_keypair() instead")]
-        pub fn gen_locked_keypair() -> Result<Self, std::io::Error> {
+        pub fn gen_locked_keypair() -> Result<Self, Error> {
             Self::generate_locked_keypair()
         }
 
@@ -349,7 +351,7 @@ pub mod protected {
         >
     {
         /// Returns a new randomly generated locked, read-only keypair.
-        pub fn generate_readonly_locked_keypair() -> Result<Self, std::io::Error> {
+        pub fn generate_readonly_locked_keypair() -> Result<Self, Error> {
             let mut public_key = HeapByteArray::<CRYPTO_BOX_PUBLICKEYBYTES>::new_locked()?;
             let mut secret_key = HeapByteArray::<CRYPTO_BOX_SECRETKEYBYTES>::new_locked()?;
 
@@ -370,7 +372,7 @@ pub mod protected {
         /// [`generate_readonly_locked_keypair`](Self::generate_readonly_locked_keypair).
         /// This method is retained for compatibility.
         #[deprecated(note = "use generate_readonly_locked_keypair() instead")]
-        pub fn gen_readonly_locked_keypair() -> Result<Self, std::io::Error> {
+        pub fn gen_readonly_locked_keypair() -> Result<Self, Error> {
             Self::generate_readonly_locked_keypair()
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,13 @@
 //! preferences. The Rustaceous API is a wrapper around the underlying classic
 //! API.
 //!
+//! ## Error handling
+//!
+//! Fallible cryptographic operations return [`Error`]. Its structured variants
+//! let callers distinguish authentication failures, invalid lengths or values,
+//! malformed encodings, invalid keys, protected-memory failures, and invalid
+//! operation state without parsing display text.
+//!
 //! It's recommended that you use the Rustaceous API unless you have strong
 //! feelings about using the Classic API. The Classic API includes some pitfalls
 //! and traps that are also present in the original libsodium API, and unless
@@ -122,15 +129,15 @@
 //!
 //! This crate includes optional [Serde](https://serde.rs/) support which can be
 //! enabled with the `serde` feature flag. When enabled, the
-//! [`Serialize`](serde::ser::Serialize) and
-//! [`Deserialize`](serde::de::Deserialize) traits are provided for data
+//! `serde::Serialize` and
+//! `serde::Deserialize` traits are provided for data
 //! structures.
 //!
 //! ## Using wincode
 //!
 //! This crate includes optional [wincode](https://crates.io/crates/wincode)
 //! support which can be enabled with the `wincode` feature flag. When enabled,
-//! [`wincode::SchemaWrite`] and [`wincode::SchemaRead`] are provided for
+//! `wincode::SchemaWrite` and `wincode::SchemaRead` are provided for
 //! supported Rustaceous box types, including
 //! [`DryocBox`](dryocbox::DryocBox),
 //! [`DryocSecretBox`](dryocsecretbox::DryocSecretBox), and
@@ -274,7 +281,7 @@ pub mod types;
 /// # Various utility functions
 pub mod utils;
 
-pub use error::Error;
+pub use error::{Error, ErrorContext, LengthConstraint, ValueConstraint};
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,15 +109,15 @@
 //!
 //! This crate includes optional [Serde](https://serde.rs/) support which can be
 //! enabled with the `serde` feature flag. When enabled, the
-//! `serde::Serialize` and
-//! `serde::Deserialize` traits are provided for data
+//! [`Serialize`](serde::ser::Serialize) and
+//! [`Deserialize`](serde::de::Deserialize) traits are provided for data
 //! structures.
 //!
 //! ## Using wincode
 //!
 //! This crate includes optional [wincode](https://crates.io/crates/wincode)
 //! support which can be enabled with the `wincode` feature flag. When enabled,
-//! `wincode::SchemaWrite` and `wincode::SchemaRead` are provided for
+//! [`wincode::SchemaWrite`] and [`wincode::SchemaRead`] are provided for
 //! supported Rustaceous box types, including
 //! [`DryocBox`](dryocbox::DryocBox),
 //! [`DryocSecretBox`](dryocsecretbox::DryocSecretBox), and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 //! Fallible cryptographic operations return [`Error`]. Its structured variants
 //! let callers distinguish authentication failures, invalid lengths or values,
 //! malformed encodings, invalid keys, protected-memory failures, and invalid
-//! operation state without parsing display text.
+//! operation state.
 //!
 //! Prefer the Rustaceous API for new code. Use the Classic API when porting
 //! libsodium code or when its byte-array interface is a better fit.

--- a/src/onetimeauth.rs
+++ b/src/onetimeauth.rs
@@ -201,7 +201,7 @@ impl OnetimeAuth {
         {
             Ok(())
         } else {
-            Err(dryoc_error!("authentication codes do not match"))
+            Err(Error::AuthenticationFailed)
         }
     }
 }

--- a/src/protected.rs
+++ b/src/protected.rs
@@ -87,8 +87,8 @@
 //! and can fail when the process exceeds the working-set limits enforced by the
 //! OS. There is no `MADV_DONTDUMP` equivalent in this module.
 //!
-//! If the `serde` feature is enabled, the [`serde::Deserialize`] and
-//! [`serde::Serialize`] traits will be implemented for [`HeapBytes`] and
+//! If the `serde` feature is enabled, the `serde::Deserialize` and
+//! `serde::Serialize` traits will be implemented for [`HeapBytes`] and
 //! [`HeapByteArray`].
 //!
 //! ## Example
@@ -204,7 +204,7 @@ pub trait Lockable<A: Zeroize + Bytes> {
     /// Windows. By default, the protect mode is set to ReadWrite (i.e., no
     /// exec) using `mprotect()` on UNIX, or `VirtualProtect()` on Windows.
     /// On Linux, it will also set `MADV_DONTDUMP` using `madvise()`.
-    fn mlock(self) -> Result<Protected<A, traits::ReadWrite, traits::Locked>, std::io::Error>;
+    fn mlock(self) -> Result<Protected<A, traits::ReadWrite, traits::Locked>, error::Error>;
 }
 
 /// Protected region of memory that can be locked.
@@ -213,28 +213,28 @@ pub trait Lock<A: Zeroize + Bytes, PM: traits::ProtectMode> {
     /// Windows. By default, the protect mode is set to ReadWrite (i.e., no
     /// exec) using `mprotect()` on UNIX, or `VirtualProtect()` on Windows.
     /// On Linux, it will also set `MADV_DONTDUMP` using `madvise()`.
-    fn mlock(self) -> Result<Protected<A, PM, traits::Locked>, std::io::Error>;
+    fn mlock(self) -> Result<Protected<A, PM, traits::Locked>, error::Error>;
 }
 
 /// Protected region of memory that can be locked (i.e., is already locked).
 pub trait Unlock<A: Zeroize + Bytes, PM: traits::ProtectMode> {
     /// Unlocks a region of memory, using `munlock()` on UNIX, or
     /// `VirtualLock()` on Windows.
-    fn munlock(self) -> Result<Protected<A, PM, traits::Unlocked>, std::io::Error>;
+    fn munlock(self) -> Result<Protected<A, PM, traits::Unlocked>, error::Error>;
 }
 
 /// Protected region of memory that can be set as read-only.
 pub trait ProtectReadOnly<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> {
     /// Protects a region of memory as read-only (and no exec), using
     /// `mprotect()` on UNIX, or `VirtualProtect()` on Windows.
-    fn mprotect_readonly(self) -> Result<Protected<A, traits::ReadOnly, LM>, std::io::Error>;
+    fn mprotect_readonly(self) -> Result<Protected<A, traits::ReadOnly, LM>, error::Error>;
 }
 
 /// Protected region of memory that can be set as read-write.
 pub trait ProtectReadWrite<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> {
     /// Protects a region of memory as read-write (and no exec), using
     /// `mprotect()` on UNIX, or `VirtualProtect()` on Windows.
-    fn mprotect_readwrite(self) -> Result<Protected<A, traits::ReadWrite, LM>, std::io::Error>;
+    fn mprotect_readwrite(self) -> Result<Protected<A, traits::ReadWrite, LM>, error::Error>;
 }
 
 /// Protected region of memory that can be set as no-access. Must be unlocked.
@@ -243,27 +243,26 @@ pub trait ProtectNoAccess<A: Zeroize + Bytes, PM: traits::ProtectMode> {
     /// `mprotect()` on UNIX, or `VirtualProtect()` on Windows.
     fn mprotect_noaccess(
         self,
-    ) -> Result<Protected<A, traits::NoAccess, traits::Unlocked>, std::io::Error>;
+    ) -> Result<Protected<A, traits::NoAccess, traits::Unlocked>, error::Error>;
 }
 
 /// Bytes which can be allocated and protected.
 pub trait NewLocked<A: Zeroize + NewBytes + Lockable<A>> {
     /// Returns a new locked byte array.
-    fn new_locked() -> Result<Protected<A, traits::ReadWrite, traits::Locked>, std::io::Error>;
+    fn new_locked() -> Result<Protected<A, traits::ReadWrite, traits::Locked>, error::Error>;
     /// Returns a new locked byte array.
-    fn new_readonly_locked()
-    -> Result<Protected<A, traits::ReadOnly, traits::Locked>, std::io::Error>;
+    fn new_readonly_locked() -> Result<Protected<A, traits::ReadOnly, traits::Locked>, error::Error>;
     /// Returns a new locked byte array, filled with random data.
-    fn generate_locked() -> Result<Protected<A, traits::ReadWrite, traits::Locked>, std::io::Error>;
+    fn generate_locked() -> Result<Protected<A, traits::ReadWrite, traits::Locked>, error::Error>;
     /// Returns a new read-only, locked byte array, filled with random data.
     fn generate_readonly_locked()
-    -> Result<Protected<A, traits::ReadOnly, traits::Locked>, std::io::Error>;
+    -> Result<Protected<A, traits::ReadOnly, traits::Locked>, error::Error>;
     /// Returns a new locked byte array, filled with random data.
     ///
     /// Prefer [`generate_locked`](Self::generate_locked). This method is
     /// retained for compatibility.
     #[deprecated(note = "use generate_locked() instead")]
-    fn gen_locked() -> Result<Protected<A, traits::ReadWrite, traits::Locked>, std::io::Error> {
+    fn gen_locked() -> Result<Protected<A, traits::ReadWrite, traits::Locked>, error::Error> {
         Self::generate_locked()
     }
     /// Returns a new read-only, locked byte array, filled with random data.
@@ -271,8 +270,8 @@ pub trait NewLocked<A: Zeroize + NewBytes + Lockable<A>> {
     /// Prefer [`generate_readonly_locked`](Self::generate_readonly_locked).
     /// This method is retained for compatibility.
     #[deprecated(note = "use generate_readonly_locked() instead")]
-    fn gen_readonly_locked()
-    -> Result<Protected<A, traits::ReadOnly, traits::Locked>, std::io::Error> {
+    fn gen_readonly_locked() -> Result<Protected<A, traits::ReadOnly, traits::Locked>, error::Error>
+    {
         Self::generate_readonly_locked()
     }
 }
@@ -546,9 +545,9 @@ impl<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> Protecte
     fn swap_some_or_err<F, OPM: traits::ProtectMode, OLM: traits::LockMode>(
         &mut self,
         f: F,
-    ) -> Result<Protected<A, OPM, OLM>, std::io::Error>
+    ) -> Result<Protected<A, OPM, OLM>, error::Error>
     where
-        F: Fn(&mut int::InternalData<A>) -> Result<Protected<A, OPM, OLM>, std::io::Error>,
+        F: Fn(&mut int::InternalData<A>) -> Result<Protected<A, OPM, OLM>, error::Error>,
     {
         match &mut self.i {
             Some(d) => {
@@ -557,10 +556,9 @@ impl<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> Protecte
                 std::mem::swap(&mut new.i, &mut self.i);
                 Ok(new)
             }
-            _ => Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "unexpected empty internal struct",
-            )),
+            _ => Err(error::Error::InvalidState {
+                context: crate::ErrorContext::ProtectedMemory,
+            }),
         }
     }
 }
@@ -568,7 +566,7 @@ impl<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> Protecte
 impl<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> Unlock<A, PM>
     for Protected<A, PM, LM>
 {
-    fn munlock(mut self) -> Result<Protected<A, PM, traits::Unlocked>, std::io::Error> {
+    fn munlock(mut self) -> Result<Protected<A, PM, traits::Unlocked>, error::Error> {
         self.swap_some_or_err(|old| {
             dryoc_munlock(old.a.as_slice())?;
             // update internal state
@@ -581,7 +579,7 @@ impl<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> Unlock<A
 impl<A: Zeroize + Bytes + Default, PM: traits::ProtectMode> Lock<A, PM>
     for Protected<A, PM, traits::Unlocked>
 {
-    fn mlock(mut self) -> Result<Protected<A, PM, traits::Locked>, std::io::Error> {
+    fn mlock(mut self) -> Result<Protected<A, PM, traits::Locked>, error::Error> {
         self.swap_some_or_err(|old| {
             dryoc_mlock(old.a.as_slice())?;
             // update internal state
@@ -594,7 +592,7 @@ impl<A: Zeroize + Bytes + Default, PM: traits::ProtectMode> Lock<A, PM>
 impl<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> ProtectReadOnly<A, PM, LM>
     for Protected<A, PM, LM>
 {
-    fn mprotect_readonly(mut self) -> Result<Protected<A, traits::ReadOnly, LM>, std::io::Error> {
+    fn mprotect_readonly(mut self) -> Result<Protected<A, traits::ReadOnly, LM>, error::Error> {
         self.swap_some_or_err(|old| {
             dryoc_mprotect_readonly(old.a.as_slice())?;
             // update internal state
@@ -607,7 +605,7 @@ impl<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> ProtectR
 impl<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> ProtectReadWrite<A, PM, LM>
     for Protected<A, PM, LM>
 {
-    fn mprotect_readwrite(mut self) -> Result<Protected<A, traits::ReadWrite, LM>, std::io::Error> {
+    fn mprotect_readwrite(mut self) -> Result<Protected<A, traits::ReadWrite, LM>, error::Error> {
         self.swap_some_or_err(|old| {
             dryoc_mprotect_readwrite(old.a.as_slice())?;
             // update internal state
@@ -622,7 +620,7 @@ impl<A: Zeroize + Bytes, PM: traits::ProtectMode> ProtectNoAccess<A, PM>
 {
     fn mprotect_noaccess(
         mut self,
-    ) -> Result<Protected<A, traits::NoAccess, traits::Unlocked>, std::io::Error> {
+    ) -> Result<Protected<A, traits::NoAccess, traits::Unlocked>, error::Error> {
         self.swap_some_or_err(|old| {
             dryoc_mprotect_noaccess(old.a.as_slice())?;
             // update internal state
@@ -705,7 +703,7 @@ impl<const LENGTH: usize> StackByteArray<LENGTH> {
     /// wrapper.
     pub fn mlock(
         self,
-    ) -> Result<Protected<HeapByteArray<LENGTH>, traits::ReadWrite, traits::Locked>, std::io::Error>
+    ) -> Result<Protected<HeapByteArray<LENGTH>, traits::ReadWrite, traits::Locked>, error::Error>
     {
         Protected::<HeapByteArray<LENGTH>, traits::ReadWrite, traits::Unlocked>::new_with(
             self.into(),
@@ -718,7 +716,7 @@ impl<const LENGTH: usize> StackByteArray<LENGTH> {
     /// Returns a readonly protected [StackByteArray].
     pub fn mprotect_readonly(
         self,
-    ) -> Result<Protected<HeapByteArray<LENGTH>, traits::ReadOnly, traits::Unlocked>, std::io::Error>
+    ) -> Result<Protected<HeapByteArray<LENGTH>, traits::ReadOnly, traits::Unlocked>, error::Error>
     {
         Protected::<HeapByteArray<LENGTH>, traits::ReadWrite, traits::Unlocked>::new_with(
             self.into(),
@@ -731,7 +729,7 @@ impl<const LENGTH: usize> Lockable<HeapByteArray<LENGTH>> for HeapByteArray<LENG
     /// Locks a [HeapByteArray], and returns a [Protected] wrapper.
     fn mlock(
         self,
-    ) -> Result<Protected<HeapByteArray<LENGTH>, traits::ReadWrite, traits::Locked>, std::io::Error>
+    ) -> Result<Protected<HeapByteArray<LENGTH>, traits::ReadWrite, traits::Locked>, error::Error>
     {
         Protected::<HeapByteArray<LENGTH>, traits::ReadWrite, traits::Unlocked>::new_with(self)
             .mlock()
@@ -742,7 +740,7 @@ impl Lockable<HeapBytes> for HeapBytes {
     /// Locks a [HeapBytes], and returns a [Protected] wrapper.
     fn mlock(
         self,
-    ) -> Result<Protected<HeapBytes, traits::ReadWrite, traits::Locked>, std::io::Error> {
+    ) -> Result<Protected<HeapBytes, traits::ReadWrite, traits::Locked>, error::Error> {
         Protected::<HeapBytes, traits::ReadWrite, traits::Unlocked>::new_with(self).mlock()
     }
 }
@@ -1220,26 +1218,26 @@ pub struct HeapByteArray<const LENGTH: usize>(ProtectedBuffer);
 pub struct HeapBytes(ProtectedBuffer);
 
 impl<A: Zeroize + NewBytes + Lockable<A>> NewLocked<A> for A {
-    fn new_locked() -> Result<Protected<Self, traits::ReadWrite, traits::Locked>, std::io::Error> {
+    fn new_locked() -> Result<Protected<Self, traits::ReadWrite, traits::Locked>, error::Error> {
         Self::new_bytes().mlock()
     }
 
     fn new_readonly_locked()
-    -> Result<Protected<Self, traits::ReadOnly, traits::Locked>, std::io::Error> {
+    -> Result<Protected<Self, traits::ReadOnly, traits::Locked>, error::Error> {
         Self::new_bytes()
             .mlock()
             .and_then(|p| p.mprotect_readonly())
     }
 
-    fn generate_locked()
-    -> Result<Protected<Self, traits::ReadWrite, traits::Locked>, std::io::Error> {
+    fn generate_locked() -> Result<Protected<Self, traits::ReadWrite, traits::Locked>, error::Error>
+    {
         let mut res = Self::new_bytes().mlock()?;
         copy_randombytes(res.as_mut_slice());
         Ok(res)
     }
 
     fn generate_readonly_locked()
-    -> Result<Protected<Self, traits::ReadOnly, traits::Locked>, std::io::Error> {
+    -> Result<Protected<Self, traits::ReadOnly, traits::Locked>, error::Error> {
         Self::generate_locked().and_then(|s| s.mprotect_readonly())
     }
 }
@@ -1261,8 +1259,7 @@ impl<A: Zeroize + NewBytes + ResizableBytes + Lockable<A>> NewLockedFromSlice<A>
     fn from_slice_into_readonly_locked(
         src: &[u8],
     ) -> Result<Protected<Self, traits::ReadOnly, traits::Locked>, crate::error::Error> {
-        Self::from_slice_into_locked(src)
-            .and_then(|s| s.mprotect_readonly().map_err(|err| err.into()))
+        Self::from_slice_into_locked(src).and_then(|s| s.mprotect_readonly())
     }
 }
 
@@ -1273,11 +1270,7 @@ impl<const LENGTH: usize> NewLockedFromSlice<HeapByteArray<LENGTH>> for HeapByte
         other: &[u8],
     ) -> Result<Protected<Self, traits::ReadWrite, traits::Locked>, crate::error::Error> {
         if other.len() != LENGTH {
-            return Err(dryoc_error!(format!(
-                "slice length {} doesn't match expected {}",
-                other.len(),
-                LENGTH
-            )));
+            return Err(length_error!(crate::ErrorContext::Slice, other.len(), exact LENGTH));
         }
         let mut res = Self::new_bytes().mlock()?;
         res.as_mut_slice().copy_from_slice(other);
@@ -1287,8 +1280,7 @@ impl<const LENGTH: usize> NewLockedFromSlice<HeapByteArray<LENGTH>> for HeapByte
     fn from_slice_into_readonly_locked(
         other: &[u8],
     ) -> Result<Protected<Self, traits::ReadOnly, traits::Locked>, crate::error::Error> {
-        Self::from_slice_into_locked(other)
-            .and_then(|s| s.mprotect_readonly().map_err(|err| err.into()))
+        Self::from_slice_into_locked(other).and_then(|s| s.mprotect_readonly())
     }
 }
 
@@ -1628,11 +1620,7 @@ impl<const LENGTH: usize> TryFrom<&[u8]> for HeapByteArray<LENGTH> {
 
     fn try_from(src: &[u8]) -> Result<Self, Self::Error> {
         if src.len() != LENGTH {
-            Err(dryoc_error!(format!(
-                "Invalid size: expected {} found {}",
-                LENGTH,
-                src.len()
-            )))
+            Err(length_error!(crate::ErrorContext::Slice, src.len(), exact LENGTH))
         } else {
             let mut arr = Self::default();
             arr.0.copy_from_slice(src);

--- a/src/protected.rs
+++ b/src/protected.rs
@@ -87,8 +87,8 @@
 //! and can fail when the process exceeds the working-set limits enforced by the
 //! OS. There is no `MADV_DONTDUMP` equivalent in this module.
 //!
-//! If the `serde` feature is enabled, the `serde::Deserialize` and
-//! `serde::Serialize` traits will be implemented for [`HeapBytes`] and
+//! If the `serde` feature is enabled, the [`serde::Deserialize`] and
+//! [`serde::Serialize`] traits will be implemented for [`HeapBytes`] and
 //! [`HeapByteArray`].
 //!
 //! ## Example
@@ -631,9 +631,9 @@ impl<A: Zeroize + Bytes, PM: traits::ProtectMode, LM: traits::LockMode> Protecte
                 std::mem::swap(&mut new.i, &mut self.i);
                 Ok(new)
             }
-            _ => Err(error::Error::InvalidState {
-                context: crate::ErrorContext::ProtectedMemory,
-            }),
+            _ => Err(error::Error::invalid_state(
+                crate::ErrorContext::ProtectedMemory,
+            )),
         }
     }
 }

--- a/src/pwhash.rs
+++ b/src/pwhash.rs
@@ -14,8 +14,8 @@
 //! * derive secret keys based on passphrases
 //! * hash arbitrary data in a manner that's strongly resistant to collisions
 //!
-//! If the `serde` feature is enabled, the [`serde::Deserialize`] and
-//! [`serde::Serialize`] traits will be implemented for [`PwHash`].
+//! If the `serde` feature is enabled, the `serde::Deserialize` and
+//! `serde::Serialize` traits will be implemented for [`PwHash`].
 //!
 //! ## Rustaceous API example
 //!
@@ -362,7 +362,7 @@ impl<Hash: NewBytes + ResizableBytes + Zeroize, Salt: Bytes + Clone + Zeroize> P
         {
             Ok(())
         } else {
-            Err(dryoc_error!("hashes do not match"))
+            Err(Error::AuthenticationFailed)
         }
     }
 

--- a/src/pwhash.rs
+++ b/src/pwhash.rs
@@ -18,8 +18,8 @@
 //! [`crate::sha256`] for arbitrary data. Password hashing is deliberately much
 //! more expensive.
 //!
-//! If the `serde` feature is enabled, the `serde::Deserialize` and
-//! `serde::Serialize` traits will be implemented for [`PwHash`].
+//! If the `serde` feature is enabled, the [`serde::Deserialize`] and
+//! [`serde::Serialize`] traits will be implemented for [`PwHash`].
 //!
 //! ## Rustaceous API example
 //!
@@ -475,12 +475,12 @@ impl<Hash: Bytes + From<Vec<u8>> + Zeroize, Salt: Bytes + From<Vec<u8>> + Zeroiz
     pub fn from_string(hashed_password: &str) -> Result<Self, Error> {
         let parsed_pwhash = crypto_pwhash::Pwhash::parse_encoded_pwhash(hashed_password)?;
 
-        let opslimit = parsed_pwhash.t_cost.ok_or(Error::MissingData {
-            context: crate::ErrorContext::PasswordHashTimeCost,
-        })? as u64;
-        let encoded_memlimit = parsed_pwhash.m_cost.ok_or(Error::MissingData {
-            context: crate::ErrorContext::PasswordHashMemoryCost,
-        })?;
+        let opslimit = parsed_pwhash.t_cost.ok_or(Error::missing_data(
+            crate::ErrorContext::PasswordHashTimeCost,
+        ))? as u64;
+        let encoded_memlimit = parsed_pwhash.m_cost.ok_or(Error::missing_data(
+            crate::ErrorContext::PasswordHashMemoryCost,
+        ))?;
         let memlimit =
             1024usize
                 .checked_mul(encoded_memlimit as usize)
@@ -492,15 +492,15 @@ impl<Hash: Bytes + From<Vec<u8>> + Zeroize, Salt: Bytes + From<Vec<u8>> + Zeroiz
                         max: (usize::MAX / 1024) as u64,
                     },
                 })?;
-        let hash = parsed_pwhash.pwhash.ok_or(Error::MissingData {
-            context: crate::ErrorContext::PasswordHash,
-        })?;
-        let salt = parsed_pwhash.salt.ok_or(Error::MissingData {
-            context: crate::ErrorContext::PasswordHashSalt,
-        })?;
-        let algorithm = parsed_pwhash.type_.ok_or(Error::MissingData {
-            context: crate::ErrorContext::PasswordHashAlgorithm,
-        })?;
+        let hash = parsed_pwhash
+            .pwhash
+            .ok_or(Error::missing_data(crate::ErrorContext::PasswordHash))?;
+        let salt = parsed_pwhash
+            .salt
+            .ok_or(Error::missing_data(crate::ErrorContext::PasswordHashSalt))?;
+        let algorithm = parsed_pwhash.type_.ok_or(Error::missing_data(
+            crate::ErrorContext::PasswordHashAlgorithm,
+        ))?;
         let hash_length = hash.len();
         let salt_length = salt.len();
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -289,10 +289,12 @@ impl<
     /// not check validity or authenticity of keypair.
     pub fn from_slices(public_key: &'a [u8], secret_key: &'a [u8]) -> Result<Self, Error> {
         Ok(Self {
-            public_key: PublicKey::try_from(public_key)
-                .map_err(|_e| dryoc_error!("invalid public key"))?,
-            secret_key: SecretKey::try_from(secret_key)
-                .map_err(|_e| dryoc_error!("invalid secret key"))?,
+            public_key: PublicKey::try_from(public_key).map_err(
+                |_| length_error!(crate::ErrorContext::PublicKey, public_key.len(), exact CRYPTO_SIGN_PUBLICKEYBYTES),
+            )?,
+            secret_key: SecretKey::try_from(secret_key).map_err(
+                |_| length_error!(crate::ErrorContext::SecretKey, secret_key.len(), exact CRYPTO_SIGN_SECRETKEYBYTES),
+            )?,
         })
     }
 }
@@ -355,7 +357,7 @@ pub mod protected {
         >
     {
         /// Returns a new locked signing keypair.
-        pub fn new_locked_keypair() -> Result<Self, std::io::Error> {
+        pub fn new_locked_keypair() -> Result<Self, Error> {
             Ok(Self {
                 public_key: HeapByteArray::<CRYPTO_SIGN_PUBLICKEYBYTES>::new_locked()?,
                 secret_key: HeapByteArray::<CRYPTO_SIGN_SECRETKEYBYTES>::new_locked()?,
@@ -363,7 +365,7 @@ pub mod protected {
         }
 
         /// Returns a new randomly generated locked signing keypair.
-        pub fn generate_locked_keypair() -> Result<Self, std::io::Error> {
+        pub fn generate_locked_keypair() -> Result<Self, Error> {
             let mut res = Self::new_locked_keypair()?;
 
             crypto_sign_keypair_inplace(
@@ -379,7 +381,7 @@ pub mod protected {
         /// Prefer [`generate_locked_keypair`](Self::generate_locked_keypair).
         /// This method is retained for compatibility.
         #[deprecated(note = "use generate_locked_keypair() instead")]
-        pub fn gen_locked_keypair() -> Result<Self, std::io::Error> {
+        pub fn gen_locked_keypair() -> Result<Self, Error> {
             Self::generate_locked_keypair()
         }
     }
@@ -391,7 +393,7 @@ pub mod protected {
         >
     {
         /// Returns a new randomly generated locked, read-only signing keypair.
-        pub fn generate_readonly_locked_keypair() -> Result<Self, std::io::Error> {
+        pub fn generate_readonly_locked_keypair() -> Result<Self, Error> {
             let mut public_key = HeapByteArray::<CRYPTO_SIGN_PUBLICKEYBYTES>::new_locked()?;
             let mut secret_key = HeapByteArray::<CRYPTO_SIGN_SECRETKEYBYTES>::new_locked()?;
 
@@ -412,7 +414,7 @@ pub mod protected {
         /// [`generate_readonly_locked_keypair`](Self::generate_readonly_locked_keypair).
         /// This method is retained for compatibility.
         #[deprecated(note = "use generate_readonly_locked_keypair() instead")]
-        pub fn gen_readonly_locked_keypair() -> Result<Self, std::io::Error> {
+        pub fn gen_readonly_locked_keypair() -> Result<Self, Error> {
             Self::generate_readonly_locked_keypair()
         }
     }
@@ -555,16 +557,15 @@ impl<
     /// with the remaining bytes containing the message.
     pub fn from_bytes(bytes: &'a [u8]) -> Result<Self, Error> {
         if bytes.len() < CRYPTO_SIGN_BYTES {
-            Err(dryoc_error!(format!(
-                "bytes of len {} less than expected minimum of {}",
-                bytes.len(),
-                CRYPTO_SIGN_BYTES
-            )))
+            Err(
+                length_error!(crate::ErrorContext::SignedMessage, bytes.len(), min CRYPTO_SIGN_BYTES),
+            )
         } else {
             let (signature, message) = bytes.split_at(CRYPTO_SIGN_BYTES);
             Ok(Self {
-                signature: Signature::try_from(signature)
-                    .map_err(|_e| dryoc_error!("invalid signature"))?,
+                signature: Signature::try_from(signature).map_err(
+                    |_| length_error!(crate::ErrorContext::Signature, signature.len(), exact CRYPTO_SIGN_BYTES),
+                )?,
                 message: Message::from(message),
             })
         }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -290,15 +290,25 @@ impl<
     ///
     /// # Errors
     ///
-    /// Returns an error if either slice has the wrong length for its key type.
+    /// Returns an error if either slice has the wrong length for its key type,
+    /// or if the target key type rejects the key bytes.
     pub fn from_slices(public_key: &'a [u8], secret_key: &'a [u8]) -> Result<Self, Error> {
+        validate_length!(
+            exact CRYPTO_SIGN_PUBLICKEYBYTES,
+            public_key.len(),
+            crate::ErrorContext::PublicKey
+        );
+        validate_length!(
+            exact CRYPTO_SIGN_SECRETKEYBYTES,
+            secret_key.len(),
+            crate::ErrorContext::SecretKey
+        );
+
         Ok(Self {
-            public_key: PublicKey::try_from(public_key).map_err(
-                |_| length_error!(crate::ErrorContext::PublicKey, public_key.len(), exact CRYPTO_SIGN_PUBLICKEYBYTES),
-            )?,
-            secret_key: SecretKey::try_from(secret_key).map_err(
-                |_| length_error!(crate::ErrorContext::SecretKey, secret_key.len(), exact CRYPTO_SIGN_SECRETKEYBYTES),
-            )?,
+            public_key: PublicKey::try_from(public_key)
+                .map_err(|_| Error::invalid_key(crate::ErrorContext::PublicKey))?,
+            secret_key: SecretKey::try_from(secret_key)
+                .map_err(|_| Error::invalid_key(crate::ErrorContext::SecretKey))?,
         })
     }
 }
@@ -652,9 +662,8 @@ impl<
         } else {
             let (signature, message) = bytes.split_at(CRYPTO_SIGN_BYTES);
             Ok(Self {
-                signature: Signature::try_from(signature).map_err(
-                    |_| length_error!(crate::ErrorContext::Signature, signature.len(), exact CRYPTO_SIGN_BYTES),
-                )?,
+                signature: Signature::try_from(signature)
+                    .map_err(|_| Error::invalid_encoding(crate::ErrorContext::Signature))?,
                 message: Message::from(message),
             })
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -550,11 +550,7 @@ impl<const LENGTH: usize> TryFrom<&[u8]> for StackByteArray<LENGTH> {
 
     fn try_from(src: &[u8]) -> Result<Self, Self::Error> {
         if src.len() != LENGTH {
-            Err(dryoc_error!(format!(
-                "Invalid size: expected {} found {}",
-                LENGTH,
-                src.len()
-            )))
+            Err(length_error!(crate::ErrorContext::Slice, src.len(), exact LENGTH))
         } else {
             let mut arr = Self::default();
             arr.0.copy_from_slice(src);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,12 +2,51 @@ use std::vec;
 
 use dryoc::precalc::PrecalcSecretKey;
 
+struct RejectingByteArray<const LENGTH: usize>([u8; LENGTH]);
+
+impl<const LENGTH: usize> dryoc::types::Bytes for RejectingByteArray<LENGTH> {
+    fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    fn len(&self) -> usize {
+        LENGTH
+    }
+
+    fn is_empty(&self) -> bool {
+        LENGTH == 0
+    }
+}
+
+impl<const LENGTH: usize> dryoc::types::ByteArray<LENGTH> for RejectingByteArray<LENGTH> {
+    fn as_array(&self) -> &[u8; LENGTH] {
+        &self.0
+    }
+}
+
+impl<const LENGTH: usize> zeroize::Zeroize for RejectingByteArray<LENGTH> {
+    fn zeroize(&mut self) {
+        self.0.fill(0);
+    }
+}
+
+impl<'a, const LENGTH: usize> TryFrom<&'a [u8]> for RejectingByteArray<LENGTH> {
+    type Error = ();
+
+    fn try_from(_: &'a [u8]) -> Result<Self, Self::Error> {
+        Err(())
+    }
+}
+
 #[test]
 fn test_structured_public_errors() {
     use dryoc::classic::crypto_auth_hmacsha256::{
         crypto_auth_hmacsha256, crypto_auth_hmacsha256_keygen, crypto_auth_hmacsha256_verify,
     };
-    use dryoc::constants::CRYPTO_AUTH_HMACSHA256_BYTES;
+    use dryoc::constants::{
+        CRYPTO_AUTH_HMACSHA256_BYTES, CRYPTO_BOX_MACBYTES, CRYPTO_BOX_PUBLICKEYBYTES,
+        CRYPTO_BOX_SEALBYTES, CRYPTO_BOX_SECRETKEYBYTES, CRYPTO_SECRETBOX_MACBYTES,
+    };
     use dryoc::types::StackByteArray;
     use dryoc::{Error, LengthConstraint};
 
@@ -47,6 +86,128 @@ fn test_structured_public_errors() {
             actual: 0x80,
             constraint: dryoc::ValueConstraint::AllowedBits { .. },
         }
+    ));
+
+    type RejectingAeadBox = dryoc::dryocaead::AeadBox<
+        dryoc::dryocaead::XChaCha20Poly1305Ietf,
+        RejectingByteArray<16>,
+        Vec<u8>,
+    >;
+    let conversion_error = match RejectingAeadBox::from_bytes(&[0u8; 16]) {
+        Ok(_) => panic!("a target type may reject a correctly sized tag"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        conversion_error.to_string(),
+        "invalid authentication tag encoding"
+    );
+    assert!(matches!(
+        conversion_error,
+        Error::InvalidEncoding {
+            context: dryoc::ErrorContext::AuthenticationTag,
+        }
+    ));
+
+    type RejectingKeyPair = dryoc::keypair::KeyPair<
+        RejectingByteArray<CRYPTO_BOX_PUBLICKEYBYTES>,
+        RejectingByteArray<CRYPTO_BOX_SECRETKEYBYTES>,
+    >;
+    let conversion_error = match RejectingKeyPair::from_slices(
+        &[0u8; CRYPTO_BOX_PUBLICKEYBYTES],
+        &[0u8; CRYPTO_BOX_SECRETKEYBYTES],
+    ) {
+        Ok(_) => panic!("a target type may reject a correctly sized key"),
+        Err(error) => error,
+    };
+    assert_eq!(conversion_error.to_string(), "invalid public key");
+    assert!(matches!(
+        conversion_error,
+        Error::InvalidKey {
+            context: dryoc::ErrorContext::PublicKey,
+        }
+    ));
+
+    let box_public_key_error = dryoc::keypair::StackKeyPair::from_slices(
+        &[0u8; CRYPTO_BOX_PUBLICKEYBYTES - 1],
+        &[0u8; CRYPTO_BOX_SECRETKEYBYTES],
+    )
+    .expect_err("a short box public key should fail");
+    assert!(matches!(
+        box_public_key_error,
+        Error::InvalidLength {
+            context: dryoc::ErrorContext::PublicKey,
+            actual,
+            constraint: LengthConstraint::Exact(CRYPTO_BOX_PUBLICKEYBYTES),
+        } if actual == CRYPTO_BOX_PUBLICKEYBYTES - 1
+    ));
+
+    let box_secret_key_error = dryoc::keypair::StackKeyPair::from_slices(
+        &[0u8; CRYPTO_BOX_PUBLICKEYBYTES],
+        &[0u8; CRYPTO_BOX_SECRETKEYBYTES - 1],
+    )
+    .expect_err("a short box secret key should fail");
+    assert!(matches!(
+        box_secret_key_error,
+        Error::InvalidLength {
+            context: dryoc::ErrorContext::SecretKey,
+            actual,
+            constraint: LengthConstraint::Exact(CRYPTO_BOX_SECRETKEYBYTES),
+        } if actual == CRYPTO_BOX_SECRETKEYBYTES - 1
+    ));
+
+    type StackSigningKeyPair =
+        dryoc::sign::SigningKeyPair<dryoc::sign::PublicKey, dryoc::sign::SecretKey>;
+    let signing_public_key_error = StackSigningKeyPair::from_slices(
+        &[0u8; dryoc::constants::CRYPTO_SIGN_PUBLICKEYBYTES - 1],
+        &[0u8; dryoc::constants::CRYPTO_SIGN_SECRETKEYBYTES],
+    )
+    .expect_err("a short signing public key should fail");
+    assert!(matches!(
+        signing_public_key_error,
+        Error::InvalidLength {
+            context: dryoc::ErrorContext::PublicKey,
+            actual,
+            constraint: LengthConstraint::Exact(dryoc::constants::CRYPTO_SIGN_PUBLICKEYBYTES),
+        } if actual == dryoc::constants::CRYPTO_SIGN_PUBLICKEYBYTES - 1
+    ));
+
+    let signing_secret_key_error = StackSigningKeyPair::from_slices(
+        &[0u8; dryoc::constants::CRYPTO_SIGN_PUBLICKEYBYTES],
+        &[0u8; dryoc::constants::CRYPTO_SIGN_SECRETKEYBYTES - 1],
+    )
+    .expect_err("a short signing secret key should fail");
+    assert!(matches!(
+        signing_secret_key_error,
+        Error::InvalidLength {
+            context: dryoc::ErrorContext::SecretKey,
+            actual,
+            constraint: LengthConstraint::Exact(dryoc::constants::CRYPTO_SIGN_SECRETKEYBYTES),
+        } if actual == dryoc::constants::CRYPTO_SIGN_SECRETKEYBYTES - 1
+    ));
+
+    assert!(matches!(
+        dryoc::dryocbox::VecBox::from_bytes(&[]),
+        Err(Error::InvalidLength {
+            context: dryoc::ErrorContext::Box,
+            actual: 0,
+            constraint: LengthConstraint::AtLeast(CRYPTO_BOX_MACBYTES),
+        })
+    ));
+    assert!(matches!(
+        dryoc::dryocbox::VecBox::from_sealed_bytes(&[]),
+        Err(Error::InvalidLength {
+            context: dryoc::ErrorContext::SealedBox,
+            actual: 0,
+            constraint: LengthConstraint::AtLeast(CRYPTO_BOX_SEALBYTES),
+        })
+    ));
+    assert!(matches!(
+        dryoc::dryocsecretbox::VecBox::from_bytes(&[]),
+        Err(Error::InvalidLength {
+            context: dryoc::ErrorContext::SecretBox,
+            actual: 0,
+            constraint: LengthConstraint::AtLeast(CRYPTO_SECRETBOX_MACBYTES),
+        })
     ));
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3,6 +3,54 @@ use std::vec;
 use dryoc::precalc::PrecalcSecretKey;
 
 #[test]
+fn test_structured_public_errors() {
+    use dryoc::classic::crypto_auth_hmacsha256::{
+        crypto_auth_hmacsha256, crypto_auth_hmacsha256_keygen, crypto_auth_hmacsha256_verify,
+    };
+    use dryoc::constants::CRYPTO_AUTH_HMACSHA256_BYTES;
+    use dryoc::types::StackByteArray;
+    use dryoc::{Error, LengthConstraint};
+
+    let slice_error =
+        StackByteArray::<4>::try_from(&[1, 2][..]).expect_err("short slices should be rejected");
+    assert_eq!(
+        slice_error.to_string(),
+        "invalid slice length: expected exactly 4, got 2"
+    );
+    assert!(matches!(
+        slice_error,
+        Error::InvalidLength {
+            context: dryoc::ErrorContext::Slice,
+            actual: 2,
+            constraint: LengthConstraint::Exact(4),
+        }
+    ));
+
+    let key = crypto_auth_hmacsha256_keygen();
+    let mut mac = [0u8; CRYPTO_AUTH_HMACSHA256_BYTES];
+    crypto_auth_hmacsha256(&mut mac, b"message", &key);
+    let authentication_error = crypto_auth_hmacsha256_verify(&mac, b"tampered", &key)
+        .expect_err("tampered messages should fail authentication");
+    assert_eq!(authentication_error.to_string(), "authentication failed");
+    assert!(matches!(authentication_error, Error::AuthenticationFailed));
+
+    let tag_error = dryoc::dryocstream::Tag::try_from(0x80)
+        .expect_err("unknown secretstream tag bits should be rejected");
+    assert_eq!(
+        tag_error.to_string(),
+        "invalid tag value: expected a value containing only bits from mask 0x3, got 128"
+    );
+    assert!(matches!(
+        tag_error,
+        Error::InvalidValue {
+            context: dryoc::ErrorContext::Tag,
+            actual: 0x80,
+            constraint: dryoc::ValueConstraint::AllowedBits { .. },
+        }
+    ));
+}
+
+#[test]
 fn test_sha3_public_api() {
     use dryoc::classic::crypto_hash::{
         Sha3256Digest, Sha3512Digest, crypto_hash_sha3256, crypto_hash_sha3256_final,


### PR DESCRIPTION
## Summary

Replace message-only errors with typed, non-exhaustive error variants across dryoc's Classic and Rustaceous APIs. The new `ErrorContext`, `LengthConstraint`, and `ValueConstraint` types make failures inspectable without parsing strings, while `Display` now reports useful expected and actual values.

No dependency was added.

## User Impact

Callers can distinguish authentication failures, invalid lengths and values, malformed encodings, invalid keys, missing data, invalid state, arithmetic overflow, and I/O failures. Printed errors are concise and contextual; derived `Debug` output exposes the structured fields.

This intentionally changes public APIs for the 1.0 release. Consumers matching or constructing the old error variants, expecting `std::io::Error` from protected-memory APIs, or using infallible stream-tag conversion must migrate as described below.

## Root Cause

`Error::Message(String)` and `dryoc_error!` embedded ad-hoc prose and source locations in errors. That forced consumers to parse text, made output inconsistent, and obscured the difference between caller input errors, authentication failures, invalid state, and internal overflow. Some fallible conversions and protected serde allocation paths also panicked instead of returning a typed error.

## Fix

- Add structured `Error`, `ErrorContext`, `LengthConstraint`, and `ValueConstraint` enums.
- Migrate Classic and Rustaceous call sites to return semantic variants.
- Preserve underlying OS errors through `Error::Io` and `Error::source()`.
- Return `dryoc::Error` consistently from protected-memory traits and constructors.
- Make stream-tag byte conversion fallible.
- Return serde errors instead of panicking on protected allocation failures.
- Reject oversized BLAKE2b keys before narrowing their length, with soft and SIMD regression tests.
- Add exact `Display` and `Debug` tests plus public integration coverage.

## Breaking Changes and Migration

### Match structured errors

`Error::Message`, `Error::FromSlice`, `From<String>`, and `From<&str>` are removed. Replace message matching or string parsing with semantic variants and fields:

```rust
match error {
    dryoc::Error::AuthenticationFailed => handle_authentication_failure(),
    dryoc::Error::InvalidLength {
        context,
        actual,
        constraint,
    } => handle_invalid_length(context, actual, constraint),
    dryoc::Error::Io(source) => handle_io_error(source),
    _ => handle_other_error(error),
}
```

`Error` and its supporting enums are `#[non_exhaustive]`, so downstream matches must include a wildcard. Treat `Display` text as diagnostic output, not a stable interface.

Code that previously constructed `Error` from a string should use the applicable structured variant. If an application needs arbitrary messages, keep them in the application's own error type instead of converting them into `dryoc::Error`.

### Update protected-memory result types

Protected-memory traits, constructors, and protected keypair generation now return `Result<_, dryoc::Error>` instead of `Result<_, std::io::Error>`. Code whose enclosing result already uses `dryoc::Error` can normally continue using `?`:

```rust
let locked = dryoc::protected::LockedBytes::new_locked(32)?;
```

Code that must expose `std::io::Error` should explicitly match `dryoc::Error::Io(source)` and decide how to translate non-I/O variants. The original OS error remains available through the variant and the standard `source()` chain.

Affected public traits include `Lockable`, `Lock`, `Unlock`, `ProtectReadOnly`, `ProtectReadWrite`, `ProtectNoAccess`, and `NewLocked`.

### Use fallible stream-tag conversion

Replace infallible byte conversion:

```rust
let tag = Tag::from(byte);
```

with:

```rust
let tag = Tag::try_from(byte)?;
```

Invalid tag bitmasks now return `Error::InvalidValue`. Use `Tag::from_bits_truncate` or `Tag::from_bits_retain` only when truncation or retaining unknown bits is explicitly intended.

### Stop asserting error strings

Prefer matching variants, contexts, and constraints in tests. Human-readable messages now include details such as `invalid nonce length: expected exactly 24, got 12`; their exact wording is not an API contract.

## Validation

- `cargo test`
- `cargo test --no-default-features`
- `cargo test --features serde`
- `cargo test --features wincode`
- `cargo +nightly test --features simd_backend,nightly`
- `cargo clippy --all-targets --features serde -- -D warnings`
- `cargo +nightly clippy --all-targets --features simd_backend,nightly -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- strict rustdoc with default and `serde,wincode` features
- wasm32 checks with no default features and with `serde,wincode`
- Windows protected-memory cross-check
- `git diff --check`
