### PR TITLE
ci: check semver compatibility

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  semver:
+    name: semver compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup stable Rust toolchain with caching
+        uses: brndnmtthws/rust-action@1871ec11ecd98fd7c97eccc0042e92c97151e41a # v1
+        with:
+          toolchain: stable
+          cargo-packages: --locked cargo-semver-checks
+      - run: cargo semver-checks --verbose
+
   audit:
     name: dependency audit
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add `cargo-semver-checks` to the normal build-and-test workflow so API compatibility is checked before release tags are created.

## User Impact

SemVer-incompatible public API changes will fail regular pull request CI according to the version already declared in `Cargo.toml`, giving maintainers feedback before the tag-triggered publish workflow runs.

## Root Cause

The existing CI validates builds, tests, features, MSRV, documentation, and dependencies, but it does not compare the current public API with the latest published crate. The first release-specific validation currently happens after a tag is pushed.

## Fix

Add a standalone `semver compatibility` job that installs `cargo-semver-checks` with the stable Rust toolchain and runs `cargo semver-checks --verbose` on pushes to `main` and pull requests targeting `main`.

## Validation

- `mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint .github/workflows/build-and-test.yml`
- `git diff --check HEAD^`
- `cargo semver-checks --verbose` against published `dryoc` 0.9.0 and current 1.0.0
