### PR TITLE
fix: authenticate cargo-binstall requests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -82,12 +82,16 @@ jobs:
         uses: brndnmtthws/rust-action@1871ec11ecd98fd7c97eccc0042e92c97151e41a # v1
         with:
           toolchain: ${{ matrix.rust }}
-          cargo-packages: cargo-nextest
+          cargo-packages: --locked cargo-nextest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Install cargo-hold
         if: runner.os != 'Windows'
         uses: brndnmtthws/rust-action-cargo-binstall@2c46d38e56ef5653e953c62f9fce2125d568a15c # v1
         with:
           packages: cargo-hold
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - run: cargo hold voyage
         if: runner.os != 'Windows'
       - run: cargo build --features ${{ env.FEATURES }}


### PR DESCRIPTION
## Summary

Authenticate cargo-binstall's GitHub API requests and keep cargo-nextest's source fallback reproducible.

## User Impact

CI jobs intermittently received GitHub API 403 responses while resolving release artifacts. This forced cargo-nextest to build from source, where installation then failed because it was not locked.

## Root Cause

The cargo-binstall subprocess did not receive the workflow's GitHub token, so release lookups used GitHub's shared, unauthenticated rate limit. The cargo-nextest invocation also omitted `--locked`, making its fallback path fail.

## Fix

- Pass the read-only workflow token to both cargo-binstall call paths.
- Install cargo-nextest with `--locked` so source fallback remains valid.

## Validation

- `mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint .github/workflows/build-and-test.yml`
- `git diff --check HEAD^ HEAD`
