### PR TITLE
ci: create draft GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          draft: false
+          draft: true
           prerelease: ${{ contains(github.ref_name, '-') }}
           discussion_category_name: General
           generate_release_notes: true


### PR DESCRIPTION
## Summary

Configure the tag-triggered publish workflow to create GitHub releases as drafts.

## User Impact

New GitHub releases will remain unpublished until they are reviewed and manually published. The existing crates.io publish step is unchanged.

## Root Cause

The `softprops/action-gh-release` step explicitly set `draft: false`, causing each tag-triggered release to publish immediately.

## Fix

Set the action's `draft` input to `true` while retaining generated release notes and prerelease detection.

## Validation

- Parsed `.github/workflows/publish.yml` with Ruby's YAML parser
- Ran `actionlint` 1.7.12 with ShellCheck 0.11.0
- Ran `git diff --check HEAD^ HEAD`
