### PR TITLE
docs: document WebAssembly support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ See the [API documentation](https://docs.rs/dryoc/latest/dryoc/) and
 * Limited use of unsafe code[^2]
 * Typed Rustaceous APIs for keys, nonces, and outputs
 * Classic and Rustaceous APIs for many libsodium operations
+* WebAssembly support via the `wasm32-unknown-unknown` target
 * Protected memory handling (`mprotect()` + `mlock()`, along with Windows
   equivalents) on stable Rust for Unix and Windows targets, enabled by default
   with the `protected` feature


### PR DESCRIPTION
## Summary

Document `wasm32-unknown-unknown` support in the README feature list.

## User Impact

Users evaluating dryoc for browser and other WebAssembly applications can now see that the target is supported.

## Root Cause

The repository already tests the WebAssembly target in CI, but the README feature list did not mention it.

## Fix

Add a concise WebAssembly support bullet alongside the existing platform and feature information.

## Validation

- `git diff-tree --check HEAD^ HEAD`
- Confirmed the existing `wasm32-unknown-unknown` CI job and WASM integration tests
