### PR TITLE
ci: use nextest for test suites

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,7 +50,9 @@ jobs:
         uses: brndnmtthws/rust-action@1871ec11ecd98fd7c97eccc0042e92c97151e41a # v1
         with:
           toolchain: stable
-          cargo-packages: ""
+          cargo-packages: --locked cargo-nextest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - run: rustup target add wasm32-unknown-unknown
       - name: Install matching wasm-bindgen test runner
         run: |
@@ -60,7 +62,7 @@ jobs:
               | head -n 1
           )"
           cargo install wasm-bindgen-cli --version "$WASM_BINDGEN_VERSION" --locked
-      - run: cargo test --target wasm32-unknown-unknown --no-default-features --features serde,base64,wincode
+      - run: cargo nextest run --target wasm32-unknown-unknown --no-default-features --features serde,base64,wincode
         env:
           CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
 
@@ -140,8 +142,10 @@ jobs:
         uses: brndnmtthws/rust-action@1871ec11ecd98fd7c97eccc0042e92c97151e41a # v1
         with:
           toolchain: stable
-          cargo-packages: ""
-      - run: cargo test --all-targets ${{ matrix.flags }}
+          cargo-packages: --locked cargo-nextest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - run: cargo nextest run --all-targets ${{ matrix.flags }}
         env:
           RUST_BACKTRACE: 1
       - run: cargo clippy --all-targets ${{ matrix.flags }} -- -D warnings
@@ -155,8 +159,10 @@ jobs:
         uses: brndnmtthws/rust-action@1871ec11ecd98fd7c97eccc0042e92c97151e41a # v1
         with:
           toolchain: 1.89.0
-          cargo-packages: ""
-      - run: cargo test --all-targets --features serde,wincode
+          cargo-packages: --locked cargo-nextest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - run: cargo nextest run --all-targets --features serde,wincode
 
   all-features:
     name: all features / nightly
@@ -167,8 +173,10 @@ jobs:
         uses: brndnmtthws/rust-action@1871ec11ecd98fd7c97eccc0042e92c97151e41a # v1
         with:
           toolchain: nightly
-          cargo-packages: ""
-      - run: cargo test --all-targets --all-features
+          cargo-packages: --locked cargo-nextest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - run: cargo nextest run --all-targets --all-features
         env:
           RUST_BACKTRACE: 1
       - run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,9 @@ jobs:
       - uses: brndnmtthws/rust-action@1871ec11ecd98fd7c97eccc0042e92c97151e41a # v1
         with:
           toolchain: stable
-          cargo-packages: ""
+          cargo-packages: --locked cargo-nextest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Verify tag matches crate version
         shell: bash
         run: |
@@ -32,10 +34,10 @@ jobs:
             echo "tag ${GITHUB_REF_NAME} does not match Cargo.toml version ${CRATE_VERSION}" >&2
             exit 1
           fi
-      - run: cargo test --all-targets
-      - run: cargo test --all-targets --no-default-features
-      - run: cargo test --all-targets --no-default-features --features serde,base64,wincode
-      - run: cargo test --all-targets --no-default-features --features serde,protected
+      - run: cargo nextest run --all-targets
+      - run: cargo nextest run --all-targets --no-default-features
+      - run: cargo nextest run --all-targets --no-default-features --features serde,base64,wincode
+      - run: cargo nextest run --all-targets --no-default-features --features serde,protected
       - run: cargo test --doc
       - run: cargo doc --no-default-features --no-deps
         env:
@@ -43,7 +45,7 @@ jobs:
       - run: cargo clippy --all-targets --features serde,base64,wincode -- -D warnings
       - name: Install nightly validation toolchain
         run: rustup toolchain install nightly --profile minimal --component clippy
-      - run: cargo +nightly test --all-targets --all-features
+      - run: cargo +nightly nextest run --all-targets --all-features
       - run: cargo +nightly test --doc --all-features
       - run: cargo +nightly clippy --all-targets --all-features -- -D warnings
       - run: cargo package


### PR DESCRIPTION
## Summary

Use cargo-nextest for executable test suites in the build and publish workflows.

## User Impact

CI and release validation now use the same faster test runner consistently across native, feature-matrix, MSRV, nightly, and WebAssembly jobs. Doctest coverage remains unchanged.

## Root Cause

Several workflow jobs still invoked cargo test directly and did not install cargo-nextest, leaving test execution inconsistent across CI.

## Fix

Install cargo-nextest with authenticated GitHub requests in each affected job and replace executable cargo test runs with cargo nextest run. Keep cargo test --doc because nextest does not support doctests.

## Validation

- mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint .github/workflows/build-and-test.yml .github/workflows/publish.yml
- cargo nextest run --target wasm32-unknown-unknown --no-default-features --features serde,base64,wincode (5 passed)
- cargo nextest run --all-targets (298 passed)
- cargo +nightly nextest run --all-targets --all-features (334 passed)
- git diff --check HEAD^
